### PR TITLE
Added handler for mbasic facebook links, made MessageActivity pass co…

### DIFF
--- a/SlimFacebook/app/src/main/java/it/rignanese/leo/slimfacebook/MainActivity.java
+++ b/SlimFacebook/app/src/main/java/it/rignanese/leo/slimfacebook/MainActivity.java
@@ -544,7 +544,8 @@ public class MainActivity extends Activity implements MyAdvancedWebView.Listener
     //*********************** OTHER ****************************
 
     String FromDestopToMobileUrl(String url) {
-        if (Uri.parse(url).getHost() != null && Uri.parse(url).getHost().endsWith("www.facebook.com")) {
+        if (Uri.parse(url).getHost() != null && Uri.parse(url).getHost().endsWith("facebook.com")) {
+	    url = url.replace("mbasic.facebook.com", "touch.facebook.com");
             url = url.replace("www.facebook.com", "touch.facebook.com");
         }
         return url;

--- a/SlimFacebook/app/src/main/java/it/rignanese/leo/slimfacebook/MessagesActivity.java
+++ b/SlimFacebook/app/src/main/java/it/rignanese/leo/slimfacebook/MessagesActivity.java
@@ -105,6 +105,13 @@ public class MessagesActivity extends Activity implements 	MyAdvancedWebView.Lis
 	//*********************** WEBVIEW EVENTS ****************************
 	@Override
 	public void onPageStarted(String url, Bitmap favicon) {
+		// We are no longer in 'messages', so pass this off to the main activity
+		if(!url.contains("messages")) {
+		    Intent i = new Intent(this, MainActivity.class);
+		    i.setData(Uri.parse(url));
+		    startActivity(i);
+
+		}
 		swipeRefreshLayout.setRefreshing(true);
 	}
 


### PR DESCRIPTION
Issue #65 is the result of Facebook passing in a URL with the mbasic.facebook.com subdomain. Also attached to this pull request is a fix for another issue that is not yet reported. 

The other issue is that while a user is inside of MessageActivity, they can click a link (like a user's name) that should refer them back to MainActivity. This doesn't happen because there is no parser set up to handle this. I believe this should address that issue as well, and I have tested it.