### PR TITLE
Fix ad blocking, custom CSS, gallery toggle and reel audio

### DIFF
--- a/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
+++ b/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,17 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- to allow to read photos -->
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- to take pictures from inside Facebook: without this the "Camera
+         permission" toggle in the settings can never be turned on -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- declaring CAMERA makes the Play Store treat a camera as required,
+         which would hide the app from devices that don't have one -->
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
     <!-- gps -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- to share pictures -->

--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -65,4 +65,6 @@
   "top": "Scroll to the top",
   "report_issue": "Report an issue",
   "hide_messenger_sidebar": "Hide Messenger sidebar",
+  "reset": "Reset",
+  "exit": "Exit app"
 }

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -67,5 +67,8 @@
   "permissions": "Permissions",
   "enable_messenger": "Enable Messenger",
   "report_issue": "Report an issue",
-  "source_code": "Source code"
+  "source_code": "Source code",
+  "top": "Scroll to the top",
+  "reset": "Reset",
+  "exit": "Exit app"
 }

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -19,8 +19,10 @@ const String suffixRecentFirst = "?sk=h_chr";
 const String suffixDefault = "?sk=h_nor";
 
 //user agent for the webview
+//keep this reasonably recent: Facebook serves a "browser not supported"
+//notice (and a degraded page) to user agents it considers outdated
 const String kFirefoxUserAgent =
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0";
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0";
 const String kIpadUserAgent =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36";
 const String kOperaMiniUserAgent =
@@ -36,3 +38,38 @@ const String kGithubProjectUrl =
     "https://github.com/rignaneseleo/SlimSocial-for-Facebook";
 const String kPlayStoreUrl =
     "https://play.google.com/store/apps/details?id=it.rignanese.leo.slimfacebook";
+
+/// Keys used to store settings in [SharedPreferences].
+///
+/// These literals live on the user's device: renaming a *value* here silently
+/// resets that setting for everyone who already has the app installed. Rename
+/// the constant if you must, never the string.
+///
+/// They are centralised because they used to be typed out by hand at every call
+/// site, and a single mismatch (`photo_permission` in the settings screen vs
+/// `photos_permission` in the webviews) left the gallery toggle permanently
+/// stuck in the off position.
+class SpKeys {
+  const SpKeys._();
+
+  static const String gpsPermission = "gps_permission";
+  static const String cameraPermission = "camera_permission";
+  static const String photosPermission = "photos_permission";
+
+  static const String enableMessenger = "enable_messenger";
+  static const String hideAds = "hide_ads";
+  static const String recentFirst = "recent_first";
+  static const String useMbasic = "use_mbasic";
+
+  static const String customUserAgent = "custom_useragent";
+  static const String customCss = "custom_css";
+  static const String customJs = "custom_js";
+  static const String customProxy = "custom_proxy";
+
+  /// Companion key holding whether the `custom_*` override above is active.
+  static String enabled(String key) => "${key}_enabled";
+
+  /// Companion keys for [customProxy].
+  static String get customProxyIp => "${customProxy}_ip";
+  static String get customProxyPort => "${customProxy}_port";
+}

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -7,9 +7,11 @@ class PrefController {
   static String getHomePage() {
     var initialURl = kTouchFacebookHomeUrl;
 
-    if (sp.getBool("use_mbasic") ?? false) initialURl = kFacebookHomeBasicUrl;
+    if (sp.getBool(SpKeys.useMbasic) ?? false) {
+      initialURl = kFacebookHomeBasicUrl;
+    }
 
-    if (sp.getBool("recent_first") ?? false) {
+    if (sp.getBool(SpKeys.recentFirst) ?? false) {
       return initialURl + suffixRecentFirst;
     }
 
@@ -17,44 +19,38 @@ class PrefController {
   }
 
   static String getUserAgent() {
-    const spKeyEnabled = "custom_useragent_enabled";
-    if (sp.getBool(spKeyEnabled) ?? false) {
-      final customUserAgent = sp.getString("custom_useragent");
-      if (customUserAgent?.isNotEmpty ?? false) {
-        debugPrint("Using custom user agent: $customUserAgent");
-        return customUserAgent!;
-      }
+    final customUserAgent = _getOverride(SpKeys.customUserAgent);
+    if (customUserAgent != null) {
+      debugPrint("Using custom user agent: $customUserAgent");
+      return customUserAgent;
     }
 
-    if (sp.getBool("use_mbasic") ?? false) return kOperaMiniUserAgent;
+    if (sp.getBool(SpKeys.useMbasic) ?? false) return kOperaMiniUserAgent;
 
     return kFirefoxUserAgent;
   }
 
   static String? getUserCustomCss() {
-    const spKeyEnabled = "custom_css_enabled";
-    if (sp.getBool(spKeyEnabled) ?? false) {
-      final customCss = sp.getString("custom_css");
-      if (customCss?.isNotEmpty ?? false) {
-        debugPrint("Using custom css: $customCss");
-        return customCss!;
-      }
-    }
-
-    return null;
+    final customCss = _getOverride(SpKeys.customCss);
+    if (customCss != null) debugPrint("Using custom css: $customCss");
+    return customCss;
   }
 
   static String? getUserCustomJs() {
-    const spKeyEnabled = "custom_js_enabled";
-    if (sp.getBool(spKeyEnabled) ?? false) {
-      final customJs = sp.getString("custom_js");
-      if (customJs?.isNotEmpty ?? false) {
-        debugPrint("Using custom js: $customJs");
-        return customJs!;
-      }
-    }
+    final customJs = _getOverride(SpKeys.customJs);
+    if (customJs != null) debugPrint("Using custom js: $customJs");
+    return customJs;
+  }
 
-    return null;
+  /// Returns the value stored under [spKey], but only when its companion
+  /// `<spKey>_enabled` switch is on and the value is not blank.
+  static String? _getOverride(String spKey) {
+    if (!(sp.getBool(SpKeys.enabled(spKey)) ?? false)) return null;
+
+    final value = sp.getString(spKey);
+    if (value == null || value.isEmpty) return null;
+
+    return value;
   }
 }
 

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -5,6 +5,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:open_file_plus/open_file_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -18,6 +19,7 @@ import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
+import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 
@@ -44,7 +46,9 @@ class _HomePageState extends ConsumerState<HomePage> {
 
   WebViewController _initWebViewController() {
     final homepage = PrefController.getHomePage();
-    final controller = (WebViewController())
+    final controller = WebViewController(
+      onPermissionRequest: handleWebViewPermissionRequest,
+    )
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setBackgroundColor(FacebookColors.darkBlue)
       ..setUserAgent(PrefController.getUserAgent())
@@ -74,6 +78,10 @@ class _HomePageState extends ConsumerState<HomePage> {
 
     if (Platform.isAndroid) {
       (controller.platform as AndroidWebViewController)
+        //videos and reels are muted until the page sees a "user gesture", and
+        //the gesture the webview recognises is not the one that starts the
+        //video: without this the first taps only toggle the sound off again
+        ..setMediaPlaybackRequiresUserGesture(false)
         ..setCustomWidgetCallbacks(
           onShowCustomWidget:
               (Widget widget, OnHideCustomWidgetCallback callback) {
@@ -92,7 +100,8 @@ class _HomePageState extends ConsumerState<HomePage> {
         )
         ..setOnShowFileSelector(
           (FileSelectorParams params) async {
-            final photosPermission = sp.getBool("photos_permission") ?? false;
+            final photosPermission =
+                sp.getBool(SpKeys.photosPermission) ?? false;
 
             if (photosPermission) {
               final result = await FilePicker.platform.pickFiles();
@@ -110,7 +119,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         )
         ..setGeolocationPermissionsPromptCallbacks(
           onShowPrompt: (request) async {
-            final gpsPermission = sp.getBool("gps_permission") ?? false;
+            final gpsPermission = sp.getBool(SpKeys.gpsPermission) ?? false;
 
             if (gpsPermission) {
               // request location permission
@@ -256,7 +265,7 @@ class _HomePageState extends ConsumerState<HomePage> {
               },
               icon: const Icon(Icons.ios_share_outlined),
             ),
-          if (sp.getBool("enable_messenger") ?? true)
+          if (sp.getBool(SpKeys.enableMessenger) ?? true)
             IconButton(
               onPressed: () async {
                 await Navigator.of(context).push(
@@ -296,6 +305,9 @@ class _HomePageState extends ConsumerState<HomePage> {
                   await _controller.clearCache();
                   await _controller.clearLocalStorage();
                   _controller = _initWebViewController();
+                  break;
+                case "exit":
+                  await SystemNavigator.pop();
                   break;
                 default:
                   debugPrint("Unknown menu item: $item");
@@ -352,6 +364,14 @@ class _HomePageState extends ConsumerState<HomePage> {
                   title: Text("reset".tr().capitalize()),
                 ),
               ),
+              PopupMenuItem<String>(
+                value: "exit",
+                child: ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.exit_to_app),
+                  title: Text("exit".tr().capitalize()),
+                ),
+              ),
             ],
           ),
         ],
@@ -388,10 +408,8 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   Future<void> injectCss() async {
-    var cssList = "";
-    for (final css in CustomCss.cssList) {
-      if (css.isEnabled()) cssList += css.code;
-    }
+    final cssList =
+        CustomCss.buildFacebookCss(PrefController.getUserCustomCss());
 
     //create the function that will be called later
     await _controller.runJavaScript(CustomJs.removeAdsFunc);
@@ -402,14 +420,14 @@ class _HomePageState extends ConsumerState<HomePage> {
                         ${CustomJs.injectCssFunc(CustomCss.removeMessengerDownloadCss.code)}
                         ${CustomJs.injectCssFunc(CustomCss.removeBrowserNotSupportedCss.code)}
                         ${CustomJs.injectCssFunc(cssList)}
-                         ${(sp.getBool('hide_ads') ?? true) ? "removeAds();" : ""}
+                         ${(sp.getBool(SpKeys.hideAds) ?? true) ? "removeAds();" : ""}
                     });"""
         .replaceAll("\n", " ");
     await _controller.runJavaScript(code);
   }
 
   Future<void> runJs() async {
-    if (sp.getBool('hide_ads') ?? true) {
+    if (sp.getBool(SpKeys.hideAds) ?? true) {
       //setup the observer to run on page updates
       await _controller.runJavaScript(CustomJs.removeAdsObserver);
     }

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -14,6 +14,7 @@ import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
+import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 
@@ -41,7 +42,9 @@ class _HomePageState extends ConsumerState<MessengerPage> {
       homepage = '$kMessengerUrl$homepage';
     }
 
-    final controller = (WebViewController())
+    final controller = WebViewController(
+      onPermissionRequest: handleWebViewPermissionRequest,
+    )
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setBackgroundColor(FacebookColors.darkBlue)
       ..setUserAgent(PrefController.getUserAgent())
@@ -67,9 +70,12 @@ class _HomePageState extends ConsumerState<MessengerPage> {
 
     if (Platform.isAndroid) {
       (controller.platform as AndroidWebViewController)
+        //let videos and voice clips play with sound on the first tap
+        ..setMediaPlaybackRequiresUserGesture(false)
         ..setOnShowFileSelector(
           (FileSelectorParams params) async {
-            final photosPermission = sp.getBool("photos_permission") ?? false;
+            final photosPermission =
+                sp.getBool(SpKeys.photosPermission) ?? false;
 
             if (photosPermission) {
               final result = await FilePicker.platform.pickFiles();
@@ -87,7 +93,7 @@ class _HomePageState extends ConsumerState<MessengerPage> {
         )
         ..setGeolocationPermissionsPromptCallbacks(
           onShowPrompt: (request) async {
-            final gpsPermission = sp.getBool("gps_permission") ?? false;
+            final gpsPermission = sp.getBool(SpKeys.gpsPermission) ?? false;
 
             if (gpsPermission) {
               // request location permission
@@ -236,14 +242,8 @@ class _HomePageState extends ConsumerState<MessengerPage> {
   }
 
   Future<void> injectCss() async {
-    var cssList = "";
-
-    if (CustomCss.darkThemeCss.isEnabled()) {
-      cssList += CustomCss.darkThemeMessengerCss.code;
-    }
-
-    final userCustomCss = PrefController.getUserCustomCss();
-    if (userCustomCss?.isNotEmpty ?? false) cssList += userCustomCss!;
+    final cssList =
+        CustomCss.buildMessengerCss(PrefController.getUserCustomCss());
 
     final code = """
                     document.addEventListener("DOMContentLoaded", function() {

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -32,9 +32,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   bool isDev = false;
 
   final Map<String, Permission> permissions = const {
-    "gps_permission": Permission.locationWhenInUse,
-    "camera_permission": Permission.camera,
-    "photos_permission": Permission.photos,
+    SpKeys.gpsPermission: Permission.locationWhenInUse,
+    SpKeys.cameraPermission: Permission.camera,
+    SpKeys.photosPermission: Permission.photos,
   };
 
   @override
@@ -87,48 +87,48 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               SettingsTile.switchTile(
                 onToggle: (value) {
                   setState(() {
-                    sp.setBool("enable_messenger", value);
+                    sp.setBool(SpKeys.enableMessenger, value);
                   });
                 },
-                initialValue: sp.getBool("enable_messenger") ?? true,
+                initialValue: sp.getBool(SpKeys.enableMessenger) ?? true,
                 leading: const Icon(Icons.messenger),
                 title: Text('enable_messenger'.tr()),
               ),
               SettingsTile.switchTile(
                 onToggle: (value) async {
                   setState(() {
-                    sp.setBool("hide_ads", value);
+                    sp.setBool(SpKeys.hideAds, value);
                   });
                   ref.invalidate(fbWebViewProvider);
                 },
-                initialValue: sp.getBool("hide_ads") ?? true,
+                initialValue: sp.getBool(SpKeys.hideAds) ?? true,
                 leading: const Icon(Icons.hide_source),
                 title: Text('hide_ads'.tr()),
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
                   setState(() {
-                    sp.setBool("recent_first", value);
+                    sp.setBool(SpKeys.recentFirst, value);
                   });
                   ref
                       .read(fbWebViewProvider.notifier)
                       .updateUrl(PrefController.getHomePage());
                 },
-                initialValue: sp.getBool("recent_first"),
+                initialValue: sp.getBool(SpKeys.recentFirst),
                 leading: const Icon(Icons.rss_feed),
                 title: Text('recent_first'.tr()),
               ),
               SettingsTile.switchTile(
                 onToggle: (value) {
                   setState(() {
-                    sp.setBool("use_mbasic", value);
+                    sp.setBool(SpKeys.useMbasic, value);
                   });
                   ref
                       .read(fbWebViewProvider.notifier)
                       .updateUrl(PrefController.getHomePage());
                   Restart.restartApp();
                 },
-                initialValue: sp.getBool("use_mbasic") ?? false,
+                initialValue: sp.getBool(SpKeys.useMbasic) ?? false,
                 leading: const Icon(Icons.abc),
                 title: Text('use_mbasic'.tr()),
                 description: Text('use_mbasic_desc'.tr()),
@@ -146,7 +146,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   await handlePermission(value, permission);
 
                   setState(() {
-                    sp.setBool("gps_permission", value);
+                    sp.setBool(SpKeys.gpsPermission, value);
                   });
                   if (value == false) {
                     //restart so the weview is blocked
@@ -155,7 +155,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   }
                 },
                 //fixme bug on sp, I shoudl use the permission handler .isgranted
-                initialValue: sp.getBool("gps_permission") ?? false,
+                initialValue: sp.getBool(SpKeys.gpsPermission) ?? false,
                 leading: const Icon(Icons.gps_fixed),
                 title: Text('gps_permission'.tr()),
               ),
@@ -169,13 +169,13 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
 
                   if (oldVal != value) {
                     setState(() {
-                      sp.setBool("camera_permission", value);
+                      sp.setBool(SpKeys.cameraPermission, value);
                     });
                     ref.invalidate(fbWebViewProvider);
                   }
                 },
                 //fixme bug on sp, I shoudl use the permission handler .isgranted
-                initialValue: sp.getBool("camera_permission") ?? false,
+                initialValue: sp.getBool(SpKeys.cameraPermission) ?? false,
                 leading: const Icon(Icons.camera_alt),
                 title: Text('camera_permission'.tr()),
               ),
@@ -189,13 +189,13 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
 
                   if (oldVal != value) {
                     setState(() {
-                      sp.setBool("photo_permission", value);
+                      sp.setBool(SpKeys.photosPermission, value);
                     });
                     ref.invalidate(fbWebViewProvider);
                   }
                 },
                 //fixme bug on sp, I shoudl use the permission handler .isgranted
-                initialValue: sp.getBool("photo_permission") ?? false,
+                initialValue: sp.getBool(SpKeys.photosPermission) ?? false,
                 leading: const Icon(Icons.photo_camera_back_outlined),
                 title: Text('photo_permission'.tr()),
               ),
@@ -272,12 +272,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.person),
                 title: Text('custom_useragent'.tr()),
                 trailing: Visibility(
-                  visible: sp.getBool("custom_useragent_enabled") ?? false,
+                  visible: sp.getBool(SpKeys.enabled(SpKeys.customUserAgent)) ?? false,
                   child: const Icon(Icons.check_circle),
                 ),
                 onPressed: (context) async {
                   await showTextInputDialog(
-                    spKey: "custom_useragent",
+                    spKey: SpKeys.customUserAgent,
                     hint: PrefController.getUserAgent(),
                   );
                   setState(() {});
@@ -287,12 +287,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.css),
                 title: Text('custom_js'.tr()),
                 trailing: Visibility(
-                  visible: sp.getBool("custom_js_enabled") ?? false,
+                  visible: sp.getBool(SpKeys.enabled(SpKeys.customJs)) ?? false,
                   child: const Icon(Icons.check_circle),
                 ),
                 onPressed: (context) async {
                   await showTextInputDialog(
-                    spKey: "custom_js",
+                    spKey: SpKeys.customJs,
                     hint: CustomJs.exampleJs,
                   );
                   setState(() {});
@@ -302,12 +302,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.javascript_sharp),
                 title: Text('custom_css'.tr()),
                 trailing: Visibility(
-                  visible: sp.getBool("custom_css_enabled") ?? false,
+                  visible: sp.getBool(SpKeys.enabled(SpKeys.customCss)) ?? false,
                   child: const Icon(Icons.check_circle),
                 ),
                 onPressed: (context) async {
                   await showTextInputDialog(
-                    spKey: "custom_css",
+                    spKey: SpKeys.customCss,
                     hint: '._5rgt._5msi { text-align: center;}',
                   );
                   setState(() {});
@@ -315,9 +315,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               ),
               if (isDev)
                 SettingsTile.navigation(
-                  enabled: !sp.getString("custom_css").isNullOrEmpty() ||
-                      !sp.getString("custom_js").isNullOrEmpty() ||
-                      !sp.getString("custom_useragent").isNullOrEmpty(),
+                  enabled: !sp.getString(SpKeys.customCss).isNullOrEmpty() ||
+                      !sp.getString(SpKeys.customJs).isNullOrEmpty() ||
+                      !sp.getString(SpKeys.customUserAgent).isNullOrEmpty(),
                   leading: const Icon(Icons.send_time_extension),
                   title: Text('send_to_dev'.tr()),
                   description: Text('send_to_dev_desc'.tr()),
@@ -327,14 +327,14 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 leading: const Icon(Icons.private_connectivity_outlined),
                 title: Text('custom_proxy'.tr()),
                 trailing: Visibility(
-                  visible: sp.getBool("custom_proxy_enabled") ?? false,
+                  visible: sp.getBool(SpKeys.enabled(SpKeys.customProxy)) ?? false,
                   child: const Icon(Icons.check_circle),
                 ),
                 onPressed: (context) async {
-                  const spKey = "custom_proxy";
-                  const spKeyEnabled = "${spKey}_enabled";
-                  const spKeyIp = "${spKey}_ip";
-                  const spKeyPort = "${spKey}_port";
+                  const spKey = SpKeys.customProxy;
+                  final spKeyEnabled = SpKeys.enabled(spKey);
+                  final spKeyIp = SpKeys.customProxyIp;
+                  final spKeyPort = SpKeys.customProxyPort;
 
                   final ip = sp.getString(spKeyIp);
                   final port = sp.getString(spKeyPort);
@@ -523,7 +523,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     required String spKey,
     String? hint,
   }) async {
-    final spKeyEnabled = "${spKey}_enabled";
+    final spKeyEnabled = SpKeys.enabled(spKey);
 
     final _textEditingController = TextEditingController();
     _textEditingController.text = sp.getString(spKey) ?? "";
@@ -647,16 +647,16 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 myCss = myJs = myUserAgent = "";
 
                 if (sendCss) {
-                  myCss = Uri.encodeFull(sp.getString("custom_css") ?? "");
+                  myCss = Uri.encodeFull(sp.getString(SpKeys.customCss) ?? "");
                 }
 
                 if (sendJs) {
-                  myJs = Uri.encodeFull(sp.getString("custom_js") ?? "");
+                  myJs = Uri.encodeFull(sp.getString(SpKeys.customJs) ?? "");
                 }
 
                 if (sendUserAgent) {
                   myUserAgent =
-                      Uri.encodeFull(sp.getString("custom_useragent") ?? "");
+                      Uri.encodeFull(sp.getString(SpKeys.customUserAgent) ?? "");
                 }
 
                 final link =
@@ -685,10 +685,10 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   }
 
   Future<void> showProxyDialog() async {
-    const spKey = "custom_proxy";
-    const spKeyEnabled = "${spKey}_enabled";
-    const spKeyIp = "${spKey}_ip";
-    const spKeyPort = "${spKey}_port";
+    const spKey = SpKeys.customProxy;
+    final spKeyEnabled = SpKeys.enabled(spKey);
+    final spKeyIp = SpKeys.customProxyIp;
+    final spKeyPort = SpKeys.customProxyPort;
 
     final _ipController = TextEditingController();
     _ipController.text = sp.getString(spKeyIp) ?? "";

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -11,6 +11,28 @@ class CustomCss {
     hideMessengerSidebar,
   ];
 
+  /// Assembles the stylesheet injected into the Facebook webview.
+  ///
+  /// [userCss] is the user's own stylesheet and goes last so it can override
+  /// the built-in rules. It used to be left out of this page altogether, which
+  /// made the "Use custom CSS style" setting look broken everywhere except
+  /// Messenger.
+  static String buildFacebookCss(String? userCss) {
+    return [
+      for (final css in cssList)
+        if (css.isEnabled()) css.code,
+      if (userCss != null && userCss.isNotEmpty) userCss,
+    ].join(' ');
+  }
+
+  /// Assembles the stylesheet injected into the Messenger webview.
+  static String buildMessengerCss(String? userCss) {
+    return [
+      if (darkThemeCss.isEnabled()) darkThemeMessengerCss.code,
+      if (userCss != null && userCss.isNotEmpty) userCss,
+    ].join(' ');
+  }
+
   static MyCss centerTextPostsCss = MyCss(
     key: 'center_text',
     code: '._5rgt._5msi { text-align: center;}',
@@ -518,10 +540,11 @@ class MyCss {
     required this.code,
     this.defaultEnabled = false,
   }) {
-    code = code
-        .replaceAll(RegExp(r'\s+'), '')
-        .replaceAll("'", r"\'")
-        .replaceAll("\n", " ");
+    //collapse the source formatting onto a single line, but keep one space:
+    //stripping whitespace entirely mangled every multi-token value, turning
+    //`border: 1px solid #333` into the unparseable `border:1pxsolid#333`.
+    //Quotes are not escaped here: CustomJs.injectCssFunc encodes the string.
+    code = code.replaceAll(RegExp(r'\s+'), ' ').trim();
   }
   String key;
   String description;

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -1,13 +1,18 @@
+import 'dart:convert';
+
 import 'package:easy_localization/easy_localization.dart';
 
 class CustomJs {
   static String injectCssFunc(String css) {
+    //jsonEncode gives us a valid JS string literal: it escapes quotes,
+    //backslashes and newlines, so user-provided CSS can't break out of the
+    //call and turn the whole injection into a syntax error
     final str = '''
       (function (css) {
         var node = document.createElement('style');
         node.innerHTML = css;
         document.body.appendChild(node);
-      }) ('$css');
+      }) (${jsonEncode(css)});
     ''';
     return str;
   }
@@ -92,12 +97,17 @@ javascript:function foo() {
 """;
 
   static String removeAdsObserver = """
-if (typeof newPostsObserver !== 'undefined') {
+// The observer is stored on `window` so it survives being re-injected on every
+// page load: without a global we cannot tell whether one is already running.
+// (The guard used to read `typeof newPostsObserver !== 'undefined'` against a
+// block-scoped `const` declared inside the branch, so it was always false and
+// the observer was never installed -- ads came back as soon as you scrolled.)
+if (typeof window.newPostsObserver === 'undefined') {
     // Select the node that will be observed for changes
     const bodyNode = document.body;
 
     // Create a new observer object
-    const newPostsObserver = new MutationObserver(function (mutations) {
+    window.newPostsObserver = new MutationObserver(function (mutations) {
         mutations.forEach(function (mutation) {
             // Filter out added nodes that are not <section> elements
             const addedSections = Array.from(mutation.addedNodes).filter(node => node.nodeName === 'SECTION');
@@ -113,7 +123,7 @@ if (typeof newPostsObserver !== 'undefined') {
     const config = { childList: true, subtree: true };
 
     // Start observing the target node for configured mutations
-    newPostsObserver.observe(bodyNode, config);
+    window.newPostsObserver.observe(bodyNode, config);
 }
   """;
 }

--- a/SlimSocial_for_Facebook/lib/utils/utils.dart
+++ b/SlimSocial_for_Facebook/lib/utils/utils.dart
@@ -44,6 +44,9 @@ void showToast(String text) => Fluttertoast.showToast(
 
 extension StringExtension on String {
   String capitalize() {
+    //a missing translation resolves to an empty string, and indexing it
+    //used to throw a RangeError while building the settings screen
+    if (isEmpty) return this;
     return "${this[0].toUpperCase()}${substring(1).toLowerCase()}";
   }
 }

--- a/SlimSocial_for_Facebook/lib/utils/webview_permissions.dart
+++ b/SlimSocial_for_Facebook/lib/utils/webview_permissions.dart
@@ -1,0 +1,42 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:slimsocial_for_facebook/consts.dart';
+import 'package:slimsocial_for_facebook/main.dart';
+import 'package:slimsocial_for_facebook/utils/utils.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// Whether SlimSocial knows how to answer a request for [types].
+///
+/// Only the camera is supported. The microphone (voice and video calls) would
+/// additionally need a `RECORD_AUDIO` manifest entry and a settings toggle of
+/// its own, so those requests are refused instead of being left unanswered.
+bool isWebViewPermissionSupported(Set<WebViewPermissionResourceType> types) {
+  return types.isNotEmpty &&
+      types.every((type) => type == WebViewPermissionResourceType.camera);
+}
+
+/// Answers a permission request coming from the web content.
+///
+/// Nothing used to listen for these requests, so the webview never received an
+/// answer and the camera toggle in the settings had no effect whatsoever:
+/// taking a photo from inside Facebook simply did nothing.
+Future<void> handleWebViewPermissionRequest(
+  WebViewPermissionRequest request,
+) async {
+  if (!isWebViewPermissionSupported(request.types)) {
+    return request.deny();
+  }
+
+  //the user has to opt in from the settings first
+  if (!(sp.getBool(SpKeys.cameraPermission) ?? false)) {
+    showToast("check_permission".tr());
+    return request.deny();
+  }
+
+  //...and Android still requires the OS-level grant on top of that
+  final status = await Permission.camera.request();
+  if (status.isGranted) return request.grant();
+
+  showToast("check_permission".tr());
+  return request.deny();
+}

--- a/SlimSocial_for_Facebook/test/consts_test.dart
+++ b/SlimSocial_for_Facebook/test/consts_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/consts.dart';
+
+void main() {
+  group('SpKeys', () {
+    // These literals are persisted on the user's device. Changing one silently
+    // resets that setting for everyone who already has the app installed, so
+    // they are pinned here on purpose.
+    test('keeps the keys already written to disk by released versions', () {
+      expect(SpKeys.gpsPermission, 'gps_permission');
+      expect(SpKeys.cameraPermission, 'camera_permission');
+      expect(SpKeys.photosPermission, 'photos_permission');
+      expect(SpKeys.enableMessenger, 'enable_messenger');
+      expect(SpKeys.hideAds, 'hide_ads');
+      expect(SpKeys.recentFirst, 'recent_first');
+      expect(SpKeys.useMbasic, 'use_mbasic');
+      expect(SpKeys.customUserAgent, 'custom_useragent');
+      expect(SpKeys.customCss, 'custom_css');
+      expect(SpKeys.customJs, 'custom_js');
+      expect(SpKeys.customProxy, 'custom_proxy');
+    });
+
+    test('derives the companion switch key', () {
+      expect(SpKeys.enabled(SpKeys.customCss), 'custom_css_enabled');
+      expect(SpKeys.enabled(SpKeys.customJs), 'custom_js_enabled');
+      expect(
+        SpKeys.enabled(SpKeys.customUserAgent),
+        'custom_useragent_enabled',
+      );
+      expect(SpKeys.enabled(SpKeys.customProxy), 'custom_proxy_enabled');
+    });
+
+    test('derives the proxy host and port keys', () {
+      expect(SpKeys.customProxyIp, 'custom_proxy_ip');
+      expect(SpKeys.customProxyPort, 'custom_proxy_port');
+    });
+
+    test('the gallery key is plural, matching what the webviews read', () {
+      // The settings screen wrote `photo_permission` while both webviews read
+      // `photos_permission`, so the toggle looked permanently switched off.
+      expect(SpKeys.photosPermission, isNot('photo_permission'));
+    });
+  });
+
+  group('kFirefoxUserAgent', () {
+    test('is recent enough that Facebook does not flag it as outdated', () {
+      final match =
+          RegExp(r'Firefox/(\d+)\.0$').firstMatch(kFirefoxUserAgent);
+
+      expect(match, isNotNull, reason: 'unexpected user agent shape');
+      expect(int.parse(match!.group(1)!), greaterThanOrEqualTo(140));
+    });
+
+    test('advertises the same version in rv: and Firefox/', () {
+      final rv = RegExp(r'rv:(\d+)\.0').firstMatch(kFirefoxUserAgent);
+      final firefox = RegExp(r'Firefox/(\d+)\.0').firstMatch(kFirefoxUserAgent);
+
+      expect(rv!.group(1), firefox!.group(1));
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
+++ b/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:slimsocial_for_facebook/consts.dart';
+import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
+import 'package:slimsocial_for_facebook/main.dart';
+
+Future<void> withPrefs(Map<String, Object> values) async {
+  SharedPreferences.setMockInitialValues(values);
+  sp = await SharedPreferences.getInstance();
+}
+
+void main() {
+  setUp(() => withPrefs({}));
+
+  group('getHomePage', () {
+    test('defaults to the touch site with the chronological suffix off', () {
+      expect(PrefController.getHomePage(), '$kTouchFacebookHomeUrl$suffixDefault');
+    });
+
+    test('switches to mbasic when asked', () async {
+      await withPrefs({SpKeys.useMbasic: true});
+
+      expect(
+        PrefController.getHomePage(),
+        '$kFacebookHomeBasicUrl$suffixDefault',
+      );
+    });
+
+    test('appends the recent-first suffix', () async {
+      await withPrefs({SpKeys.recentFirst: true});
+
+      expect(
+        PrefController.getHomePage(),
+        '$kTouchFacebookHomeUrl$suffixRecentFirst',
+      );
+    });
+  });
+
+  group('getUserAgent', () {
+    test('defaults to the bundled Firefox agent', () {
+      expect(PrefController.getUserAgent(), kFirefoxUserAgent);
+    });
+
+    test('uses the light agent together with mbasic', () async {
+      await withPrefs({SpKeys.useMbasic: true});
+
+      expect(PrefController.getUserAgent(), kOperaMiniUserAgent);
+    });
+
+    test('honours the custom agent once it is enabled', () async {
+      await withPrefs({
+        SpKeys.customUserAgent: 'my-agent',
+        SpKeys.enabled(SpKeys.customUserAgent): true,
+      });
+
+      expect(PrefController.getUserAgent(), 'my-agent');
+    });
+
+    test('ignores a custom agent that was saved but left disabled', () async {
+      await withPrefs({SpKeys.customUserAgent: 'my-agent'});
+
+      expect(PrefController.getUserAgent(), kFirefoxUserAgent);
+    });
+
+    test('ignores a blank custom agent', () async {
+      await withPrefs({
+        SpKeys.customUserAgent: '',
+        SpKeys.enabled(SpKeys.customUserAgent): true,
+      });
+
+      expect(PrefController.getUserAgent(), kFirefoxUserAgent);
+    });
+  });
+
+  group('getUserCustomCss', () {
+    test('returns null when unset', () {
+      expect(PrefController.getUserCustomCss(), isNull);
+    });
+
+    test('returns null while the switch is off', () async {
+      await withPrefs({SpKeys.customCss: '.a { color: red; }'});
+
+      expect(PrefController.getUserCustomCss(), isNull);
+    });
+
+    test('returns the stylesheet once enabled', () async {
+      await withPrefs({
+        SpKeys.customCss: '.a { color: red; }',
+        SpKeys.enabled(SpKeys.customCss): true,
+      });
+
+      expect(PrefController.getUserCustomCss(), '.a { color: red; }');
+    });
+  });
+
+  group('getUserCustomJs', () {
+    test('returns null while the switch is off', () async {
+      await withPrefs({SpKeys.customJs: 'foo();'});
+
+      expect(PrefController.getUserCustomJs(), isNull);
+    });
+
+    test('returns the snippet once enabled', () async {
+      await withPrefs({
+        SpKeys.customJs: 'foo();',
+        SpKeys.enabled(SpKeys.customJs): true,
+      });
+
+      expect(PrefController.getUserCustomJs(), 'foo();');
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/css_build_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_build_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:slimsocial_for_facebook/main.dart';
+import 'package:slimsocial_for_facebook/utils/css.dart';
+
+Future<void> withPrefs(Map<String, Object> values) async {
+  SharedPreferences.setMockInitialValues(values);
+  sp = await SharedPreferences.getInstance();
+}
+
+void main() {
+  setUp(() => withPrefs({}));
+
+  group('buildFacebookCss', () {
+    test('applies the user stylesheet', () {
+      // This is the regression that mattered: the Facebook page never looked at
+      // the user's CSS, so the setting only did anything inside Messenger.
+      expect(
+        CustomCss.buildFacebookCss('.mine { color: red; }'),
+        contains('.mine { color: red; }'),
+      );
+    });
+
+    test('puts the user stylesheet last so it wins the cascade', () async {
+      await withPrefs({CustomCss.centerTextPostsCss.key: true});
+
+      final css = CustomCss.buildFacebookCss('.mine { color: red; }');
+
+      expect(
+        css.indexOf('.mine'),
+        greaterThan(css.indexOf(CustomCss.centerTextPostsCss.code)),
+      );
+    });
+
+    test('includes the stylesheets the user switched on', () async {
+      await withPrefs({CustomCss.hideStoriesCss.key: true});
+
+      expect(
+        CustomCss.buildFacebookCss(null),
+        contains(CustomCss.hideStoriesCss.code),
+      );
+    });
+
+    test('leaves out the stylesheets that are off', () {
+      expect(
+        CustomCss.buildFacebookCss(null),
+        isNot(contains(CustomCss.hideStoriesCss.code)),
+      );
+    });
+
+    test('separates the stylesheets so rules do not merge', () async {
+      await withPrefs({
+        CustomCss.hideStoriesCss.key: true,
+        CustomCss.centerTextPostsCss.key: true,
+      });
+
+      final css = CustomCss.buildFacebookCss(null);
+
+      expect(css, isNot(contains('}.')));
+      expect(css, isNot(contains('};')));
+    });
+
+    test('handles a null and a blank user stylesheet', () {
+      expect(CustomCss.buildFacebookCss(null), isNotNull);
+      expect(CustomCss.buildFacebookCss(''), isNot(contains('  ')));
+    });
+  });
+
+  group('buildMessengerCss', () {
+    test('applies the user stylesheet', () {
+      expect(
+        CustomCss.buildMessengerCss('.mine { color: red; }'),
+        contains('.mine { color: red; }'),
+      );
+    });
+
+    test('adds the Messenger dark theme only when dark mode is on', () async {
+      expect(
+        CustomCss.buildMessengerCss(null),
+        isNot(contains(CustomCss.darkThemeMessengerCss.code)),
+      );
+
+      await withPrefs({CustomCss.darkThemeCss.key: true});
+
+      expect(
+        CustomCss.buildMessengerCss(null),
+        contains(CustomCss.darkThemeMessengerCss.code),
+      );
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/css_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:slimsocial_for_facebook/main.dart';
+import 'package:slimsocial_for_facebook/utils/css.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    sp = await SharedPreferences.getInstance();
+  });
+
+  group('MyCss normalisation', () {
+    test('collapses the source formatting onto a single line', () {
+      final css = MyCss(
+        key: 'k',
+        description: 'd',
+        code: '''
+article {
+    margin-top: 50px !important;
+}
+''',
+      );
+
+      expect(css.code, 'article { margin-top: 50px !important; }');
+    });
+
+    test('keeps a space between the tokens of a compound value', () {
+      // Stripping whitespace entirely produced `border:1pxsolid#333`, which
+      // the browser drops, taking the whole dark theme down with it.
+      final css = MyCss(
+        key: 'k',
+        description: 'd',
+        code: '.a { border: 1px solid #333 !important; }',
+      );
+
+      expect(css.code, contains('1px solid #333'));
+    });
+
+    test('keeps multi-part shorthand values intact', () {
+      final css = MyCss(
+        key: 'k',
+        description: 'd',
+        code: '.a { box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16); }',
+      );
+
+      expect(css.code, contains('0 3px 6px rgba(0, 0, 0, 0.16)'));
+    });
+
+    test('leaves quotes untouched so they can be encoded later', () {
+      final css = MyCss(
+        key: 'k',
+        description: 'd',
+        code: "[aria-label='Next'] { display: none; }",
+      );
+
+      expect(css.code, "[aria-label='Next'] { display: none; }");
+    });
+
+    test('every bundled stylesheet is collapsed to one line', () {
+      for (final css in CustomCss.cssList) {
+        expect(css.code, isNot(contains('\n')), reason: css.key);
+        expect(css.code, isNot(contains('  ')), reason: css.key);
+      }
+    });
+
+    test('the dark theme keeps the spaces inside its border values', () {
+      // `border: 1px solid #dddfe2` was being flattened to `1pxsolid#dddfe2`,
+      // so the browser threw the declaration away.
+      expect(CustomCss.darkThemeCss.code, contains('1px solid'));
+    });
+  });
+
+  group('MyCss.isEnabled', () {
+    test('falls back to defaultEnabled when nothing is stored', () {
+      expect(
+        MyCss(key: 'a', description: 'd', code: '', defaultEnabled: true)
+            .isEnabled(),
+        isTrue,
+      );
+      expect(
+        MyCss(key: 'b', description: 'd', code: '').isEnabled(),
+        isFalse,
+      );
+    });
+
+    test('reads back what setEnabled stored', () async {
+      final css = MyCss(key: 'c', description: 'd', code: '');
+
+      css.setEnabled(true);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(css.isEnabled(), isTrue);
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/js_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/js_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/js.dart';
+
+void main() {
+  group('CustomJs.injectCssFunc', () {
+    test('wraps the stylesheet in a valid JS string literal', () {
+      final js = CustomJs.injectCssFunc('.a { color: red; }');
+
+      expect(js, contains(jsonEncode('.a { color: red; }')));
+    });
+
+    test('escapes single quotes instead of terminating the argument', () {
+      // The CSS used to be interpolated into a single-quoted JS string, so an
+      // apostrophe in a user stylesheet broke the whole injection.
+      final js = CustomJs.injectCssFunc("[aria-label='Next'] { color: red; }");
+
+      expect(js, isNot(contains("('[aria-label='")));
+      expect(js, contains("[aria-label='Next']"));
+    });
+
+    test('escapes double quotes', () {
+      final js = CustomJs.injectCssFunc('[aria-label="Next"] { color: red; }');
+
+      expect(js, contains(r'[aria-label=\"Next\"]'));
+    });
+
+    test('encodes newlines so the caller can flatten the snippet', () {
+      // Both webviews run `.replaceAll("\n", " ")` over the generated code;
+      // a raw newline inside the string literal would be destroyed by that.
+      final js = CustomJs.injectCssFunc('.a {\n  color: red;\n}');
+      final argument = js.substring(js.indexOf('}) (') + 4);
+
+      expect(argument, contains(r'\n'));
+      expect(argument.contains('\n  color'), isFalse);
+    });
+  });
+
+  group('CustomJs.removeAdsObserver', () {
+    test('installs the observer when none is running yet', () {
+      // The guard used to be `typeof newPostsObserver !== 'undefined'` against
+      // a name that only existed inside the branch, so it was always false and
+      // the observer was never created: ads reappeared as soon as you scrolled.
+      expect(
+        CustomJs.removeAdsObserver,
+        contains("typeof window.newPostsObserver === 'undefined'"),
+      );
+    });
+
+    test('stores the observer globally so it is not re-created', () {
+      expect(
+        CustomJs.removeAdsObserver,
+        contains('window.newPostsObserver = new MutationObserver'),
+      );
+    });
+
+    test('observes using the global reference', () {
+      expect(
+        CustomJs.removeAdsObserver,
+        contains('window.newPostsObserver.observe(bodyNode, config)'),
+      );
+    });
+
+    test('never declares a block-scoped observer again', () {
+      expect(CustomJs.removeAdsObserver, isNot(contains('const newPosts')));
+      expect(CustomJs.removeAdsObserver, isNot(contains('let newPosts')));
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/utils_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/utils_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/utils.dart';
+
+void main() {
+  group('capitalize', () {
+    test('upper-cases the first letter and lower-cases the rest', () {
+      expect('settings'.capitalize(), 'Settings');
+      expect('SETTINGS'.capitalize(), 'Settings');
+    });
+
+    test('returns an empty string instead of throwing', () {
+      // A missing translation resolves to '', and indexing it used to throw a
+      // RangeError while the settings screen was being built.
+      expect(''.capitalize(), '');
+    });
+
+    test('handles a single character', () {
+      expect('a'.capitalize(), 'A');
+    });
+  });
+
+  group('isNullOrEmpty', () {
+    test('treats null, empty and blank as empty', () {
+      expect(null.isNullOrEmpty(), isTrue);
+      expect(''.isNullOrEmpty(), isTrue);
+      expect('   '.isNullOrEmpty(), isTrue);
+    });
+
+    test('treats real content as not empty', () {
+      expect('a'.isNullOrEmpty(), isFalse);
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/webview_permissions_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/webview_permissions_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+void main() {
+  group('isWebViewPermissionSupported', () {
+    test('accepts a camera-only request', () {
+      expect(
+        isWebViewPermissionSupported({WebViewPermissionResourceType.camera}),
+        isTrue,
+      );
+    });
+
+    test('refuses the microphone: no toggle and no RECORD_AUDIO', () {
+      expect(
+        isWebViewPermissionSupported(
+          {WebViewPermissionResourceType.microphone},
+        ),
+        isFalse,
+      );
+    });
+
+    test('refuses a request that bundles the microphone in', () {
+      expect(
+        isWebViewPermissionSupported({
+          WebViewPermissionResourceType.camera,
+          WebViewPermissionResourceType.microphone,
+        }),
+        isFalse,
+      );
+    });
+
+    test('refuses an empty request rather than granting it', () {
+      expect(isWebViewPermissionSupported({}), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Fixes five bugs that account for a large share of the open issue tracker, plus the smaller defects in the same code paths. All changes are in `SlimSocial_for_Facebook/`.

## Ads reappeared on scroll

Closes #286, closes #236, closes #181

The `MutationObserver` that re-runs `removeAds()` on newly loaded posts was guarded by `typeof newPostsObserver !== 'undefined'`. That condition is evaluated in the enclosing scope, where the name is never declared, so it was always false and the observer was never installed. Only the posts present at `DOMContentLoaded` were ever cleaned.

The observer is now held on `window`, which is what makes "is one already running?" answerable across page loads.

## Custom CSS was ignored on the Facebook page

Closes #177

`injectCss()` on the home page never read `PrefController.getUserCustomCss()`, so **Use custom CSS style** applied inside Messenger only. Both pages now go through `CustomCss.buildFacebookCss` / `buildMessengerCss`, which append the user stylesheet last so it wins the cascade.

This also unblocks the CSS half of the workaround in #293.

## The gallery permission toggle never reflected its state

Closes #241, closes #190

The settings screen stored `photo_permission`; both webviews read `photos_permission`.

All `SharedPreferences` keys now live in a single `SpKeys` class, so the two sides cannot drift apart again. The stored literals are unchanged — upgrading resets nothing — and a test pins each one.

## Dark theme declarations were discarded

Closes #196, closes #188, closes #216, closes #267

The `MyCss` constructor stripped every whitespace character, mangling each multi-token value:

```
border: 1px solid #333   ->   border:1pxsolid#333
box-shadow: 0 3px 6px …  ->   box-shadow:03px6px…
```

Browsers drop those declarations, which is why the dark theme rendered half-applied. Whitespace runs now collapse to a single space.

Quote escaping moved from the constructor into `CustomJs.injectCssFunc`, which `jsonEncode`s the stylesheet. An apostrophe in a user stylesheet can no longer terminate the injection call and take the whole `<style>` block with it.

## Reels and videos needed repeated taps for audio

Closes #293, closes #264, closes #246

`setMediaPlaybackRequiresUserGesture(false)` lets the first tap start playback with sound — the permanent fix requested in #293. Facebook continues to mute feed autoplay through its own scripts, so this affects deliberate taps, not scrolling.

## Also

- **Webview permission requests are now answered.** Closes #283, contributes to #198. Nothing listened for them, so camera requests from web content were left hanging and the camera toggle had no effect. The camera is granted when enabled; the microphone is refused, since the app carries neither a toggle nor a `RECORD_AUDIO` entry for it.
- **`android.permission.CAMERA` is declared**, which the camera toggle requires in order to be switchable at all. It is paired with `uses-feature android:required="false"` so the Play Store keeps listing the app on devices without a camera; the built APK confirms `uses-feature-not-required: android.hardware.camera`.
- **Default Firefox user agent bumped 124 → 147.** Closes #266, closes #253. Facebook serves a degraded page and a "browser not supported" notice to agents it treats as outdated. This keeps the desktop agent; moving to a mobile one changes the entire site layout and belongs in its own change (see #290).
- **Explicit "Exit app" menu entry.** Closes #302.
- **`capitalize()` no longer throws** a `RangeError` on the empty string a missing translation resolves to.

## Verification

52 new unit tests. `flutter test` passes, `flutter analyze` reports nothing from the new code, and the debug APK builds.

The tests assert the shapes that broke: the observer guard, `1px solid` surviving CSS normalisation, the user stylesheet reaching the Facebook page, and every persisted preference key. These five regressions now fail the suite instead of the feed.

## Scope

`pubspec.lock` is untouched, keeping the dependency graph out of a bugfix change. #200 needs a monochrome icon asset and #269 needs notification support the app does not yet have, so both stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)