### PR TITLE
Raise the Kotlin Gradle Plugin to 2.2.20 so the Android build succeeds

### DIFF
--- a/SlimSocial_for_Facebook/.vscode/settings.json
+++ b/SlimSocial_for_Facebook/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/versions/3.29.2"
+  "dart.flutterSdkPath": ".fvm/versions/3.44.8"
 }

--- a/SlimSocial_for_Facebook/android/settings.gradle.kts
+++ b/SlimSocial_for_Facebook/android/settings.gradle.kts
@@ -19,7 +19,11 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    // 2.x is required by in_app_purchase_android 0.5.0, which calls
+    // KotlinAndroidProjectExtension.compilerOptions -- absent from KGP 1.x, so
+    // the build failed inside that plugin's own build script. 2.2.20 is the
+    // floor Flutter 3.44.8 asks for; anything lower builds but warns.
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Rebased onto `master`. Most of what this PR originally carried is now redundant — you fixed the FVM discovery your own way (root `.fvmrc` + legacy config) and moved the SDK pin to 3.44.8 yourself. Those parts are dropped, along with the `codemagic.yaml` I had added, since your approach already solves that.

What remains is the one failure still present on `master`.

## The Android build fails

`in_app_purchase_android 0.5.0`, pulled in by the Play Billing 8 upgrade, calls `KotlinAndroidProjectExtension.compilerOptions` in its own build script. That API does not exist in the 1.x Kotlin Gradle Plugin, and `master` still pins **1.8.22**:

```
Build file '.../in_app_purchase_android-0.5.0/android/build.gradle.kts' line: 32
* What went wrong:
'void org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension.compilerOptions(...)'
```

So `assembleDebug` fails before it reaches any of your code. Raised to **2.2.20**.

Not the bare 2.x minimum: on Flutter 3.44.8 anything below 2.2.20 builds but warns that support is about to be dropped, so this avoids landing a value that is already deprecated. AGP 8.7.0 and Gradle 8.10.2 are untouched and both support it.

## Also

`.vscode/settings.json` still pointed the Dart SDK path at `3.29.2`, which no longer resolves dependencies now that the pin has moved. Same class of stale reference your CI commits were clearing, just one that got missed.

## Verification

On Flutter 3.44.8, rebased on `9f85040`:

| Step | Result |
|---|---|
| `flutter analyze --no-fatal-infos` | exit 0, no errors or warnings |
| `flutter test` | 52/52 pass |
| `flutter build apk --debug` | builds, zero Kotlin warnings |

## Two things left alone

- Flutter warns that **Gradle 8.10.2** and **AGP 8.7.0** will be dropped, wanting 8.14.0 and 8.11.1. The build works today; bumping either is a bigger change and belongs on its own.
- The FVM version is now declared in four tracked files: `.fvmrc` and `.fvm/fvm_config.json`, at both the repo root and in `SlimSocial_for_Facebook/`. They all read 3.44.8 today. Worth knowing that the previous breakage was exactly this shape — a stale copy naming 3.29.2 that tooling reads in preference to the one you updated. Happy to collapse it to a single source if you want, but not folded into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)