### PR TITLE
Fix uploader

### DIFF
--- a/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
+++ b/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- to allow to read photos -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <!-- gps -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- to share pictures -->


### PR DESCRIPTION
Fix photo browser:

Keep permission `android.permission.READ_EXTERNAL_STORAGE"/>` because it is needed for android versions before 13 or so