### PR TITLE
Migrate PrefController to Riverpod Provider

### DIFF
--- a/SlimSocial_for_Facebook/analysis_options.yaml
+++ b/SlimSocial_for_Facebook/analysis_options.yaml
@@ -31,3 +31,4 @@ linter:
     public_member_api_docs: false
     prefer_single_quotes: false
     no_leading_underscores_for_local_identifiers: false
+    avoid_classes_with_only_static_members: true

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -14,6 +14,22 @@ const List<String> kPermittedHostnamesMessenger = [
   "m.me",
 ];
 
+//key for the shared preferences
+
+const String spKeyUseMbasic = "use_mbasic";
+const String spKeyRecentFirst = "recent_first";
+const String spKeyCustomProxy = "custom_proxy";
+const String spKeyCustomUserAgent = "custom_useragent";
+const String spKeyCustomCss = "custom_css";
+const String spKeyCustomJs = "custom_js";
+
+// key enabled for the shared preferences
+const String spKeyUserAgentEnabled = "custom_useragent_enabled";
+const String spKeyCustomCssEnabled = "custom_css_enabled";
+const String spKeyCustomJsEnabled = "custom_js_enabled";
+const String spKeyCustomProxyEnabled = "custom_proxy_enabled";
+
+
 //suffix for the feed
 const String suffixRecentFirst = "?sk=h_chr";
 const String suffixDefault = "?sk=h_nor";

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -1,24 +1,27 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:slimsocial_for_facebook/consts.dart';
+import 'package:slimsocial_for_facebook/main.dart';
 
-import '../consts.dart';
-import '../main.dart';
+
+part 'fb_controller.g.dart';
 
 class PrefController {
   static String getHomePage() {
-    String initialURl = kTouchFacebookHomeUrl;
+    var initialURl = kTouchFacebookHomeUrl;
 
     if (sp.getBool("use_mbasic") ?? false) initialURl = kFacebookHomeBasicUrl;
 
-    if (sp.getBool("recent_first") ?? false)
+    if (sp.getBool("recent_first") ?? false) {
       return initialURl + suffixRecentFirst;
-
+    }
     return initialURl + suffixDefault;
   }
 
   static String getUserAgent() {
-    String spKeyEnabled = "custom_useragent_enabled";
+    const spKeyEnabled = "custom_useragent_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
-      var customUserAgent = sp.getString("custom_useragent");
+      final customUserAgent = sp.getString("custom_useragent");
       if (customUserAgent?.isNotEmpty ?? false) {
         print("Using custom user agent: $customUserAgent");
         return customUserAgent!;
@@ -31,9 +34,9 @@ class PrefController {
   }
 
   static String? getUserCustomCss() {
-    String spKeyEnabled = "custom_css_enabled";
+    const spKeyEnabled = "custom_css_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
-      var customCss = sp.getString("custom_css");
+      final customCss = sp.getString("custom_css");
       if (customCss?.isNotEmpty ?? false) {
         print("Using custom css: $customCss");
         return customCss!;
@@ -44,9 +47,9 @@ class PrefController {
   }
 
   static String? getUserCustomJs() {
-    String spKeyEnabled = "custom_js_enabled";
+    const spKeyEnabled = "custom_js_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
-      var customJs = sp.getString("custom_js");
+      final customJs = sp.getString("custom_js");
       if (customJs?.isNotEmpty ?? false) {
         print("Using custom js: $customJs");
         return customJs!;
@@ -57,10 +60,29 @@ class PrefController {
   }
 }
 
-class webViewUriState extends StateNotifier<Uri> {
+/* class webViewUriState extends StateNotifier<Uri> {
   webViewUriState(this.ref) : super(Uri.parse(kTouchFacebookHomeUrl));
 
   final Ref ref;
 
   void updateUrl(String _url) => state = Uri.parse(_url);
+} */
+
+@riverpod
+class WebViewUriNotifier extends _$WebViewUriNotifier {
+  @override
+  Future<Uri> build() async {
+    // Imposta un valore di default per il provider
+    return Uri.parse(kTouchFacebookHomeUrl);
+  }
+
+  // Metodo per aggiornare lo stato
+  Future<void> updateUrl(String newUriString) async {
+    state = const AsyncLoading();
+    try {
+      state = AsyncData(Uri.parse(newUriString));
+    } catch (error) {
+      state = AsyncError(error, StackTrace.current);
+    }
+  }
 }

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:slimsocial_for_facebook/consts.dart';
 import 'package:slimsocial_for_facebook/main.dart';
@@ -6,8 +5,16 @@ import 'package:slimsocial_for_facebook/main.dart';
 
 part 'fb_controller.g.dart';
 
-class PrefController {
-  static String getHomePage() {
+@riverpod
+class PrefController extends _$PrefController {
+
+  @override
+  void build() {
+    // Void build method only to inizialize the provider
+  }
+
+
+  String get homePageUrl {
     var initialURl = kTouchFacebookHomeUrl;
 
     if (sp.getBool("use_mbasic") ?? false) initialURl = kFacebookHomeBasicUrl;
@@ -18,7 +25,8 @@ class PrefController {
     return initialURl + suffixDefault;
   }
 
-  static String getUserAgent() {
+
+  String get userAgent {
     const spKeyEnabled = "custom_useragent_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
       final customUserAgent = sp.getString("custom_useragent");
@@ -33,7 +41,8 @@ class PrefController {
     return kFirefoxUserAgent;
   }
 
-  static String? getUserCustomCss() {
+
+  String? get userCustomCss {
     const spKeyEnabled = "custom_css_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
       final customCss = sp.getString("custom_css");
@@ -46,7 +55,7 @@ class PrefController {
     return null;
   }
 
-  static String? getUserCustomJs() {
+  String? get userCustomJs {
     const spKeyEnabled = "custom_js_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
       final customJs = sp.getString("custom_js");

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -27,8 +27,7 @@ class PrefController extends _$PrefController {
 
 
   String get userAgent {
-    const spKeyEnabled = "custom_useragent_enabled";
-    if (sp.getBool(spKeyEnabled) ?? false) {
+    if (sp.getBool(spKeyUserAgentEnabled) ?? false) {
       final customUserAgent = sp.getString("custom_useragent");
       if (customUserAgent?.isNotEmpty ?? false) {
         print("Using custom user agent: $customUserAgent");
@@ -43,8 +42,7 @@ class PrefController extends _$PrefController {
 
 
   String? get userCustomCss {
-    const spKeyEnabled = "custom_css_enabled";
-    if (sp.getBool(spKeyEnabled) ?? false) {
+    if (sp.getBool(spKeyCustomCssEnabled) ?? false) {
       final customCss = sp.getString("custom_css");
       if (customCss?.isNotEmpty ?? false) {
         print("Using custom css: $customCss");
@@ -56,8 +54,7 @@ class PrefController extends _$PrefController {
   }
 
   String? get userCustomJs {
-    const spKeyEnabled = "custom_js_enabled";
-    if (sp.getBool(spKeyEnabled) ?? false) {
+    if (sp.getBool(spKeyCustomJsEnabled) ?? false) {
       final customJs = sp.getString("custom_js");
       if (customJs?.isNotEmpty ?? false) {
         print("Using custom js: $customJs");

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:slimsocial_for_facebook/consts.dart';
 import 'package:slimsocial_for_facebook/main.dart';
@@ -5,16 +6,8 @@ import 'package:slimsocial_for_facebook/main.dart';
 
 part 'fb_controller.g.dart';
 
-@riverpod
-class PrefController extends _$PrefController {
-
-  @override
-  void build() {
-    // Void build method only to inizialize the provider
-  }
-
-
-  String get homePageUrl {
+class PrefController {
+  static String getHomePage() {
     var initialURl = kTouchFacebookHomeUrl;
 
     if (sp.getBool("use_mbasic") ?? false) initialURl = kFacebookHomeBasicUrl;
@@ -25,9 +18,9 @@ class PrefController extends _$PrefController {
     return initialURl + suffixDefault;
   }
 
-
-  String get userAgent {
-    if (sp.getBool(spKeyUserAgentEnabled) ?? false) {
+  static String getUserAgent() {
+    const spKeyEnabled = "custom_useragent_enabled";
+    if (sp.getBool(spKeyEnabled) ?? false) {
       final customUserAgent = sp.getString("custom_useragent");
       if (customUserAgent?.isNotEmpty ?? false) {
         print("Using custom user agent: $customUserAgent");
@@ -41,8 +34,9 @@ class PrefController extends _$PrefController {
   }
 
 
-  String? get userCustomCss {
-    if (sp.getBool(spKeyCustomCssEnabled) ?? false) {
+  static String? getUserCustomCss() {
+    const spKeyEnabled = "custom_css_enabled";
+    if (sp.getBool(spKeyEnabled) ?? false) {
       final customCss = sp.getString("custom_css");
       if (customCss?.isNotEmpty ?? false) {
         print("Using custom css: $customCss");
@@ -53,8 +47,10 @@ class PrefController extends _$PrefController {
     return null;
   }
 
-  String? get userCustomJs {
-    if (sp.getBool(spKeyCustomJsEnabled) ?? false) {
+
+  static String? getUserCustomJs() {
+    const spKeyEnabled = "custom_js_enabled";
+    if (sp.getBool(spKeyEnabled) ?? false) {
       final customJs = sp.getString("custom_js");
       if (customJs?.isNotEmpty ?? false) {
         print("Using custom js: $customJs");

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:slimsocial_for_facebook/consts.dart';
 import 'package:slimsocial_for_facebook/main.dart';
@@ -6,8 +5,16 @@ import 'package:slimsocial_for_facebook/main.dart';
 
 part 'fb_controller.g.dart';
 
-class PrefController {
-  static String getHomePage() {
+@riverpod
+class PrefController extends _$PrefController {
+
+  @override
+  void build() {
+    // Void build method only to inizialize the provider
+  }
+
+
+  String get homePageUrl {
     var initialURl = kTouchFacebookHomeUrl;
 
     if (sp.getBool("use_mbasic") ?? false) initialURl = kFacebookHomeBasicUrl;
@@ -18,7 +25,8 @@ class PrefController {
     return initialURl + suffixDefault;
   }
 
-  static String getUserAgent() {
+
+  String get userAgent {
     const spKeyEnabled = "custom_useragent_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
       final customUserAgent = sp.getString("custom_useragent");
@@ -34,7 +42,8 @@ class PrefController {
   }
 
 
-  static String? getUserCustomCss() {
+
+  String? get userCustomCss {
     const spKeyEnabled = "custom_css_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
       final customCss = sp.getString("custom_css");
@@ -48,7 +57,7 @@ class PrefController {
   }
 
 
-  static String? getUserCustomJs() {
+  String? get userCustomJs {
     const spKeyEnabled = "custom_js_enabled";
     if (sp.getBool(spKeyEnabled) ?? false) {
       final customJs = sp.getString("custom_js");

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'fb_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$webViewUriNotifierHash() =>
+    r'70317dacd19ea8566f71fad4cb27e39b2c9bb3e6';
+
+/// See also [WebViewUriNotifier].
+@ProviderFor(WebViewUriNotifier)
+final webViewUriNotifierProvider =
+    AutoDisposeAsyncNotifierProvider<WebViewUriNotifier, Uri>.internal(
+  WebViewUriNotifier.new,
+  name: r'webViewUriNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$webViewUriNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$WebViewUriNotifier = AutoDisposeAsyncNotifier<Uri>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
@@ -6,24 +6,9 @@ part of 'fb_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$prefControllerHash() => r'8a7f97d6f8277196bb797f5e2c0eaf5a4e93a2aa';
 
-/// See also [PrefController].
-@ProviderFor(PrefController)
-final prefControllerProvider =
-    AutoDisposeNotifierProvider<PrefController, void>.internal(
-  PrefController.new,
-  name: r'prefControllerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$prefControllerHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-typedef _$PrefController = AutoDisposeNotifier<void>;
 String _$webViewUriNotifierHash() =>
-    r'748b066077a8ac14e79289420cf17cab03e341f6';
+    r'70317dacd19ea8566f71fad4cb27e39b2c9bb3e6';
 
 /// See also [WebViewUriNotifier].
 @ProviderFor(WebViewUriNotifier)

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
@@ -6,8 +6,24 @@ part of 'fb_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+String _$prefControllerHash() => r'8a7f97d6f8277196bb797f5e2c0eaf5a4e93a2aa';
+
+/// See also [PrefController].
+@ProviderFor(PrefController)
+final prefControllerProvider =
+    AutoDisposeNotifierProvider<PrefController, void>.internal(
+  PrefController.new,
+  name: r'prefControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$prefControllerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$PrefController = AutoDisposeNotifier<void>;
 String _$webViewUriNotifierHash() =>
-    r'70317dacd19ea8566f71fad4cb27e39b2c9bb3e6';
+    r'748b066077a8ac14e79289420cf17cab03e341f6';
 
 /// See also [WebViewUriNotifier].
 @ProviderFor(WebViewUriNotifier)

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.g.dart
@@ -7,8 +7,24 @@ part of 'fb_controller.dart';
 // **************************************************************************
 
 
+String _$prefControllerHash() => r'8a7f97d6f8277196bb797f5e2c0eaf5a4e93a2aa';
+
+/// See also [PrefController].
+@ProviderFor(PrefController)
+final prefControllerProvider =
+    AutoDisposeNotifierProvider<PrefController, void>.internal(
+  PrefController.new,
+  name: r'prefControllerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$prefControllerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$PrefController = AutoDisposeNotifier<void>;
 String _$webViewUriNotifierHash() =>
-    r'70317dacd19ea8566f71fad4cb27e39b2c9bb3e6';
+    r'748b066077a8ac14e79289420cf17cab03e341f6';
 
 /// See also [WebViewUriNotifier].
 @ProviderFor(WebViewUriNotifier)

--- a/SlimSocial_for_Facebook/lib/main.dart
+++ b/SlimSocial_for_Facebook/lib/main.dart
@@ -16,10 +16,10 @@ import 'package:slimsocial_for_facebook/utils/utils.dart';
 late SharedPreferences sp;
 
 //riverpod state
-final fbWebViewProvider =
+/* final fbWebViewProvider =
     StateNotifierProvider<webViewUriState, Uri>(webViewUriState.new);
-final messengerWebViewProvider =
-    StateNotifierProvider<webViewUriState, Uri>(webViewUriState.new);
+final messegerWebViewProvider =
+    StateNotifierProvider<webViewUriState, Uri>(webViewUriState.new); */
 
 late PackageInfo packageInfo;
 
@@ -39,12 +39,13 @@ Future<void> main() async {
   _appLinks.uriLinkStream.listen((uri) {
     print("Received uri: $uri");
     //run the app with the uri
-    container.read(fbWebViewProvider.notifier).updateUrl(uri.toString());
+    container
+        .read(webViewUriNotifierProvider.notifier)
+        .updateUrl(uri.toString());
   });
 
   runApp(
     ProviderScope(
-      parent: container,
       child: EasyLocalization(
         supportedLocales: const [
           Locale('it', 'IT'),

--- a/SlimSocial_for_Facebook/lib/main.dart
+++ b/SlimSocial_for_Facebook/lib/main.dart
@@ -146,6 +146,23 @@ class _SlimSocialAppState extends State<SlimSocialApp> {
         textTheme: GoogleFonts.robotoTextTheme(
           ThemeData(brightness: Brightness.light).textTheme,
         ),
+        popupMenuTheme: const PopupMenuThemeData(
+          textStyle: TextStyle(
+            color: FacebookColors.blue,
+          ),
+          iconColor: FacebookColors.blue,
+        ), 
+        listTileTheme: const ListTileThemeData(
+          tileColor: FacebookColors.white,
+          selectedTileColor: FacebookColors.lightBlue,
+          iconColor: FacebookColors.blue,
+          textColor: FacebookColors.darkBlue,
+        ),
+        iconButtonTheme: const IconButtonThemeData(
+          style: ButtonStyle(
+            foregroundColor: WidgetStatePropertyAll(FacebookColors.blue),
+          ),
+        ),
       ),
       darkTheme: ThemeData(
         useMaterial3: false,
@@ -153,6 +170,19 @@ class _SlimSocialAppState extends State<SlimSocialApp> {
         textTheme: GoogleFonts.robotoTextTheme(
           ThemeData(brightness: Brightness.dark).textTheme,
         ),
+        popupMenuTheme: const PopupMenuThemeData(
+          textStyle: TextStyle(
+            color: FacebookColors.white,
+          ),
+          iconColor: FacebookColors.white,
+        ), 
+        listTileTheme: const ListTileThemeData(
+          //tileColor: FacebookColors.white,
+          selectedTileColor: FacebookColors.lightBlue,
+          iconColor: FacebookColors.white,
+          textColor: FacebookColors.white,
+        ),
+
       ),
       themeMode: _themeMode,
       home: const HomePage(),

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -35,6 +35,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   bool isScontentUrl = false;
 
   late WebViewController _controller;
+  late PrefController _prefController;
 
   @override
   void dispose() {
@@ -104,7 +105,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     }
 
 
-    final userCustomJs = PrefController.getUserCustomJs();
+    final userCustomJs = _prefController.userCustomJs;
     if (userCustomJs?.isNotEmpty ?? false) {
       await _controller.runJavaScript(userCustomJs!);
     }
@@ -127,7 +128,7 @@ class _HomePageState extends ConsumerState<HomePage> {
       ..setBackgroundColor(FacebookColors.white)
       //..setBackgroundColor(FacebookColors.darkBlue)
 
-      ..setUserAgent(PrefController.getUserAgent())
+      ..setUserAgent(_prefController.userAgent)
       ..setNavigationDelegate(
         NavigationDelegate(
           onNavigationRequest: onNavigationRequest,
@@ -266,12 +267,15 @@ class _HomePageState extends ConsumerState<HomePage> {
             //_controller?.loadUrl(PrefController.getHomePage());
             ref
                 .read(webViewUriNotifierProvider.notifier)
-                .updateUrl(PrefController.getHomePage());
+                .updateUrl(_prefController.homePageUrl);
           },
 
-          icon: Icon(Icons.home, color: CustomCss.darkThemeCss.isEnabled()
+          icon: Icon(
+            Icons.home,
+            color: CustomCss.darkThemeCss.isEnabled()
                 ? FacebookColors.white
-                : FacebookColors.blue,),
+                : FacebookColors.blue,
+          ),
         ),
         centerTitle: true,
         title: GestureDetector(
@@ -433,23 +437,13 @@ class _HomePageState extends ConsumerState<HomePage> {
               return false;
             }
 
-            return false;
-          }
-          return true;
-        },
-        child: Stack(
-          alignment: AlignmentDirectional.bottomCenter,
-          children: [
-            WebViewWidget(
-              controller: _controller,
-            ),
-            if (isLoading)
-              const Center(
-                child: CircularProgressIndicator(
-                  valueColor:
-                      AlwaysStoppedAnimation<Color>(FacebookColors.official),
-                  //backgroundColor: Colors.white,
-                ),
+            return true;
+          },
+          child: Stack(
+            alignment: AlignmentDirectional.bottomCenter,
+            children: [
+              WebViewWidget(
+                controller: _controller,
               ),
               if (isLoading)
                 const Center(

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -266,16 +266,26 @@ class _HomePageState extends ConsumerState<HomePage> {
                 .read(webViewUriNotifierProvider.notifier)
                 .updateUrl(PrefController.getHomePage());
           },
-          icon: const Icon(Icons.home),
+          icon: Icon(Icons.home, color: CustomCss.darkThemeCss.isEnabled()
+                ? FacebookColors.white
+                : FacebookColors.blue,),
         ),
         centerTitle: true,
         title: GestureDetector(
-          child: const Text('SlimSocial'),
+          child: Text(
+            'SlimSocial',
+            style: TextStyle(
+              color: CustomCss.darkThemeCss.isEnabled()
+                  ? FacebookColors.white
+                  : FacebookColors.blue,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
           onTap: () => _controller.scrollTo(0, 0),
         ),
         backgroundColor: CustomCss.darkThemeCss.isEnabled()
             ? FacebookColors.darkBlue
-            : FacebookColors.official,
+            : FacebookColors.white,
         elevation: 0,
         actions: [
           /*  IconButton(
@@ -318,7 +328,13 @@ class _HomePageState extends ConsumerState<HomePage> {
                   ),
                 );
               },
-              icon: Image.asset('assets/icons/ic_messenger.png', height: 22),
+              icon: Image.asset(
+                'assets/icons/ic_messenger.png',
+                height: 22,
+                color: CustomCss.darkThemeCss.isEnabled()
+                    ? FacebookColors.white
+                    : FacebookColors.blue,
+              ),
             ),
           PopupMenuButton<String>(
             onSelected: (item) async {

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -268,12 +268,10 @@ class _HomePageState extends ConsumerState<HomePage> {
                 .read(webViewUriNotifierProvider.notifier)
                 .updateUrl(PrefController.getHomePage());
           },
-          icon: Icon(
-            Icons.home,
-            color: CustomCss.darkThemeCss.isEnabled()
+
+          icon: Icon(Icons.home, color: CustomCss.darkThemeCss.isEnabled()
                 ? FacebookColors.white
-                : FacebookColors.blue,
-          ),
+                : FacebookColors.blue,),
         ),
         centerTitle: true,
         title: GestureDetector(

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -31,9 +31,15 @@ class HomePage extends ConsumerStatefulWidget {
 }
 
 class _HomePageState extends ConsumerState<HomePage> {
-  late WebViewController _controller;
   bool isLoading = false;
   bool isScontentUrl = false;
+
+  late WebViewController _controller;
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
 
   @override
   void initState() {
@@ -42,11 +48,83 @@ class _HomePageState extends ConsumerState<HomePage> {
     _controller = _initWebViewController();
   }
 
+  Future<NavigationDecision> onNavigationRequest(
+    NavigationRequest request,
+  ) async {
+    final uri = Uri.parse(request.url);
+    print("onNavigationRequest: ${request.url}");
+
+    for (final other in kPermittedHostnamesFb) {
+      if (uri.host.endsWith(other)) {
+        return NavigationDecision.navigate;
+      }
+    }
+    for (final other in kPermittedHostnamesMessenger) {
+      if (uri.host.endsWith(other)) {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => MessengerPage(initialUrl: uri.toString()),
+          ),
+        );
+        return NavigationDecision.prevent;
+      }
+    }
+
+    // open on webview
+    print("Launching external url: ${request.url}");
+    launchInAppUrl(context, request.url);
+    return NavigationDecision.prevent;
+  }
+
+  Future<void> injectCss() async {
+    var cssList = "";
+    for (final css in CustomCss.cssList) {
+      if (css.isEnabled()) cssList += css.code;
+    }
+
+    //create the function that will be called later
+    await _controller.runJavaScript(CustomJs.removeAdsFunc);
+
+    //it's important to remove the \n
+    final code = """
+                    document.addEventListener("DOMContentLoaded", function() {
+                        ${CustomJs.injectCssFunc(CustomCss.removeMessengerDownloadCss.code)}
+                        ${CustomJs.injectCssFunc(CustomCss.removeBrowserNotSupportedCss.code)}
+                        ${CustomJs.injectCssFunc(cssList)}
+                         ${(sp.getBool('hide_ads') ?? true) ? "removeAds();" : ""}
+                    });"""
+        .replaceAll("\n", " ");
+    await _controller.runJavaScript(code);
+  }
+
+  Future<void> runJs() async {
+    if (sp.getBool('hide_ads') ?? true) {
+      //setup the observer to run on page updates
+      await _controller.runJavaScript(CustomJs.removeAdsObserver);
+    }
+
+    final userCustomJs = PrefController.getUserCustomJs();
+    if (userCustomJs?.isNotEmpty ?? false) {
+      await _controller.runJavaScript(userCustomJs!);
+    }
+  }
+
+/*  JavascriptChannel _setupJavascriptChannel(BuildContext context) {
+    return JavascriptChannel(
+      name: 'Toaster',
+      onMessageReceived: (JavascriptMessage message) {
+        // ignore: deprecated_member_use
+        print('Message received: ${message.message}');
+      },
+    );
+  }*/
+
   WebViewController _initWebViewController() {
     final homepage = PrefController.getHomePage();
     final controller = (WebViewController())
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
-      ..setBackgroundColor(FacebookColors.darkBlue)
+      ..setBackgroundColor(FacebookColors.white)
+      //..setBackgroundColor(FacebookColors.darkBlue)
       ..setUserAgent(PrefController.getUserAgent())
       ..setNavigationDelegate(
         NavigationDelegate(
@@ -137,68 +215,45 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   @override
-  void dispose() {
-    super.dispose();
-  }
-
-  Future<NavigationDecision> onNavigationRequest(
-    NavigationRequest request,
-  ) async {
-    final uri = Uri.parse(request.url);
-    print("onNavigationRequest: ${request.url}");
-
-    for (final other in kPermittedHostnamesFb)
-      if (uri.host.endsWith(other)) {
-        return NavigationDecision.navigate;
-      }
-
-    for (final other in kPermittedHostnamesMessenger) {
-      if (uri.host.endsWith(other)) {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => MessengerPage(initialUrl: uri.toString()),
-          ),
-        );
-        return NavigationDecision.prevent;
-      }
-    }
-
-    // open on webview
-    print("Launching external url: ${request.url}");
-    launchInAppUrl(context, request.url);
-    return NavigationDecision.prevent;
-  }
-
-  @override
   Widget build(BuildContext context) {
     //refresh the page whenever a new state (url) comes
-    ref.listen<Uri>(
-      fbWebViewProvider,
-      (previous, next) async {
-        final currentUrl = await _controller.currentUrl();
-        if (currentUrl != null) {
-          final currentUri = Uri.parse(currentUrl);
-          if (currentUri.toString() == next.toString()) {
-            print("refreshing keeping the y index...");
-            //if I'm refreshing the page, I need to save the current scroll position
-            final position = await _controller.getScrollPosition();
-            final x = position.dx;
-            final y = position.dy;
+    ref.listen<AsyncValue<Uri>>(
+      webViewUriNotifierProvider,
+      (previous, next) {
+        next.when(
+          data: (uri) async {
+            final currentUrl = await _controller.currentUrl();
+            if (currentUrl != null) {
+              final currentUri = Uri.parse(currentUrl);
+              if (currentUri.toString() == uri.toString()) {
+                print("refreshing keeping the y index...");
+                //if I'm refreshing the page, I need to save the current scroll position
+                final position = await _controller.getScrollPosition();
+                final x = position.dx;
+                final y = position.dy;
 
-            //refresh
-            await _controller.reload();
+                //refresh
+                await _controller.reload();
 
-            //go back to the previous location
-            if (y > 0 || x > 0) {
-              await Future.delayed(const Duration(milliseconds: 1500));
-              print("restoring  $x, $y");
-              await _controller.scrollTo(x.toInt(), y.toInt());
+                //go back to the previous location
+                if (y > 0 || x > 0) {
+                  await Future.delayed(const Duration(milliseconds: 1500));
+                  print("restoring  $x, $y");
+                  await _controller.scrollTo(x.toInt(), y.toInt());
+                }
+                return;
+              }
             }
-            return;
-          }
-        }
 
-        await _controller.loadRequest(next);
+            await _controller.loadRequest(uri);
+          },
+          loading: () {
+            const CircularProgressIndicator();
+          },
+          error: (error, stackTrace) {
+            print("Error: $error");
+          },
+        );
       },
     );
 
@@ -208,7 +263,7 @@ class _HomePageState extends ConsumerState<HomePage> {
           onPressed: () {
             //_controller?.loadUrl(PrefController.getHomePage());
             ref
-                .read(fbWebViewProvider.notifier)
+                .read(webViewUriNotifierProvider.notifier)
                 .updateUrl(PrefController.getHomePage());
           },
           icon: const Icon(Icons.home),
@@ -270,23 +325,21 @@ class _HomePageState extends ConsumerState<HomePage> {
               switch (item) {
                 case "share_url":
                   final url = await _controller.currentUrl();
-                  if (url != null) Share.share(url);
+                  if (url != null) await Share.share(url);
                   break;
                 case "refresh":
-                  _controller.reload();
+                  await _controller.reload();
                   break;
                 case "settings":
-                  Navigator.of(context).pushNamed("/settings");
+                  await Navigator.of(context).pushNamed("/settings");
                   break;
                 case "top":
-                  _controller.scrollTo(0, 0);
+                  await _controller.scrollTo(0, 0);
                   break;
                 case "support":
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) =>
-                          SettingsPage(productId: "donation_1"),
+                  await Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (ctx) => SettingsPage(productId: "donation_1"),
                     ),
                   );
                   break;
@@ -304,7 +357,6 @@ class _HomePageState extends ConsumerState<HomePage> {
               PopupMenuItem<String>(
                 value: "top",
                 child: ListTile(
-                  contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.vertical_align_top),
                   title: Text("top".tr().capitalize()),
                 ),
@@ -312,7 +364,6 @@ class _HomePageState extends ConsumerState<HomePage> {
               PopupMenuItem<String>(
                 value: "refresh",
                 child: ListTile(
-                  contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.refresh),
                   title: Text("refresh".tr().capitalize()),
                 ),
@@ -320,7 +371,6 @@ class _HomePageState extends ConsumerState<HomePage> {
               PopupMenuItem<String>(
                 value: "share_url",
                 child: ListTile(
-                  contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.share),
                   title: Text("share_url".tr().capitalize()),
                 ),
@@ -328,7 +378,6 @@ class _HomePageState extends ConsumerState<HomePage> {
               PopupMenuItem<String>(
                 value: "settings",
                 child: ListTile(
-                  contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.settings),
                   title: Text("settings".tr().capitalize()),
                 ),
@@ -337,7 +386,6 @@ class _HomePageState extends ConsumerState<HomePage> {
                 value: "support",
                 child: ListTile(
                   iconColor: Colors.red,
-                  contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.favorite),
                   title: Text("support".tr().capitalize()),
                 ),
@@ -345,7 +393,6 @@ class _HomePageState extends ConsumerState<HomePage> {
               PopupMenuItem<String>(
                 value: "reset",
                 child: ListTile(
-                  contentPadding: EdgeInsets.zero,
                   leading: const Icon(Icons.restore),
                   title: Text("reset".tr().capitalize()),
                 ),
@@ -374,57 +421,16 @@ class _HomePageState extends ConsumerState<HomePage> {
               controller: _controller,
             ),
             if (isLoading)
-              const LinearProgressIndicator(
-                valueColor:
-                    AlwaysStoppedAnimation<Color>(FacebookColors.official),
-                backgroundColor: Colors.transparent,
+              const Center(
+                child: CircularProgressIndicator(
+                  valueColor:
+                      AlwaysStoppedAnimation<Color>(FacebookColors.official),
+                  //backgroundColor: Colors.white,
+                ),
               ),
           ],
         ),
       ),
     );
   }
-
-  Future<void> injectCss() async {
-    var cssList = "";
-    for (final css in CustomCss.cssList) {
-      if (css.isEnabled()) cssList += css.code;
-    }
-
-    //create the function that will be called later
-    await _controller.runJavaScript(CustomJs.removeAdsFunc);
-
-    //it's important to remove the \n
-    final code = """
-                    document.addEventListener("DOMContentLoaded", function() {
-                        ${CustomJs.injectCssFunc(CustomCss.removeMessengerDownloadCss.code)}
-                        ${CustomJs.injectCssFunc(CustomCss.removeBrowserNotSupportedCss.code)}
-                        ${CustomJs.injectCssFunc(cssList)}
-                         ${(sp.getBool('hide_ads') ?? true) ? "removeAds();" : ""}
-                    });"""
-        .replaceAll("\n", " ");
-    await _controller.runJavaScript(code);
-  }
-
-  Future<void> runJs() async {
-    if (sp.getBool('hide_ads') ?? true) {
-      //setup the observer to run on page updates
-      await _controller.runJavaScript(CustomJs.removeAdsObserver);
-    }
-
-    final userCustomJs = PrefController.getUserCustomJs();
-    if (userCustomJs?.isNotEmpty ?? false) {
-      await _controller.runJavaScript(userCustomJs!);
-    }
-  }
-
-/*  JavascriptChannel _setupJavascriptChannel(BuildContext context) {
-    return JavascriptChannel(
-      name: 'Toaster',
-      onMessageReceived: (JavascriptMessage message) {
-        // ignore: deprecated_member_use
-        print('Message received: ${message.message}');
-      },
-    );
-  }*/
 }

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -35,7 +35,6 @@ class _HomePageState extends ConsumerState<HomePage> {
   bool isScontentUrl = false;
 
   late WebViewController _controller;
-  late PrefController _prefController;
 
   @override
   void dispose() {
@@ -104,7 +103,8 @@ class _HomePageState extends ConsumerState<HomePage> {
       await _controller.runJavaScript(CustomJs.removeAdsObserver);
     }
 
-    final userCustomJs = _prefController.userCustomJs;
+
+    final userCustomJs = PrefController.getUserCustomJs();
     if (userCustomJs?.isNotEmpty ?? false) {
       await _controller.runJavaScript(userCustomJs!);
     }
@@ -126,7 +126,8 @@ class _HomePageState extends ConsumerState<HomePage> {
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setBackgroundColor(FacebookColors.white)
       //..setBackgroundColor(FacebookColors.darkBlue)
-      ..setUserAgent(_prefController.userAgent)
+
+      ..setUserAgent(PrefController.getUserAgent())
       ..setNavigationDelegate(
         NavigationDelegate(
           onNavigationRequest: onNavigationRequest,
@@ -265,7 +266,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             //_controller?.loadUrl(PrefController.getHomePage());
             ref
                 .read(webViewUriNotifierProvider.notifier)
-                .updateUrl(_prefController.homePageUrl);
+                .updateUrl(PrefController.getHomePage());
           },
           icon: Icon(
             Icons.home,
@@ -433,13 +434,24 @@ class _HomePageState extends ConsumerState<HomePage> {
               }
               return false;
             }
-            return true;
-          },
-          child: Stack(
-            alignment: AlignmentDirectional.bottomCenter,
-            children: [
-              WebViewWidget(
-                controller: _controller,
+
+            return false;
+          }
+          return true;
+        },
+        child: Stack(
+          alignment: AlignmentDirectional.bottomCenter,
+          children: [
+            WebViewWidget(
+              controller: _controller,
+            ),
+            if (isLoading)
+              const Center(
+                child: CircularProgressIndicator(
+                  valueColor:
+                      AlwaysStoppedAnimation<Color>(FacebookColors.official),
+                  //backgroundColor: Colors.white,
+                ),
               ),
               if (isLoading)
                 const Center(

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -27,11 +27,13 @@ class MessengerPage extends ConsumerStatefulWidget {
 
 class _HomePageState extends ConsumerState<MessengerPage> {
   late WebViewController _controller;
+  late PrefController _prefController;
   bool isLoading = false;
 
   @override
   void initState() {
     super.initState();
+    _prefController = ref.read(prefControllerProvider.notifier);
     _controller = _initWebViewController();
   }
 
@@ -44,7 +46,7 @@ class _HomePageState extends ConsumerState<MessengerPage> {
     final controller = (WebViewController())
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setBackgroundColor(FacebookColors.darkBlue)
-      ..setUserAgent(PrefController.getUserAgent())
+      ..setUserAgent(_prefController.userAgent)
       ..setNavigationDelegate(
         NavigationDelegate(
           onNavigationRequest: onNavigationRequest,
@@ -237,7 +239,7 @@ class _HomePageState extends ConsumerState<MessengerPage> {
   }
 
   Future<void> runJs() async {
-    final userCustomJs = PrefController.getUserCustomJs();
+    final userCustomJs = _prefController.userCustomJs;
     if (userCustomJs?.isNotEmpty ?? false)
       await _controller.runJavaScript(userCustomJs!);
   }
@@ -248,7 +250,7 @@ class _HomePageState extends ConsumerState<MessengerPage> {
     if (CustomCss.darkThemeCss.isEnabled())
       cssList += CustomCss.darkThemeMessengerCss.code;
 
-    final userCustomCss = PrefController.getUserCustomCss();
+    final userCustomCss = _prefController.userCustomCss;
     if (userCustomCss?.isNotEmpty ?? false) cssList += userCustomCss!;
 
     final code = """

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -19,7 +19,6 @@ import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-
 class SettingsPage extends ConsumerStatefulWidget {
   SettingsPage({this.productId, super.key});
   //this is used to make a shortcut for donations
@@ -119,7 +118,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   ref
                       .read(webViewUriNotifierProvider.notifier)
 
-                      .updateUrl(PrefController.getHomePage());
+                      .updateUrl(_prefController.homePageUrl);
                 },
                 initialValue: sp.getBool("recent_first"),
                 leading: const Icon(Icons.rss_feed),
@@ -134,7 +133,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   ref
                       .read(webViewUriNotifierProvider.notifier)
 
-                      .updateUrl(PrefController.getHomePage());
+                      .updateUrl(_prefController.homePageUrl);
                   Restart.restartApp();
                 },
                 initialValue: sp.getBool("use_mbasic") ?? false,
@@ -244,7 +243,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.vertical_align_top),
                 title: Text(CustomCss.fixedBarCss.key.tr()),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -257,7 +255,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.hideStoriesCss.key.tr()),
                 leading: const Icon(Icons.hide_image),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -270,7 +267,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.centerTextPostsCss.key.tr()),
                 leading: const Icon(Icons.format_align_center),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -283,7 +279,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.addSpaceBetweenPostsCss.key.tr()),
                 leading: const Icon(Icons.format_line_spacing),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
             ],
           ),
@@ -299,7 +294,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 ),
                 onPressed: (context) async {
                   await showTextInputDialog(
-                    spKey: spKeyCustomUserAgent,
+
+                    spKey: "custom_useragent",
                     hint: _prefController.userAgent,
                   );
                   setState(() {});

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -99,7 +99,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   setState(() {
                     sp.setBool("hide_ads", value);
                   });
-                  ref.refresh(fbWebViewProvider);
+                  ref.refresh(webViewUriNotifierProvider);
                 },
                 initialValue: sp.getBool("hide_ads") ?? true,
                 leading: const Icon(Icons.hide_source),
@@ -111,7 +111,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                     sp.setBool("recent_first", value);
                   });
                   ref
-                      .read(fbWebViewProvider.notifier)
+                      .read(webViewUriNotifierProvider.notifier)
                       .updateUrl(PrefController.getHomePage());
                 },
                 initialValue: sp.getBool("recent_first"),
@@ -124,7 +124,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                     sp.setBool("use_mbasic", value);
                   });
                   ref
-                      .read(fbWebViewProvider.notifier)
+                      .read(webViewUriNotifierProvider.notifier)
                       .updateUrl(PrefController.getHomePage());
                   Restart.restartApp();
                 },
@@ -171,7 +171,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                     setState(() {
                       sp.setBool("camera_permission", value);
                     });
-                    ref.refresh(fbWebViewProvider);
+                    ref.refresh(webViewUriNotifierProvider);
                   }
                 },
                 //fixme bug on sp, I shoudl use the permission handler .isgranted
@@ -191,7 +191,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                     setState(() {
                       sp.setBool("photo_permission", value);
                     });
-                    ref.refresh(fbWebViewProvider);
+                    ref.refresh(webViewUriNotifierProvider);
                   }
                 },
                 //fixme bug on sp, I shoudl use the permission handler .isgranted
@@ -213,7 +213,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
 
                   final newTheme = value ? ThemeMode.dark : ThemeMode.light;
                   SlimSocialApp.of(context).changeTheme(newTheme);
-                  ref.refresh(fbWebViewProvider);
+                  ref.refresh(webViewUriNotifierProvider);
                 },
                 initialValue: CustomCss.darkThemeCss.isEnabled(),
                 title: Text(CustomCss.darkThemeCss.key.tr()),
@@ -224,7 +224,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   setState(() {
                     sp.setBool(CustomCss.fixedBarCss.key, value);
                   });
-                  ref.refresh(fbWebViewProvider);
+                  ref.refresh(webViewUriNotifierProvider);
                 },
                 initialValue: CustomCss.fixedBarCss.isEnabled(),
                 leading: const Icon(Icons.vertical_align_top),
@@ -235,7 +235,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   setState(() {
                     sp.setBool(CustomCss.hideStoriesCss.key, value);
                   });
-                  ref.refresh(fbWebViewProvider);
+                  ref.refresh(webViewUriNotifierProvider);
                 },
                 initialValue: CustomCss.hideStoriesCss.isEnabled(),
                 title: Text(CustomCss.hideStoriesCss.key.tr()),
@@ -246,7 +246,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   setState(() {
                     sp.setBool(CustomCss.centerTextPostsCss.key, value);
                   });
-                  ref.refresh(fbWebViewProvider);
+                  ref.refresh(webViewUriNotifierProvider);
                 },
                 initialValue: CustomCss.centerTextPostsCss.isEnabled(),
                 title: Text(CustomCss.centerTextPostsCss.key.tr()),
@@ -257,7 +257,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   setState(() {
                     sp.setBool(CustomCss.addSpaceBetweenPostsCss.key, value);
                   });
-                  ref.refresh(fbWebViewProvider);
+                  ref.refresh(webViewUriNotifierProvider);
                 },
                 initialValue: CustomCss.addSpaceBetweenPostsCss.isEnabled(),
                 title: Text(CustomCss.addSpaceBetweenPostsCss.key.tr()),

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -19,7 +19,6 @@ import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-
 class SettingsPage extends ConsumerStatefulWidget {
   SettingsPage({this.productId, super.key});
   //this is used to make a shortcut for donations
@@ -31,6 +30,7 @@ class SettingsPage extends ConsumerStatefulWidget {
 
 class _SettingsPageState extends ConsumerState<SettingsPage> {
   StreamSubscription<List<PurchaseDetails>>? _paymentSubscription;
+  late PrefController _prefController;
   bool isDev = false;
 
   final Map<String, Permission> permissions = const {
@@ -41,6 +41,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
 
   @override
   void initState() {
+    _prefController = ref.read(prefControllerProvider.notifier);
     _updatePermissionsToggle();
 
     if (!widget.productId.isNullOrEmpty()) {
@@ -116,7 +117,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   });
                   ref
                       .read(webViewUriNotifierProvider.notifier)
-                      .updateUrl(PrefController.getHomePage());
+                      .updateUrl(_prefController.homePageUrl);
                 },
                 initialValue: sp.getBool("recent_first"),
                 leading: const Icon(Icons.rss_feed),
@@ -130,7 +131,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   });
                   ref
                       .read(webViewUriNotifierProvider.notifier)
-                      .updateUrl(PrefController.getHomePage());
+                      .updateUrl(_prefController.homePageUrl);
                   Restart.restartApp();
                 },
                 initialValue: sp.getBool("use_mbasic") ?? false,
@@ -240,7 +241,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.vertical_align_top),
                 title: Text(CustomCss.fixedBarCss.key.tr()),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -253,7 +253,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.hideStoriesCss.key.tr()),
                 leading: const Icon(Icons.hide_image),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -266,7 +265,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.centerTextPostsCss.key.tr()),
                 leading: const Icon(Icons.format_align_center),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -279,7 +277,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.addSpaceBetweenPostsCss.key.tr()),
                 leading: const Icon(Icons.format_line_spacing),
                 activeSwitchColor: FacebookColors.blue,
-
               ),
             ],
           ),
@@ -296,7 +293,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 onPressed: (context) async {
                   await showTextInputDialog(
                     spKey: "custom_useragent",
-                    hint: PrefController.getUserAgent(),
+                    hint: _prefController.userAgent,
                   );
                   setState(() {});
                 },

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -117,7 +117,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   });
                   ref
                       .read(webViewUriNotifierProvider.notifier)
-                      .updateUrl(_prefController.homePageUrl);
+
+                      .updateUrl(PrefController.getHomePage());
                 },
                 initialValue: sp.getBool("recent_first"),
                 leading: const Icon(Icons.rss_feed),
@@ -131,7 +132,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   });
                   ref
                       .read(webViewUriNotifierProvider.notifier)
-                      .updateUrl(_prefController.homePageUrl);
+
+                      .updateUrl(PrefController.getHomePage());
                   Restart.restartApp();
                 },
                 initialValue: sp.getBool("use_mbasic") ?? false,

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -13,10 +13,12 @@ import 'package:share_plus/share_plus.dart';
 import 'package:slimsocial_for_facebook/consts.dart';
 import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
 import 'package:slimsocial_for_facebook/main.dart';
+import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:url_launcher/url_launcher.dart';
+
 
 class SettingsPage extends ConsumerStatefulWidget {
   SettingsPage({this.productId, super.key});
@@ -93,6 +95,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: sp.getBool("enable_messenger") ?? true,
                 leading: const Icon(Icons.messenger),
                 title: Text('enable_messenger'.tr()),
+                activeSwitchColor: FacebookColors.blue,
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -104,6 +107,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: sp.getBool("hide_ads") ?? true,
                 leading: const Icon(Icons.hide_source),
                 title: Text('hide_ads'.tr()),
+                activeSwitchColor: FacebookColors.blue,
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -117,6 +121,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: sp.getBool("recent_first"),
                 leading: const Icon(Icons.rss_feed),
                 title: Text('recent_first'.tr()),
+                activeSwitchColor: FacebookColors.blue,
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -132,6 +137,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.abc),
                 title: Text('use_mbasic'.tr()),
                 description: Text('use_mbasic_desc'.tr()),
+                activeSwitchColor: FacebookColors.blue,
               ),
             ],
           ),
@@ -158,6 +164,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: sp.getBool("gps_permission") ?? false,
                 leading: const Icon(Icons.gps_fixed),
                 title: Text('gps_permission'.tr()),
+                activeSwitchColor: FacebookColors.blue,
               ),
               SettingsTile.switchTile(
                 onToggle: (value) async {
@@ -178,6 +185,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: sp.getBool("camera_permission") ?? false,
                 leading: const Icon(Icons.camera_alt),
                 title: Text('camera_permission'.tr()),
+                activeSwitchColor: FacebookColors.blue,
               ),
               SettingsTile.switchTile(
                 onToggle: (value) async {
@@ -198,6 +206,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: sp.getBool("photo_permission") ?? false,
                 leading: const Icon(Icons.photo_camera_back_outlined),
                 title: Text('photo_permission'.tr()),
+                activeSwitchColor: FacebookColors.blue,
               ),
             ],
           ),
@@ -218,6 +227,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: CustomCss.darkThemeCss.isEnabled(),
                 title: Text(CustomCss.darkThemeCss.key.tr()),
                 leading: const Icon(Icons.format_paint),
+                activeSwitchColor: FacebookColors.blue,
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -229,6 +239,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: CustomCss.fixedBarCss.isEnabled(),
                 leading: const Icon(Icons.vertical_align_top),
                 title: Text(CustomCss.fixedBarCss.key.tr()),
+                activeSwitchColor: FacebookColors.blue,
+
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -240,6 +252,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: CustomCss.hideStoriesCss.isEnabled(),
                 title: Text(CustomCss.hideStoriesCss.key.tr()),
                 leading: const Icon(Icons.hide_image),
+                activeSwitchColor: FacebookColors.blue,
+
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -251,6 +265,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: CustomCss.centerTextPostsCss.isEnabled(),
                 title: Text(CustomCss.centerTextPostsCss.key.tr()),
                 leading: const Icon(Icons.format_align_center),
+                activeSwitchColor: FacebookColors.blue,
+
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -262,6 +278,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 initialValue: CustomCss.addSpaceBetweenPostsCss.isEnabled(),
                 title: Text(CustomCss.addSpaceBetweenPostsCss.key.tr()),
                 leading: const Icon(Icons.format_line_spacing),
+                activeSwitchColor: FacebookColors.blue,
+
               ),
             ],
           ),

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -292,7 +292,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 ),
                 onPressed: (context) async {
                   await showTextInputDialog(
-                    spKey: "custom_useragent",
+                    spKey: spKeyCustomUserAgent,
                     hint: _prefController.userAgent,
                   );
                   setState(() {});
@@ -307,7 +307,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 ),
                 onPressed: (context) async {
                   await showTextInputDialog(
-                    spKey: "custom_js",
+                    spKey: spKeyCustomJs,
                     hint: CustomJs.exampleJs,
                   );
                   setState(() {});
@@ -322,7 +322,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 ),
                 onPressed: (context) async {
                   await showTextInputDialog(
-                    spKey: "custom_css",
+                    spKey: spKeyCustomCss,
                     hint: '._5rgt._5msi { text-align: center;}',
                   );
                   setState(() {});
@@ -346,7 +346,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   child: const Icon(Icons.check_circle),
                 ),
                 onPressed: (context) async {
-                  const spKey = "custom_proxy";
+                  const spKey = spKeyCustomProxy;
                   const spKeyEnabled = "${spKey}_enabled";
                   const spKeyIp = "${spKey}_ip";
                   const spKeyPort = "${spKey}_port";
@@ -691,7 +691,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   }
 
   Future showProxyDialog() async {
-    const spKey = "custom_proxy";
+    const spKey = spKeyCustomProxy;
     const spKeyEnabled = "${spKey}_enabled";
     const spKeyIp = "${spKey}_ip";
     const spKeyPort = "${spKey}_port";

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -19,6 +19,7 @@ import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+
 class SettingsPage extends ConsumerStatefulWidget {
   SettingsPage({this.productId, super.key});
   //this is used to make a shortcut for donations
@@ -243,6 +244,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.vertical_align_top),
                 title: Text(CustomCss.fixedBarCss.key.tr()),
                 activeSwitchColor: FacebookColors.blue,
+
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -255,6 +257,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.hideStoriesCss.key.tr()),
                 leading: const Icon(Icons.hide_image),
                 activeSwitchColor: FacebookColors.blue,
+
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -267,6 +270,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.centerTextPostsCss.key.tr()),
                 leading: const Icon(Icons.format_align_center),
                 activeSwitchColor: FacebookColors.blue,
+
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
@@ -279,6 +283,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.addSpaceBetweenPostsCss.key.tr()),
                 leading: const Icon(Icons.format_line_spacing),
                 activeSwitchColor: FacebookColors.blue,
+
               ),
             ],
           ),

--- a/SlimSocial_for_Facebook/lib/style/color_schemes.g.dart
+++ b/SlimSocial_for_Facebook/lib/style/color_schemes.g.dart
@@ -53,6 +53,7 @@ final lightColorScheme = ColorScheme(
   surfaceTint: FacebookColors.blue,
   outlineVariant: FacebookColors.darkGrey,
   scrim: FacebookColors.black,
+
 );
 
 final darkColorScheme = ColorScheme(

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -1,4 +1,4 @@
-import '../main.dart';
+import 'package:slimsocial_for_facebook/main.dart';
 
 class CustomCss {
   static List<MyCss> cssList = [
@@ -42,7 +42,7 @@ class CustomCss {
     description: 'Fixed bar',
     defaultEnabled: true,
     code:
-        '#header { position: fixed; z-index: 6; top: 0px; } #root { padding-top: 84px; } .flyout { max-height: \$spx; overflow-y: scroll; } .item.more { position: fixed; bottom: 0px; text-align: center !important; }',
+        r'#header { position: fixed; z-index: 6; top: 0px; } #root { padding-top: 84px; } .flyout { max-height: $spx; overflow-y: scroll; } .item.more { position: fixed; bottom: 0px; text-align: center !important; }',
   );
 
   static MyCss removeMessengerDownloadCss = MyCss(
@@ -172,10 +172,11 @@ a.x1i10hfl.x1qjc9v5.xjqpnuy.xa49m3k.xqeqjp1.x2hbi6w.x13fuv20.xu3j5b3.x1q0q8m5.x2
   );
 
   static MyCss darkThemeCss0 = MyCss(
-      key: 'dark_theme',
-      description: 'dark theme',
-      code:
-          "body, #root, .storyStream, ._2v9s, ._4nmh, ._4u3j, ._35aq, ._146a, ._4g34, ._5pxb, ._55wq, ._7om2, ._53_-, ._3iyw, ._6j_d, ._8ytl, ._4_d0, ._6beq, ._vi6, ._55ws, ._u42, ._13fn, .jx-result, .jx-typeahead-results, ._56bt, ._52x7, ._vqv, ._4g33, ._5rgt, .popover_flyout, .flyout, #m_newsfeed_stream, ._55wo, ._3iln, .mentions-suggest, #header, ._xy, ._bgx, .acb, .acg, .aclb, .touch._4g34, ._59e9, .nontouch._5ui0, input[type=text], .acw, ._5up8, ._5kgn, .tlLinkContainer, .aps, .jewel.flyout.header, .appCenterCategorySelectorButton, .tlBody, #timelineBody, .timelineX, .timeline.feed, .timeline.tlPrelude, .timeline.tlFeedPlaceholder, .touch._5c9u, .touch._5ca9, .innerLink, ._5dy4, ._52x3, #m_group_stories_container, .albums, .subpage, ._uwu, ._uww, .scrollAreaBody, .al, .apl, .structuredPublisher, .groupChromeView, ._djv, ._bjg, ._5kgn, ._3f50, ._55wm, ._58f0, ._55wr, ._22wy, ._1gkq, ._484w, ._1ih_, ._1p70, ._4e8n, ._15n_, ._1of-, ._5b6o, ._2rgt, ._u2c, ._5as1, ._3tl8, ._333v, ._5-lw, ._13e_, ._2rea._24e1._412_._bpa._vyy._5t8z, .touch._uoq, ._1t4h, .touch._45fu._18qg._1_ac, ._10c_._2jl2, ._4s0c, ._1h_j, .touch._3e18, .touch._533c{ background:#000!important; /*thebackground*/ } ._65wzO{ background:none!important; } ._51-g, ._2b06, ._5-lx, ._14v5._14v5._14v8{ background:#383a3e!important; } h3._391s{ color:#383a3e!important; } ._50cg._2ss{ background:#000!important; } .composerLinkText, .fcg, ._5c4t._1g06{ color:#d2d2d2!important; } /*whitetext*/ body, .touch._2ya3, .composerTextSelected, .composerInput, .mentions-input, input[type=text], ._5001, .timeline.cover.profileName, .appListTitle, ._52jd, ._52jb, ._52jg, ._5qc3, .tlActorText, .tlLinkTitle, ._5379, ._5cqn, ._592p, ._3c9l, ._4yrh, .name, .btn, .upText, .tlLinkTitleOnly, ._5rgt, ._52x2, ._52jh, ._52ja, ._56bz, ._2tbu, ._1mwn, ._55sr, ._5t6r, ._1_oe, ._52lz, ._2l5v, .inputtext, .inputpassword, .touch, .touchtr, .touchinput, .touchtextarea, .touch.mfsm, ._2b06span, ._59k{ color:#d2d2d2!important; } ._5s61._2pis { background-color:#dfeff0!important; border-radius:10px!important; } .touch._2ya3{ border-radius:5px; padding:5px; } /*bluelinktext*/ a, .actor, .mfsl, .fcw, .title, .blueName, ._5aw4, ._vqv, ._5yll, ._5qc3, ._52lz, ._4nwe, ._27vp, ._ir4, ._5wsv, ._46pa,header{ color:#DFEFF0!important; } /*darkimportant*/ .acy, .nontouch._55mb.actor-link, .nontoucha.btnD, .inlineMedia.storyAttachment{ background:#304702!important; } .statusBox, ._5whq, ._56bt, .composerInput, .mentions-input, ._1svy, ._bji{ background:#323232!important; } .ufiBorder, ._5as0, ._5ef_, ._35aq{ border-color:#555!important; } ._59te{ border-color:black!important; } /*buttons*/ .button>a.touchable, .btn, .touch._5c9u, ._2l5v, ._52x1, ._tn0, ._52ja{ background:#323232!important; } /*contextmenu*/ ._5c0e, ._5bn_{ background:#4e4e4e!important; } article, ._4o50, .acw, ._53_-, ._3wjp, ._usq, ._55wq, ._400s{ border:1pxdotted#383838!important; border-radius:4px; } ._1_oa, ._bmx, ._52x1{ border-bottom:1pxdotted#383838!important; } articleh3{ color:#999!important; } /*noborder*/ .aclb, ._53_-, ._52x6, ._52x1, ._2l5v, ._tn0, ._52ja, ._5lm6{ border-top:0px; border-bottom:0px; } ._59te.popoverOpen, ._59te.isActivem, ._59te{ background:#000; /*topbar*/ border-bottom:1pxsolid#444; border-right:1pxsolid#444; } /*#feed_jewel._59tf{ background-position:-22px-103px; } #requests_jewel._59tf{ background-position:-122px-148px; } #messages_jewel._59tf{ background-position:-268px-103px; } #notifications_jewel._2jdm._59tf{ background-position:-350px-103px; } #notifications_jewel._59tf{ background-position:0-149px; } #search_jewel._59tf{ background-position:-186px-103px; } #bookmarks_jewel._59tf{ background-position:-104px-103px; }*/ ._2lut{ border:1pxdotted#e9eaed!important; }");
+    key: 'dark_theme',
+    description: 'dark theme',
+    code:
+        "body, #root, .storyStream, ._2v9s, ._4nmh, ._4u3j, ._35aq, ._146a, ._4g34, ._5pxb, ._55wq, ._7om2, ._53_-, ._3iyw, ._6j_d, ._8ytl, ._4_d0, ._6beq, ._vi6, ._55ws, ._u42, ._13fn, .jx-result, .jx-typeahead-results, ._56bt, ._52x7, ._vqv, ._4g33, ._5rgt, .popover_flyout, .flyout, #m_newsfeed_stream, ._55wo, ._3iln, .mentions-suggest, #header, ._xy, ._bgx, .acb, .acg, .aclb, .touch._4g34, ._59e9, .nontouch._5ui0, input[type=text], .acw, ._5up8, ._5kgn, .tlLinkContainer, .aps, .jewel.flyout.header, .appCenterCategorySelectorButton, .tlBody, #timelineBody, .timelineX, .timeline.feed, .timeline.tlPrelude, .timeline.tlFeedPlaceholder, .touch._5c9u, .touch._5ca9, .innerLink, ._5dy4, ._52x3, #m_group_stories_container, .albums, .subpage, ._uwu, ._uww, .scrollAreaBody, .al, .apl, .structuredPublisher, .groupChromeView, ._djv, ._bjg, ._5kgn, ._3f50, ._55wm, ._58f0, ._55wr, ._22wy, ._1gkq, ._484w, ._1ih_, ._1p70, ._4e8n, ._15n_, ._1of-, ._5b6o, ._2rgt, ._u2c, ._5as1, ._3tl8, ._333v, ._5-lw, ._13e_, ._2rea._24e1._412_._bpa._vyy._5t8z, .touch._uoq, ._1t4h, .touch._45fu._18qg._1_ac, ._10c_._2jl2, ._4s0c, ._1h_j, .touch._3e18, .touch._533c{ background:#000!important; /*thebackground*/ } ._65wzO{ background:none!important; } ._51-g, ._2b06, ._5-lx, ._14v5._14v5._14v8{ background:#383a3e!important; } h3._391s{ color:#383a3e!important; } ._50cg._2ss{ background:#000!important; } .composerLinkText, .fcg, ._5c4t._1g06{ color:#d2d2d2!important; } /*whitetext*/ body, .touch._2ya3, .composerTextSelected, .composerInput, .mentions-input, input[type=text], ._5001, .timeline.cover.profileName, .appListTitle, ._52jd, ._52jb, ._52jg, ._5qc3, .tlActorText, .tlLinkTitle, ._5379, ._5cqn, ._592p, ._3c9l, ._4yrh, .name, .btn, .upText, .tlLinkTitleOnly, ._5rgt, ._52x2, ._52jh, ._52ja, ._56bz, ._2tbu, ._1mwn, ._55sr, ._5t6r, ._1_oe, ._52lz, ._2l5v, .inputtext, .inputpassword, .touch, .touchtr, .touchinput, .touchtextarea, .touch.mfsm, ._2b06span, ._59k{ color:#d2d2d2!important; } ._5s61._2pis { background-color:#dfeff0!important; border-radius:10px!important; } .touch._2ya3{ border-radius:5px; padding:5px; } /*bluelinktext*/ a, .actor, .mfsl, .fcw, .title, .blueName, ._5aw4, ._vqv, ._5yll, ._5qc3, ._52lz, ._4nwe, ._27vp, ._ir4, ._5wsv, ._46pa,header{ color:#DFEFF0!important; } /*darkimportant*/ .acy, .nontouch._55mb.actor-link, .nontoucha.btnD, .inlineMedia.storyAttachment{ background:#304702!important; } .statusBox, ._5whq, ._56bt, .composerInput, .mentions-input, ._1svy, ._bji{ background:#323232!important; } .ufiBorder, ._5as0, ._5ef_, ._35aq{ border-color:#555!important; } ._59te{ border-color:black!important; } /*buttons*/ .button>a.touchable, .btn, .touch._5c9u, ._2l5v, ._52x1, ._tn0, ._52ja{ background:#323232!important; } /*contextmenu*/ ._5c0e, ._5bn_{ background:#4e4e4e!important; } article, ._4o50, .acw, ._53_-, ._3wjp, ._usq, ._55wq, ._400s{ border:1pxdotted#383838!important; border-radius:4px; } ._1_oa, ._bmx, ._52x1{ border-bottom:1pxdotted#383838!important; } articleh3{ color:#999!important; } /*noborder*/ .aclb, ._53_-, ._52x6, ._52x1, ._2l5v, ._tn0, ._52ja, ._5lm6{ border-top:0px; border-bottom:0px; } ._59te.popoverOpen, ._59te.isActivem, ._59te{ background:#000; /*topbar*/ border-bottom:1pxsolid#444; border-right:1pxsolid#444; } /*#feed_jewel._59tf{ background-position:-22px-103px; } #requests_jewel._59tf{ background-position:-122px-148px; } #messages_jewel._59tf{ background-position:-268px-103px; } #notifications_jewel._2jdm._59tf{ background-position:-350px-103px; } #notifications_jewel._59tf{ background-position:0-149px; } #search_jewel._59tf{ background-position:-186px-103px; } #bookmarks_jewel._59tf{ background-position:-104px-103px; }*/ ._2lut{ border:1pxdotted#e9eaed!important; }",
+  );
 
   static MyCss darkThemeMessengerCss = MyCss(
     key: 'dark_theme_messenger',
@@ -215,10 +216,9 @@ a.x1i10hfl.x1qjc9v5.xjqpnuy.xa49m3k.xqeqjp1.x2hbi6w.x13fuv20.xu3j5b3.x1q0q8m5.x2
   );
 
   static MyCss darkThemeCss = MyCss(
-      key: 'dark_theme',
-      description: 'dark theme messenger',
-      defaultEnabled: false,
-      code: """
+    key: 'dark_theme',
+    description: 'dark theme messenger',
+    code: """
 /* ===========================
 Credits: Bean Verified Bean Terified
 https://userstyles.org/styles/160729/violet-nebula
@@ -497,8 +497,8 @@ a:hover {
 ._53ij {
     background-color: rgba(0, 0, 0, 0.8) !important;
 }
-""" +
-          """
+"""
+        """
 /*badge*/
 span._59tg {
     background-color: #3141ac !important;
@@ -507,33 +507,32 @@ span._59tg {
 #header { 
 background-color: #080618 !important; 
 }
-""");
+""",
+  );
 }
 
 class MyCss {
-  String key;
-  String description;
-  String code;
-  bool defaultEnabled;
-
   MyCss({
     required this.key,
     required this.description,
     required this.code,
     this.defaultEnabled = false,
   }) {
-    this.code = this
-        .code
+    code = code
         .replaceAll(RegExp(r'\s+'), '')
-        .replaceAll("'", "\\'")
+        .replaceAll("'", r"\'")
         .replaceAll("\n", " ");
   }
+  String key;
+  String description;
+  String code;
+  bool defaultEnabled;
 
   bool isEnabled() {
     return sp.getBool(key) ?? defaultEnabled;
   }
 
-  void setEnabled(bool enabled) async {
-    sp.setBool(key, enabled);
+  Future<void> setEnabled(bool enabled) async {
+    await sp.setBool(key, enabled);
   }
 }

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -7,6 +7,7 @@ class CustomJs {
         var node = document.createElement('style');
         node.innerHTML = css;
         document.body.appendChild(node);
+        document.body.style.zoom = "0.97";
       }) ('${css}');
     ''';
     return str;

--- a/SlimSocial_for_Facebook/pubspec.lock
+++ b/SlimSocial_for_Facebook/pubspec.lock
@@ -94,6 +94,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.2"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.9.2"
   characters:
     dependency: transitive
     description:
@@ -134,6 +198,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.1"
   collection:
     dependency: transitive
     description:
@@ -346,6 +418,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.4"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   glob:
     dependency: transitive
     description:
@@ -362,6 +442,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.2.1"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   gtk:
     dependency: transitive
     description:
@@ -378,6 +466,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  http_multi_server:
+    dependency: transitive
+    description:
+      name: http_multi_server
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
@@ -450,6 +546,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
@@ -482,6 +594,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   macros:
     dependency: transitive
     description:
@@ -690,6 +810,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pool:
+    dependency: transitive
+    description:
+      name: pool
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.1"
   pub_semver:
     dependency: transitive
     description:
@@ -722,6 +850,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.1"
+  riverpod_analyzer_utils:
+    dependency: transitive
+    description:
+      name: riverpod_analyzer_utils
+      sha256: "0dcb0af32d561f8fa000c6a6d95633c9fb08ea8a8df46e3f9daca59f11218167"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.6"
+  riverpod_annotation:
+    dependency: "direct main"
+    description:
+      name: riverpod_annotation
+      sha256: e5e796c0eba4030c704e9dae1b834a6541814963292839dcf9638d53eba84f5c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.5"
+  riverpod_generator:
+    dependency: "direct dev"
+    description:
+      name: riverpod_generator
+      sha256: "63311e361ffc578d655dfc31b48dfa4ed3bc76fd06f9be845e9bf97c5c11a429"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
   rxdart:
     dependency: transitive
     description:
@@ -810,11 +962,35 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shelf:
+    dependency: transitive
+    description:
+      name: shelf
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
+  shelf_web_socket:
+    dependency: transitive
+    description:
+      name: shelf_web_socket
+      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   source_span:
     dependency: transitive
     description:
@@ -855,6 +1031,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
@@ -879,6 +1063,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.2"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -999,6 +1191,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   webview_flutter:
     dependency: "direct main"
     description:
@@ -1008,7 +1216,7 @@ packages:
     source: hosted
     version: "4.9.0"
   webview_flutter_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter_android
       sha256: "6e64fcb1c19d92024da8f33503aaeeda35825d77142c01d0ea2aa32edc79fdc8"

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
   flutter_jailbreak_detection: 1.10.0
   webview_flutter: 4.9.0
+  webview_flutter_android:
   flutter_custom_tabs: 1.0.4
   url_launcher: 6.1.10
   permission_handler: 11.3.1
@@ -31,11 +32,14 @@ dependencies:
   flutter_file_downloader: 2.0.0
   open_file_plus: 3.4.1
   native_flutter_proxy: 0.1.15
+  riverpod_annotation: ^2.3.5
 
 dev_dependencies:
   flutter_launcher_icons: 0.13.1
   custom_lint: 0.6.5
   very_good_analysis: 6.0.0
+  build_runner: ^2.0.0
+  riverpod_generator: ^2.0.0
 
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This pull request refactors the PrefController class by replacing it with a Riverpod provider generated using the Riverpod code generator in Flutter.

**Changes made:**

- Removed the PrefController class, which previously handled preference state management.
- Created a new Riverpod provider to manage preferences, leveraging the Riverpod code generator for cleaner and more maintainable code.
- Refactored dependent widgets to consume state using ref.watch() and ConsumerWidget.

**Benefits:**

- Improved state management following Riverpod's best practices.
- Enhanced scalability and maintainability of the codebase.
- Cleaner and more testable architecture through dependency injection.
