### PR TITLE
Add tag-driven release automation (Codemagic build + GitHub release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,164 @@
+name: Release
+
+# Pushing a version tag like 26.08.05+119 on master:
+#   1. starts the Codemagic "release-android" workflow (codemagic.yaml), which
+#      builds the universal APK with exactly that version name/number,
+#   2. waits for the build to finish and downloads the APK,
+#   3. creates a GitHub release with an auto-generated changelog and the APK.
+#
+# Requires the CODEMAGIC_API_TOKEN repository secret
+# (Codemagic > Teams > Personal Account > Integrations > Codemagic API).
+#
+# The workflow can also be re-run for an existing tag via workflow_dispatch
+# (e.g. if Codemagic or the release step failed).
+
+on:
+  push:
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*\+[0-9]*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing version tag to (re)release, e.g. 26.08.05+119"
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ inputs.tag || github.ref_name }}
+
+env:
+  # Same app id as the Codemagic build badge in README.md.
+  CODEMAGIC_APP_ID: 645a7fe598007bd18863656d
+  # Workflow name defined in codemagic.yaml.
+  CODEMAGIC_WORKFLOW_ID: release-android
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ inputs.tag || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Validate tag
+        run: |
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$ ]]; then
+            echo "::error::Tag '$TAG' does not match the release format <version>+<build>, e.g. 26.08.05+119"
+            exit 1
+          fi
+          git fetch origin master
+          if ! git merge-base --is-ancestor "$(git rev-parse HEAD)" origin/master; then
+            echo "::error::Tag '$TAG' does not point to a commit on master; releases are only built from master."
+            exit 1
+          fi
+
+      - name: Generate changelog
+        run: |
+          PREV_TAG="$(git describe --tags --abbrev=0 "${TAG}^" 2>/dev/null || true)"
+          {
+            echo "## Changelog"
+            if [[ -n "$PREV_TAG" ]]; then
+              git log --no-merges --pretty='- %s' "${PREV_TAG}..${TAG}"
+              echo
+              echo "**Full changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...${TAG}"
+            else
+              git log --no-merges --pretty='- %s' "${TAG}"
+            fi
+          } > "$RUNNER_TEMP/release-notes.md"
+          cat "$RUNNER_TEMP/release-notes.md"
+
+      - name: Start Codemagic build
+        id: codemagic
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+        run: |
+          if [[ -z "$CODEMAGIC_API_TOKEN" ]]; then
+            echo "::error::The CODEMAGIC_API_TOKEN repository secret is not configured."
+            exit 1
+          fi
+          PAYLOAD="$(jq -n \
+            --arg appId "$CODEMAGIC_APP_ID" \
+            --arg workflowId "$CODEMAGIC_WORKFLOW_ID" \
+            --arg tag "$TAG" \
+            '{appId: $appId, workflowId: $workflowId, tag: $tag,
+              environment: {variables: {RELEASE_TAG: $tag}}}')"
+          RESPONSE="$(curl -fsS -X POST "https://api.codemagic.io/builds" \
+            -H "Content-Type: application/json" \
+            -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
+            -d "$PAYLOAD")"
+          BUILD_ID="$(echo "$RESPONSE" | jq -r '.buildId // empty')"
+          if [[ -z "$BUILD_ID" ]]; then
+            echo "::error::Codemagic did not return a buildId. Response: $RESPONSE"
+            exit 1
+          fi
+          echo "Started Codemagic build: https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$BUILD_ID"
+          echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Codemagic build
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          BUILD_ID: ${{ steps.codemagic.outputs.build_id }}
+        run: |
+          BUILD_URL="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$BUILD_ID"
+          for i in $(seq 1 90); do
+            RESPONSE="$(curl -sS -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
+              "https://api.codemagic.io/builds/$BUILD_ID" || true)"
+            STATUS="$(echo "$RESPONSE" | jq -r '.build.status // empty' 2>/dev/null || true)"
+            echo "[$i/90] Codemagic build status: ${STATUS:-unreachable}"
+            case "$STATUS" in
+              finished)
+                exit 0
+                ;;
+              failed|canceled|timeout|skipped)
+                echo "::error::Codemagic build ended with status '$STATUS' — $BUILD_URL"
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+          echo "::error::Timed out waiting for Codemagic build — $BUILD_URL"
+          exit 1
+
+      - name: Download universal APK
+        env:
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          BUILD_ID: ${{ steps.codemagic.outputs.build_id }}
+        run: |
+          APK_URL="$(curl -fsS -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
+            "https://api.codemagic.io/builds/$BUILD_ID" \
+            | jq -r '[.build.artefacts[] | select(.name | endswith(".apk"))][0].url // empty')"
+          if [[ -z "$APK_URL" ]]; then
+            echo "::error::No APK artefact found on Codemagic build $BUILD_ID"
+            exit 1
+          fi
+          APK="SlimSocial_for_Facebook_v${TAG}.apk"
+          curl -fsSL -H "x-auth-token: $CODEMAGIC_API_TOKEN" -o "$APK" "$APK_URL"
+          unzip -l "$APK" > /dev/null # fail early on a truncated or non-APK download
+          ls -lh "$APK"
+          echo "APK=$APK" >> "$GITHUB_ENV"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="SlimSocial for Facebook $TAG"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — updating notes and APK."
+            gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --notes-file "$RUNNER_TEMP/release-notes.md"
+            gh release upload "$TAG" "$APK" --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$TAG" "$APK" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "$TITLE" \
+              --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,0 +1,46 @@
+# Codemagic CI configuration (https://docs.codemagic.io/)
+#
+# The release-android workflow is not triggered by Codemagic webhooks: it is
+# started through the Codemagic REST API by the GitHub Actions workflow
+# .github/workflows/release.yml whenever a release tag (e.g. 26.08.05+119)
+# is pushed to master. The GitHub workflow then waits for this build,
+# downloads the universal APK and publishes the GitHub release.
+
+workflows:
+  release-android:
+    name: Release Android APK
+    instance_type: mac_mini_m2
+    max_build_duration: 45
+    working_directory: SlimSocial_for_Facebook
+    environment:
+      android_signing:
+        # Must match the reference name of the upload keystore stored in
+        # Codemagic > Team settings > Code signing identities > Android.
+        # It exports CM_KEYSTORE_PATH / CM_KEYSTORE_PASSWORD / CM_KEY_ALIAS /
+        # CM_KEY_PASSWORD, which android/app/build.gradle.kts picks up.
+        - keystore_reference
+      flutter: fvm # version taken from .fvmrc in the repository root
+      java: 17
+    scripts:
+      - name: Flutter pub get
+        script: flutter pub get
+      - name: Build universal release APK with the version from the tag
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          # RELEASE_TAG is passed by the GitHub Actions workflow; CM_TAG is set
+          # by Codemagic itself when the build is started from a tag.
+          TAG="${RELEASE_TAG:-${CM_TAG:-}}"
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$ ]]; then
+            echo "ERROR: no release tag found (RELEASE_TAG/CM_TAG)."
+            echo "Expected a tag like 26.08.05+119, got: '${TAG}'"
+            exit 1
+          fi
+          BUILD_NAME="${TAG%%+*}"
+          BUILD_NUMBER="${TAG##*+}"
+          echo "Building version ${BUILD_NAME} (build ${BUILD_NUMBER})"
+          flutter build apk --release \
+            --build-name="$BUILD_NAME" \
+            --build-number="$BUILD_NUMBER"
+    artifacts:
+      - SlimSocial_for_Facebook/build/**/outputs/**/*.apk


### PR DESCRIPTION
## What this does

Pushing a version tag like `26.08.05+119` on `master` now runs the full release pipeline automatically:

1. **Version from tag** — the tag name is parsed into `--build-name=26.08.05` and `--build-number=119`, so the APK carries exactly that version regardless of what pubspec.yaml says.
2. **Starts Codemagic** — the new `release-android` workflow in `codemagic.yaml` is triggered through the Codemagic REST API on the tagged commit. It uses `flutter: fvm` (reads the root `.fvmrc`, currently 3.44.8) and Codemagic-managed Android signing (the `CM_KEYSTORE_*` variables that `android/app/build.gradle.kts` already expects).
3. **GitHub release** — the action waits for the build, downloads the universal APK, and publishes a release with:
   - a changelog generated from commits since the previous tag (plus a compare link),
   - the APK attached as `SlimSocial_for_Facebook_v<tag>.apk` (same naming as the existing 26.08.05+119 release).

The workflow refuses tags that are not on `master` or don't match the `<x>.<y>.<z>+<n>` format. It can also be re-run for an existing tag via *Actions → Release → Run workflow* (useful if Codemagic flaked); in that case it updates the existing release instead of failing.

## One-time setup required before the first tagged release

1. **Add the `CODEMAGIC_API_TOKEN` repository secret** (GitHub → Settings → Secrets → Actions). The token is in Codemagic → Teams → Personal Account → Integrations → Codemagic API. The app id is not secret (it's already in the README badge), so it's hardcoded in the workflow.
2. **Keystore reference**: `codemagic.yaml` references an upload keystore named `keystore_reference` under Codemagic → Team settings → Code signing identities → Android keystores. If your keystore there has a different reference name, either rename it or edit that one line in `codemagic.yaml`. If signing was only ever configured inside the old Workflow Editor UI, upload the keystore to Code signing identities once.
3. If the API returns a "workflow not found" error on first run, enable *codemagic.yaml* as the configuration source for the app in Codemagic settings.

## Release process after this PR

```
git tag 26.09.01+120 && git push origin 26.09.01+120
```

Everything else is automatic.

## Notes

- The existing Codemagic UI workflow is untouched; the API call targets the yaml workflow by name (`release-android`), and no webhook triggering is defined in the yaml, so tags won't start duplicate builds.
- `Changelog.txt` stopped at v5.x, so the changelog comes from git commit subjects instead.
- The old `_old/codemagic.yaml` is left as-is; Codemagic only reads the root file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)