### PR TITLE
Add a text size setting for the webview

### DIFF
--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -14,6 +14,8 @@
   "hide_stories": "Hide stories",
   "center_text": "Center text on posts",
   "add_space": "Add space between posts",
+  "text_zoom": "Text size",
+  "text_zoom_desc": "Scale the page text without breaking the layout",
   "advanced": "advanced",
   "custom_useragent": "Set a custom user agent",
   "custom_js": "Run custom JS code",

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -14,6 +14,8 @@
   "hide_stories": "Hide stories",
   "center_text": "Center text on posts",
   "add_space": "Add space between posts",
+  "text_zoom": "Text size",
+  "text_zoom_desc": "Scale the page text without breaking the layout",
   "advanced": "advanced",
   "custom_useragent": "Set a custom user agent",
   "custom_js": "Run custom JS code",

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -28,6 +28,17 @@ const String kIpadUserAgent =
 const String kOperaMiniUserAgent =
     "Opera/9.80 (Android; Opera Mini/69.0.2254/191.303; U; en) Presto/2.12.423 Version/12.16";
 
+//text scaling applied to the webview, as a percentage
+//
+//Android multiplies the page text by the system font scale, and Facebook's
+//layout overflows instead of reflowing when it grows: text ends up clipped or
+//running off the screen. Pinning the scale would take large-text accessibility
+//away from the people who rely on it, so the value is a setting and is only
+//clamped to a range the page survives.
+const int kMinTextZoom = 80;
+const int kMaxTextZoom = 150;
+const int kDefaultTextZoom = 100;
+
 const String kEmailToDevUrl =
     "mailto:dev.rignaneseleo+slimsocial@gmail.com?subject=SlimSocial%20for%20Facebook%20feedback";
 const String kGithubIssuesUrl =
@@ -55,6 +66,8 @@ class SpKeys {
   static const String gpsPermission = "gps_permission";
   static const String cameraPermission = "camera_permission";
   static const String photosPermission = "photos_permission";
+
+  static const String textZoom = "text_zoom";
 
   static const String enableMessenger = "enable_messenger";
   static const String hideAds = "hide_ads";

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -30,6 +30,23 @@ class PrefController {
     return kFirefoxUserAgent;
   }
 
+  /// Text scaling for the webview, as a percentage of the page's own size.
+  ///
+  /// Clamped on the way out as well as on the way in, so a value written by an
+  /// older build (or a corrupted preference) can never render the page
+  /// unreadable.
+  static int getTextZoom() =>
+      _clampTextZoom(sp.getInt(SpKeys.textZoom) ?? kDefaultTextZoom);
+
+  static Future<void> setTextZoom(int textZoom) =>
+      sp.setInt(SpKeys.textZoom, _clampTextZoom(textZoom));
+
+  static int _clampTextZoom(int textZoom) {
+    if (textZoom < kMinTextZoom) return kMinTextZoom;
+    if (textZoom > kMaxTextZoom) return kMaxTextZoom;
+    return textZoom;
+  }
+
   static String? getUserCustomCss() {
     final customCss = _getOverride(SpKeys.customCss);
     if (customCss != null) debugPrint("Using custom css: $customCss");

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -34,6 +34,7 @@ class HomePage extends ConsumerStatefulWidget {
 
 class _HomePageState extends ConsumerState<HomePage> {
   late WebViewController _controller;
+  AndroidWebViewController? _androidController;
   bool isLoading = false;
   bool isScontentUrl = false;
 
@@ -62,6 +63,10 @@ class _HomePageState extends ConsumerState<HomePage> {
 
             //inject the css as soon as the DOM is loaded
             await injectCss();
+
+            //re-read the zoom, so changing it in the settings takes effect on
+            //the next load instead of needing the app restarted
+            await _androidController?.setTextZoom(PrefController.getTextZoom());
           },
           onPageFinished: (String url) async {
             await runJs();
@@ -77,11 +82,15 @@ class _HomePageState extends ConsumerState<HomePage> {
       ..loadRequest(Uri.parse(homepage));
 
     if (Platform.isAndroid) {
-      (controller.platform as AndroidWebViewController)
+      final androidController = controller.platform as AndroidWebViewController;
+      _androidController = androidController;
+
+      androidController
         //videos and reels are muted until the page sees a "user gesture", and
         //the gesture the webview recognises is not the one that starts the
         //video: without this the first taps only toggle the sound off again
         ..setMediaPlaybackRequiresUserGesture(false)
+        ..setTextZoom(PrefController.getTextZoom())
         ..setCustomWidgetCallbacks(
           onShowCustomWidget:
               (Widget widget, OnHideCustomWidgetCallback callback) {

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -28,6 +28,7 @@ class MessengerPage extends ConsumerStatefulWidget {
 
 class _HomePageState extends ConsumerState<MessengerPage> {
   late WebViewController _controller;
+  AndroidWebViewController? _androidController;
   bool isLoading = false;
 
   @override
@@ -54,6 +55,10 @@ class _HomePageState extends ConsumerState<MessengerPage> {
           onPageStarted: (String url) async {
             //inject the css as soon as the DOM is loaded
             await injectCss();
+
+            //re-read the zoom, so changing it in the settings takes effect on
+            //the next load instead of needing the app restarted
+            await _androidController?.setTextZoom(PrefController.getTextZoom());
           },
           onPageFinished: (String url) async {
             await runJs();
@@ -69,9 +74,13 @@ class _HomePageState extends ConsumerState<MessengerPage> {
       ..loadRequest(Uri.parse(homepage));
 
     if (Platform.isAndroid) {
-      (controller.platform as AndroidWebViewController)
+      final androidController = controller.platform as AndroidWebViewController;
+      _androidController = androidController;
+
+      androidController
         //let videos and voice clips play with sound on the first tap
         ..setMediaPlaybackRequiresUserGesture(false)
+        ..setTextZoom(PrefController.getTextZoom())
         ..setOnShowFileSelector(
           (FileSelectorParams params) async {
             final photosPermission =

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -263,6 +263,18 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text(CustomCss.addSpaceBetweenPostsCss.key.tr()),
                 leading: const Icon(Icons.format_line_spacing),
               ),
+              SettingsTile.navigation(
+                leading: const Icon(Icons.format_size),
+                title: Text('text_zoom'.tr()),
+                description: Text('text_zoom_desc'.tr()),
+                trailing: Text("${PrefController.getTextZoom()}%"),
+                onPressed: (context) async {
+                  await showTextZoomDialog();
+                  setState(() {});
+                  //the webview re-reads the zoom while the page reloads
+                  ref.invalidate(fbWebViewProvider);
+                },
+              ),
             ],
           ),
           SettingsSection(
@@ -581,6 +593,59 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   sp.setString(spKey, _textEditingController.text.trim());
                 });
                 Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> showTextZoomDialog() async {
+    var textZoom = PrefController.getTextZoom();
+
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('text_zoom'.tr()),
+          content: StatefulBuilder(
+            builder: (context, StateSetter _setState) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text("$textZoom%"),
+                  Slider(
+                    value: textZoom.toDouble(),
+                    min: kMinTextZoom.toDouble(),
+                    max: kMaxTextZoom.toDouble(),
+                    //one stop every 5%, finer than that is not noticeable
+                    divisions: (kMaxTextZoom - kMinTextZoom) ~/ 5,
+                    label: "$textZoom%",
+                    onChanged: (value) =>
+                        _setState(() => textZoom = value.round()),
+                  ),
+                ],
+              );
+            },
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: Text('reset'.tr().capitalize()),
+              onPressed: () async {
+                await PrefController.setTextZoom(kDefaultTextZoom);
+                if (context.mounted) Navigator.of(context).pop();
+              },
+            ),
+            TextButton(
+              child: Text('cancel'.tr().capitalize()),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            TextButton(
+              child: Text('save'.tr().capitalize()),
+              onPressed: () async {
+                await PrefController.setTextZoom(textZoom);
+                if (context.mounted) Navigator.of(context).pop();
               },
             ),
           ],

--- a/SlimSocial_for_Facebook/test/consts_test.dart
+++ b/SlimSocial_for_Facebook/test/consts_test.dart
@@ -18,6 +18,7 @@ void main() {
       expect(SpKeys.customCss, 'custom_css');
       expect(SpKeys.customJs, 'custom_js');
       expect(SpKeys.customProxy, 'custom_proxy');
+      expect(SpKeys.textZoom, 'text_zoom');
     });
 
     test('derives the companion switch key', () {

--- a/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
+++ b/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
@@ -109,4 +109,45 @@ void main() {
       expect(PrefController.getUserCustomJs(), 'foo();');
     });
   });
+
+  group('text zoom', () {
+    test('leaves the page at its own size until the user asks otherwise', () {
+      expect(PrefController.getTextZoom(), kDefaultTextZoom);
+    });
+
+    test('returns the value the user picked', () async {
+      await PrefController.setTextZoom(130);
+
+      expect(PrefController.getTextZoom(), 130);
+    });
+
+    test('refuses to store a value outside the usable range', () async {
+      await PrefController.setTextZoom(1000);
+      expect(PrefController.getTextZoom(), kMaxTextZoom);
+
+      await PrefController.setTextZoom(0);
+      expect(PrefController.getTextZoom(), kMinTextZoom);
+    });
+
+    test('clamps a stored value it did not write itself', () async {
+      // A build with a wider range, or a hand-edited preferences file, must not
+      // be able to leave the page at an unreadable size.
+      await withPrefs({SpKeys.textZoom: 5});
+      expect(PrefController.getTextZoom(), kMinTextZoom);
+
+      await withPrefs({SpKeys.textZoom: 400});
+      expect(PrefController.getTextZoom(), kMaxTextZoom);
+    });
+
+    test('keeps the range wide enough to be worth offering', () {
+      expect(kMinTextZoom, lessThan(kDefaultTextZoom));
+      expect(kMaxTextZoom, greaterThan(kDefaultTextZoom));
+    });
+
+    test('the slider divides the range into whole steps', () {
+      // The dialog uses (max - min) / 5 divisions; a remainder would put the
+      // last stop somewhere the user cannot actually select.
+      expect((kMaxTextZoom - kMinTextZoom) % 5, 0);
+    });
+  });
 }

--- a/SlimSocial_for_Facebook/test/lang_test.dart
+++ b/SlimSocial_for_Facebook/test/lang_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The two stylesheets every other translation falls back to.
+///
+/// `_.json` is the catch-all easy_localization reads when a locale has no file
+/// of its own, so a label missing from both of these renders as an empty string
+/// in every language.
+const List<String> _fallbackLangFiles = [
+  'assets/lang/_.json',
+  'assets/lang/en-US.json',
+];
+
+Map<String, dynamic> _readLang(String path) {
+  final contents = File(path).readAsStringSync();
+  return jsonDecode(contents) as Map<String, dynamic>;
+}
+
+void main() {
+  group('fallback translations', () {
+    test('are valid JSON', () {
+      for (final path in _fallbackLangFiles) {
+        expect(() => _readLang(path), returnsNormally, reason: path);
+      }
+    });
+
+    test('carry every label the settings screen asks for', () {
+      // A missing key resolves to an empty string, which used to crash
+      // `capitalize()` outright and still leaves an unlabelled row behind.
+      const required = [
+        'text_zoom',
+        'text_zoom_desc',
+        'dark_theme',
+        'fixed_bar',
+        'hide_stories',
+        'center_text',
+        'add_space',
+        'enable_messenger',
+        'permissions',
+        'advanced',
+        'style',
+      ];
+
+      for (final path in _fallbackLangFiles) {
+        final lang = _readLang(path);
+        for (final key in required) {
+          expect(lang.containsKey(key), isTrue, reason: '$key missing in $path');
+          expect(lang[key], isNotEmpty, reason: '$key is blank in $path');
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Why

Android scales webview text by the system font size. Facebook's layout overflows rather than reflows when that grows, so text gets clipped or runs off the screen — and anyone who raised the system font for accessibility reasons had no way to get a usable page back.

`AndroidWebViewController.setTextZoom` was available but never called.

Closes #199
Closes #186

May also help #268, #193 and #231, which report the same overflow symptoms without naming the system font size — leaving those open until someone confirms.

## What

A slider in **Settings → Style**, 80–150% in 5% steps, defaulting to 100% so nothing changes for users who don't touch it.

Pinning the zoom to 100% would have fixed the layout in one line, at the cost of taking large text away from the people who rely on it — hence a setting.

- `PrefController.getTextZoom()` / `setTextZoom()` clamp on both read and write, so a preference written by a build with a different range can't leave the page unreadable.
- Both webviews apply it at creation *and* re-read it in `onPageStarted`, so moving the slider takes effect on the next page load instead of requiring an app restart (the pattern `use_mbasic` and the proxy settings use).
- New strings in the two fallback translation files.

## Tests

`flutter test`: 60 passing, up from 52.

- 6 cases covering the default, round-tripping, clamping on write, clamping a value it didn't write itself, and that the range divides into whole slider steps.
- `test/lang_test.dart` asserts the fallback translation files carry every label the settings screen renders — a missing key resolves to an empty string and leaves an unlabelled row behind.

`flutter analyze` reports no new issues (49 pre-existing infos, none in the added code).

## Not verified

The zoom itself is Android-platform behaviour and isn't exercised by the unit tests — it needs a manual check on a device with the system font size turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)