### PR TITLE
Fix: support 16 KB memory page sizes

### DIFF
--- a/SlimSocial_for_Facebook/android/build.gradle.kts
+++ b/SlimSocial_for_Facebook/android/build.gradle.kts
@@ -3,6 +3,18 @@ allprojects {
         google()
         mavenCentral()
     }
+
+    // flutter_jailbreak_detection depends on rootbeer 0.1.0 (JitPack), whose prebuilt
+    // libtoolChecker.so is only 4 KB page aligned — Google Play rejects the bundle with
+    // "Your app does not support 16 KB memory page sizes". rootbeer-lib 0.1.2 (Maven
+    // Central, same API) ships 16 KB aligned binaries.
+    configurations.all {
+        resolutionStrategy.dependencySubstitution {
+            substitute(module("com.github.scottyab:rootbeer"))
+                .using(module("com.scottyab:rootbeer-lib:0.1.2"))
+                .because("rootbeer 0.1.0 native lib is not 16 KB page aligned")
+        }
+    }
 }
 
 val newBuildDir: Directory = rootProject.layout.buildDirectory.dir("../../build").get()

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -1,7 +1,7 @@
 name: slimsocial_for_facebook
 description: Webview to securely navigate Facebook
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 26.08.04+118
+version: 26.08.05+119
 
 environment:
   sdk: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
## Problem

Play Console rejects the bundle with **"Your app does not support 16 KB memory page sizes"**.

## Root cause

`flutter_jailbreak_detection` depends on `com.github.scottyab:rootbeer:0.1.0` (JitPack), whose prebuilt `libtoolChecker.so` has ELF LOAD segments aligned to 4 KB only. Every other native library in the bundle (`libflutter.so`, `libapp.so`, `libdatastore_shared_counter.so`) was already 16 KB aligned — rootbeer 0.1.0 was the single offender across all three ABIs.

## Fix

- Gradle dependency substitution in `android/build.gradle.kts`: `com.github.scottyab:rootbeer` → `com.scottyab:rootbeer-lib:0.1.2` (same library and API, published on Maven Central; 0.1.1 added 16 KB page size support, 0.1.2 enforces it). The plugin only calls `RootBeer(context).isRooted`, which is unchanged.
- Version bump `26.08.04+118` → `26.08.05+119` for the Play re-upload.

## Verification

Built the release AAB with Flutter 3.44.8 and checked the ELF program headers of every packaged `.so`:

| Library | Before | After |
|---|---|---|
| libtoolChecker.so (all ABIs) | 0x1000 (4 KB) ❌ | 0x4000 (16 KB) ✅ |
| libflutter.so | 0x10000 ✅ | 0x10000 ✅ |
| libapp.so | ≥0x4000 ✅ | ≥0x4000 ✅ |
| libdatastore_shared_counter.so | 0x4000 ✅ | 0x4000 ✅ |

All 12 `.so` files in the bundle now satisfy the 16 KB requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)