### PR TITLE
added functionality to remove suggested posts from pages and groups

### DIFF
--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -8,6 +8,7 @@
   "use_mbasic_desc": "It works better on older devices or slower connections",
   "recent_first": "Show recent posts first",
   "hide_ads": "Hide some ads (experimental)",
+  "hide_suggested": "Hide suggested posts",
   "style": "style",
   "dark_theme": "Enable dark theme",
   "fixed_bar": "Fixed top bar",

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -8,6 +8,7 @@
   "use_mbasic_desc": "Funziona meglio su dispositivi pi\u00f9 vecchi o connessioni pi\u00f9 lente.",
   "recent_first": "Mostra prima i post recenti",
   "hide_ads": "Nascondi alcuni annunci (sperimentale)",
+  "hide_suggested": "Nascondi post suggeriti",
   "style": "stile",
   "dark_theme": "Abilita il tema scuro",
   "fixed_bar": "Barra superiore fissa",

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -393,6 +393,7 @@ class _HomePageState extends ConsumerState<HomePage> {
 
     //create the function that will be called later
     await _controller.runJavaScript(CustomJs.removeAdsFunc);
+    await _controller.runJavaScript(CustomJs.removeSuggestedFunc);
 
     //it's important to remove the \n
     final code = """
@@ -401,6 +402,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                         ${CustomJs.injectCssFunc(CustomCss.removeBrowserNotSupportedCss.code)}
                         ${CustomJs.injectCssFunc(cssList)}
                          ${(sp.getBool('hide_ads') ?? true) ? "removeAds();" : ""}
+                         ${(sp.getBool('hide_suggested') ?? true) ? "removeSuggested();" : ""}
                     });"""
         .replaceAll("\n", " ");
     await _controller.runJavaScript(code);
@@ -410,6 +412,9 @@ class _HomePageState extends ConsumerState<HomePage> {
     if (sp.getBool('hide_ads') ?? true) {
       //setup the observer to run on page updates
       await _controller.runJavaScript(CustomJs.removeAdsObserver);
+    }
+    if (sp.getBool('hide_suggested') ?? true) {
+      await _controller.runJavaScript(CustomJs.removeSuggestedObserver);
     }
 
     final userCustomJs = PrefController.getUserCustomJs();

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -108,6 +108,17 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               SettingsTile.switchTile(
                 onToggle: (value) {
                   setState(() {
+                    sp.setBool("hide_suggested", value);
+                  });
+                  ref.refresh(fbWebViewProvider);
+                },
+                initialValue: sp.getBool("hide_suggested") ?? true,
+                leading: const Icon(Icons.hide_source),
+                title: Text('hide_suggested'.tr()),
+              ),
+              SettingsTile.switchTile(
+                onToggle: (value) {
+                  setState(() {
                     sp.setBool("recent_first", value);
                   });
                   ref

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -99,13 +99,74 @@ if (typeof newPostsObserver !== 'undefined') {
     const newPostsObserver = new MutationObserver(function (mutations) {
         mutations.forEach(function (mutation) {
             // Filter out added nodes that are not <section> elements
-            const addedSections = Array.from(mutation.addedNodes).filter(node => node.nodeName === 'SECTION');
+            const addedSections = Array.from(mutation.addedNodes);
 
             // Check if any new <section> elements were added
             if (addedSections.length) {
                 removeAds();
             }
         });
+    });
+
+    // Options for the observer (which mutations to observe)
+    const config = { childList: true, subtree: true };
+
+    // Start observing the target node for configured mutations
+    newPostsObserver.observe(bodyNode, config);
+}
+  """;
+
+  static String removeSuggestedFunc = """
+  javascript: function removeSuggested() {
+    var followKeywords = [
+      // Italian
+      "Segui",
+      "Iscriviti",
+      // English
+      "Follow",
+      "Like",
+      "${"suggested_keyword_fb".tr()}",
+    ];
+
+    var followSpans = document.querySelectorAll('span.f2').filter(span =>
+      followKeywords.some(keyword => span.textContent.includes(keyword))
+    );
+
+    followSpans.forEach(span => {
+      // Go up 6 parents
+      let sixthParent = span;
+      for (let i = 0; i < 6; i++) {
+          if (sixthParent) {
+              sixthParent = sixthParent.parentElement;
+          }
+      }
+
+      if (sixthParent) {
+          sixthParent.style.display = 'none';
+          if (sixthParent.previousElementSibling) {
+              sixthParent.previousElementSibling.style.display = 'none';
+          }
+      }
+    });
+  }
+""";
+
+  static String removeSuggestedObserver = """
+if (typeof newPostsObserver !== 'undefined') {
+    // Select the node that will be observed for changes
+    const bodyNode = document.body;
+
+    // Create a new observer object
+    const newPostsObserver = new MutationObserver(function (mutations) {
+      mutations.forEach(function (mutation) {
+          // Filter out added nodes that are not <section> elements
+          const addedSections = Array.from(mutation.addedNodes);
+
+          // Check if any new <section> elements were added
+          if (addedSections.length) {
+              removeSuggested();
+          }
+      });
     });
 
     // Options for the observer (which mutations to observe)


### PR DESCRIPTION
- Added a new setting to remove suggested posts from pages and groups that user is not following and JavaScript logic to hide them from the page in English and Italian
- Fixed advertisement posts that were not removed when removal setting was enabled