### PR TITLE
test: cover the webview load-failure retry state machine

### DIFF
--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -20,6 +20,7 @@ import 'package:slimsocial_for_facebook/utils/ad_filter.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/dark_theme.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
+import 'package:slimsocial_for_facebook/utils/load_retry_policy.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -40,47 +41,22 @@ class _HomePageState extends ConsumerState<HomePage> {
   bool isLoading = false;
   bool isScontentUrl = false;
 
-  /// Set when the main frame fails to load, so the app can show its own error
-  /// state instead of the browser's.
-  ///
-  /// Without this the user gets Chrome's "webpage not available" page on a
-  /// near-black background, which reads as the app being broken rather than the
-  /// network being briefly unavailable.
-  bool _loadFailed = false;
-
-  /// Whether the navigation currently in flight already reported an error.
-  ///
-  /// Android delivers `onPageFinished` for a failed main-frame load too: the
-  /// error page commits and finishes like any other document. Without this the
-  /// error page's own finish would look like a success and clear the retry
-  /// counter, so the ceiling below could never be reached.
-  bool _navigationFailed = false;
-
-  /// Automatic retries used since the last successful load.
-  ///
-  /// Bounded so a genuinely unreachable site does not become a reload loop.
-  int _loadRetries = 0;
-
-  /// The automatic retry waiting to fire, if any.
-  ///
-  /// Held so a retry that has been superseded — by a manual refresh, or by the
-  /// page coming back on its own — can be cancelled: reloading a healthy page
-  /// throws the user back to the top of the feed.
-  Timer? _retryTimer;
-
-  /// How many times to retry before showing the error screen.
-  ///
-  /// Measured on a real device: opening the app as the phone wakes produces
-  /// `ERR_INTERNET_DISCONNECTED` first — no network attached at all — and only
-  /// then `ERR_NAME_NOT_RESOLVED` once DNS is reachable but not yet answering.
-  /// A single quick retry lands in the middle of that and still fails, so the
-  /// delay grows with each attempt.
-  static const int _maxLoadRetries = 3;
+  /// Owns everything about a failed load: how many automatic retries are
+  /// left, how long to wait before each, and whether the app should be showing
+  /// its own error state instead of the browser's.
+  late final LoadRetryPolicy _retryPolicy;
 
   @override
   void initState() {
     super.initState();
 
+    _retryPolicy = LoadRetryPolicy(
+      target: _WebViewLoadTarget(() => _controller),
+      homeUrl: () => Uri.parse(PrefController.getHomePage()),
+      onChanged: () {
+        if (mounted) setState(() {});
+      },
+    );
     _controller = _initWebViewController();
   }
 
@@ -101,11 +77,9 @@ class _HomePageState extends ConsumerState<HomePage> {
           onNavigationRequest: onNavigationRequest,
           onWebResourceError: onWebResourceError,
           onPageStarted: (String url) async {
-            _navigationFailed = false;
+            _retryPolicy.onNavigationStarted();
             setState(() {
               isScontentUrl = Uri.parse(url).host.contains("scontent");
-              //a new navigation started, so any previous failure is stale
-              _loadFailed = false;
             });
 
             //inject the css as soon as the DOM is loaded
@@ -122,16 +96,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             await _androidController?.setTextZoom(PrefController.getTextZoom());
           },
           onPageFinished: (String url) async {
-            //a page that finished loading is not a failed one, even if a
-            //subresource errored on the way
-            if (!_navigationFailed && (_loadFailed || _loadRetries > 0)) {
-              _retryTimer?.cancel();
-              setState(() {
-                _loadFailed = false;
-                _loadRetries = 0;
-              });
-            }
-            _navigationFailed = false;
+            _retryPolicy.onNavigationFinished();
             await runJs();
             if (kDebugMode) debugPrint(url);
           },
@@ -228,7 +193,7 @@ class _HomePageState extends ConsumerState<HomePage> {
 
   @override
   void dispose() {
-    _retryTimer?.cancel();
+    _retryPolicy.dispose();
     super.dispose();
   }
 
@@ -245,64 +210,20 @@ class _HomePageState extends ConsumerState<HomePage> {
     unawaited(PrefController.addAdsBlocked(count));
   }
 
-  /// Handles a failed page load.
-  ///
-  /// Only main-frame failures matter: Facebook drops individual images and
-  /// beacons all the time, and treating those as a page failure would replace a
-  /// perfectly good feed with an error screen.
-  ///
-  /// The first failure is retried automatically once. The common case is a
-  /// transient DNS failure when the app is opened as the device wakes and the
-  /// network has not settled — the load fails, and without a retry the user is
-  /// left looking at an error until they think to reload themselves.
+  /// Hands a failed page load to the retry policy.
   void onWebResourceError(WebResourceError error) {
-    if (error.isForMainFrame == false) return;
+    //a failure the platform will not classify is treated as the main frame's
+    final isForMainFrame = error.isForMainFrame ?? true;
 
-    debugPrint(
-      "load failed: ${error.errorType} ${error.errorCode} ${error.description}",
-    );
-
-    _navigationFailed = true;
-
-    if (_loadRetries < _maxLoadRetries) {
-      _loadRetries++;
-      //2s, then 4s, then 6s — long enough in total to outlast a phone
-      //reattaching to the network, short enough not to feel stuck
-      final delay = Duration(seconds: 2 * _loadRetries);
-      _retryTimer?.cancel();
-      _retryTimer = Timer(delay, () {
-        if (!mounted) return;
-        unawaited(reissueLoad(error.url));
-      });
-      return;
+    //Facebook drops individual images and beacons all the time, so only a
+    //main-frame failure is worth a line in the log
+    if (isForMainFrame) {
+      debugPrint(
+        "load failed: ${error.errorType} ${error.errorCode} ${error.description}",
+      );
     }
 
-    if (!mounted) return;
-    setState(() => _loadFailed = true);
-  }
-
-  /// Asks the webview for the failed page again.
-  ///
-  /// A plain `reload()` is not enough after a failed *first* load: iOS has no
-  /// committed navigation to reload at that point, so the call does nothing and
-  /// fires no callbacks at all — the retry would silently never happen. A null
-  /// current url is exactly that state.
-  Future<void> reissueLoad(String? url) async {
-    if (await _controller.currentUrl() != null) {
-      await _controller.reload();
-      return;
-    }
-    await _controller
-        .loadRequest(Uri.parse(url ?? PrefController.getHomePage()));
-  }
-
-  Future<void> retryLoad() async {
-    _retryTimer?.cancel();
-    setState(() {
-      _loadFailed = false;
-      _loadRetries = 0;
-    });
-    await _controller.loadRequest(Uri.parse(PrefController.getHomePage()));
+    _retryPolicy.onLoadError(url: error.url, isForMainFrame: isForMainFrame);
   }
 
   Future<NavigationDecision> onNavigationRequest(
@@ -551,7 +472,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             ),
             //covers the webview so the browser's own error page, sitting on a
             //near-black background, is never what the user sees
-            if (_loadFailed)
+            if (_retryPolicy.loadFailed)
               ColoredBox(
                 color: Theme.of(context).colorScheme.surface,
                 child: Center(
@@ -573,7 +494,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                         ),
                         const SizedBox(height: 24),
                         FilledButton.icon(
-                          onPressed: retryLoad,
+                          onPressed: _retryPolicy.retryNow,
                           icon: const Icon(Icons.refresh),
                           label: Text("retry".tr()),
                         ),
@@ -697,4 +618,23 @@ class _HomePageState extends ConsumerState<HomePage> {
       },
     );
   }*/
+}
+
+/// Lets [LoadRetryPolicy] drive the webview without knowing about it.
+///
+/// The controller is reached through a callback because the policy is built
+/// first: it is what the controller's navigation callbacks report to.
+class _WebViewLoadTarget implements LoadRetryTarget {
+  const _WebViewLoadTarget(this._controller);
+
+  final WebViewController Function() _controller;
+
+  @override
+  Future<String?> currentUrl() => _controller().currentUrl();
+
+  @override
+  Future<void> reload() => _controller().reload();
+
+  @override
+  Future<void> loadRequest(Uri uri) => _controller().loadRequest(uri);
 }

--- a/SlimSocial_for_Facebook/lib/utils/load_retry_policy.dart
+++ b/SlimSocial_for_Facebook/lib/utils/load_retry_policy.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+/// The webview, as far as the retry policy needs to know it.
+///
+/// Kept to the three calls the policy makes so the policy stays plain Dart:
+/// the retry rules are the part worth testing, and a `WebViewController` can
+/// only be built on a device.
+abstract class LoadRetryTarget {
+  /// The url of the committed navigation, or null when nothing has committed
+  /// yet — a fresh webview that has never finished a load.
+  Future<String?> currentUrl();
+
+  Future<void> reload();
+
+  Future<void> loadRequest(Uri uri);
+}
+
+/// Decides what to do when a page fails to load.
+///
+/// A failed main-frame load is retried automatically a few times before the
+/// app gives up and shows its own error state. The common case is a transient
+/// DNS failure when the app is opened as the device wakes and the network has
+/// not settled — the load fails, and without a retry the user is left looking
+/// at an error until they think to reload themselves.
+class LoadRetryPolicy {
+  LoadRetryPolicy({
+    required this.target,
+    required this.homeUrl,
+    required this.onChanged,
+  });
+
+  final LoadRetryTarget target;
+
+  /// Where to go when the failed url is unknown.
+  final Uri Function() homeUrl;
+
+  /// Called when [loadFailed] flips, so the ui can repaint. Retrying quietly
+  /// in the background changes nothing on screen and does not call this.
+  final void Function() onChanged;
+
+  /// How many times to retry before showing the error screen.
+  ///
+  /// Measured on a real device: opening the app as the phone wakes produces
+  /// `ERR_INTERNET_DISCONNECTED` first — no network attached at all — and only
+  /// then `ERR_NAME_NOT_RESOLVED` once DNS is reachable but not yet answering.
+  /// A single quick retry lands in the middle of that and still fails, so the
+  /// delay grows with each attempt.
+  static const int maxRetries = 3;
+
+  /// Grows with each attempt: 2s, then 4s, then 6s — long enough in total to
+  /// outlast a phone reattaching to the network, short enough not to feel
+  /// stuck.
+  static const Duration retryStep = Duration(seconds: 2);
+
+  bool _loadFailed = false;
+  bool _navigationFailed = false;
+  int _retryCount = 0;
+  Timer? _retryTimer;
+  bool _disposed = false;
+
+  /// Whether the app should show its own error state.
+  ///
+  /// Without this the user gets Chrome's "webpage not available" page on a
+  /// near-black background, which reads as the app being broken rather than
+  /// the network being briefly unavailable.
+  bool get loadFailed => _loadFailed;
+
+  /// Automatic retries used since the last successful load.
+  int get retryCount => _retryCount;
+
+  void onNavigationStarted() {
+    _navigationFailed = false;
+    //a new navigation started, so any previous failure is stale
+    _setLoadFailed(false);
+  }
+
+  /// Handles a failed page load.
+  ///
+  /// Only main-frame failures matter: Facebook drops individual images and
+  /// beacons all the time, and treating those as a page failure would replace
+  /// a perfectly good feed with an error screen.
+  void onLoadError({required String? url, required bool isForMainFrame}) {
+    if (!isForMainFrame) return;
+
+    _navigationFailed = true;
+
+    if (_retryCount < maxRetries) {
+      _retryCount++;
+      _retryTimer?.cancel();
+      _retryTimer = Timer(retryStep * _retryCount, () {
+        unawaited(reissueLoad(url));
+      });
+      return;
+    }
+
+    _setLoadFailed(true);
+  }
+
+  void onNavigationFinished() {
+    //a page that finished loading is not a failed one, even if a subresource
+    //errored on the way. Android delivers `onPageFinished` for a failed
+    //main-frame load too — the error page commits and finishes like any other
+    //document — so a navigation that already reported an error is not a
+    //success and must not clear the count, or the ceiling above could never
+    //be reached.
+    if (!_navigationFailed && (_loadFailed || _retryCount > 0)) {
+      //reloading a healthy page throws the user back to the top of the feed,
+      //so a retry the page has already made unnecessary is dropped
+      _retryTimer?.cancel();
+      _retryCount = 0;
+      _setLoadFailed(false);
+    }
+    _navigationFailed = false;
+  }
+
+  /// Retries at the user's request, from the error screen.
+  Future<void> retryNow() async {
+    _retryTimer?.cancel();
+    _retryCount = 0;
+    _setLoadFailed(false);
+    await target.loadRequest(homeUrl());
+  }
+
+  /// Asks the webview for the failed page again.
+  ///
+  /// A plain `reload()` is not enough after a failed *first* load: iOS has no
+  /// committed navigation to reload at that point, so the call does nothing
+  /// and fires no callbacks at all — the retry would silently never happen. A
+  /// null current url is exactly that state.
+  Future<void> reissueLoad(String? url) async {
+    if (_disposed) return;
+    if (await target.currentUrl() != null) {
+      await target.reload();
+      return;
+    }
+    await target.loadRequest(Uri.parse(url ?? homeUrl().toString()));
+  }
+
+  void dispose() {
+    _disposed = true;
+    _retryTimer?.cancel();
+  }
+
+  void _setLoadFailed(bool value) {
+    if (_loadFailed == value) return;
+    _loadFailed = value;
+    onChanged();
+  }
+}

--- a/SlimSocial_for_Facebook/pubspec.lock
+++ b/SlimSocial_for_Facebook/pubspec.lock
@@ -210,7 +210,7 @@ packages:
     source: hosted
     version: "0.0.2"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
 
   webview_flutter_android: any
 dev_dependencies:
+  fake_async: 1.3.3
   flutter_launcher_icons: 0.14.3
   custom_lint: 0.7.5
   very_good_analysis: 7.0.0

--- a/SlimSocial_for_Facebook/test/utils/load_retry_policy_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/load_retry_policy_test.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/load_retry_policy.dart';
+
+const String _kHome = "https://m.facebook.com/";
+const String _kFailed = "https://m.facebook.com/home.php";
+
+/// Stands in for the webview: records what the policy asked it to do and lets
+/// a test pretend there is no committed navigation yet (`url` left null).
+class _FakeTarget implements LoadRetryTarget {
+  _FakeTarget({this.url});
+
+  String? url;
+  final List<String> calls = <String>[];
+
+  @override
+  Future<String?> currentUrl() async => url;
+
+  @override
+  Future<void> reload() async {
+    calls.add("reload");
+  }
+
+  @override
+  Future<void> loadRequest(Uri uri) async {
+    calls.add("load:$uri");
+  }
+}
+
+void main() {
+  late _FakeTarget target;
+  late LoadRetryPolicy policy;
+  late int changes;
+
+  LoadRetryPolicy build({String? currentUrl = _kHome}) {
+    target = _FakeTarget(url: currentUrl);
+    changes = 0;
+    return policy = LoadRetryPolicy(
+      target: target,
+      homeUrl: () => Uri.parse(_kHome),
+      onChanged: () => changes++,
+    );
+  }
+
+  void fail(FakeAsync async, {bool isForMainFrame = true}) {
+    policy.onLoadError(url: _kFailed, isForMainFrame: isForMainFrame);
+    // let the reissue's awaited `currentUrl()` settle if a retry fired
+    async.flushMicrotasks();
+  }
+
+  group('LoadRetryPolicy', () {
+    test('the error page finishing does not clear the retry count', () {
+      fakeAsync((async) {
+        build();
+        policy.onNavigationStarted();
+        fail(async);
+        expect(policy.retryCount, 1);
+
+        // Android delivers onPageFinished for the error page itself
+        policy.onNavigationFinished();
+
+        expect(policy.retryCount, 1, reason: "error page is not a success");
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+        expect(target.calls, <String>["reload"]);
+      });
+    });
+
+    test('escalates the delay and gives up after the third retry', () {
+      fakeAsync((async) {
+        build();
+        for (final expected in <int>[2, 4, 6]) {
+          fail(async);
+          async.elapse(Duration(seconds: expected - 1));
+          async.flushMicrotasks();
+          expect(
+            target.calls.length,
+            expected ~/ 2 - 1,
+            reason: "must still be waiting ${expected}s in",
+          );
+          async.elapse(const Duration(seconds: 1));
+          async.flushMicrotasks();
+          expect(target.calls.length, expected ~/ 2);
+        }
+
+        expect(policy.loadFailed, isFalse);
+        fail(async);
+        expect(policy.loadFailed, isTrue, reason: "retries exhausted");
+        async.elapse(const Duration(minutes: 1));
+        async.flushMicrotasks();
+        expect(target.calls.length, 3, reason: "no fourth retry");
+      });
+    });
+
+    test('a real success resets the counter and cancels the pending retry', () {
+      fakeAsync((async) {
+        build();
+        fail(async);
+        expect(policy.retryCount, 1);
+
+        policy.onNavigationStarted();
+        policy.onNavigationFinished();
+
+        expect(policy.retryCount, 0);
+        expect(policy.loadFailed, isFalse);
+        async.elapse(const Duration(minutes: 1));
+        async.flushMicrotasks();
+        expect(target.calls, isEmpty, reason: "superseded retry must not fire");
+      });
+    });
+
+    test('loads the url again when there is no committed navigation', () {
+      fakeAsync((async) {
+        build(currentUrl: null);
+        fail(async);
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+        expect(target.calls, <String>["load:$_kFailed"]);
+      });
+    });
+
+    test('falls back to the home page when the failed url is unknown', () {
+      fakeAsync((async) {
+        build(currentUrl: null);
+        policy.onLoadError(url: null, isForMainFrame: true);
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+        expect(target.calls, <String>["load:$_kHome"]);
+      });
+    });
+
+    test('a manual retry clears the failure and cancels the pending retry', () {
+      fakeAsync((async) {
+        build();
+        fail(async);
+        unawaited(policy.retryNow());
+        async.flushMicrotasks();
+
+        expect(policy.retryCount, 0);
+        expect(policy.loadFailed, isFalse);
+        async.elapse(const Duration(minutes: 1));
+        async.flushMicrotasks();
+        expect(target.calls, <String>["load:$_kHome"]);
+      });
+    });
+
+    test('dispose cancels the pending retry', () {
+      fakeAsync((async) {
+        build();
+        fail(async);
+        policy.dispose();
+        async.elapse(const Duration(minutes: 1));
+        async.flushMicrotasks();
+        expect(target.calls, isEmpty);
+      });
+    });
+
+    test('ignores failures that are not for the main frame', () {
+      fakeAsync((async) {
+        build();
+        fail(async, isForMainFrame: false);
+
+        expect(policy.retryCount, 0);
+        expect(policy.loadFailed, isFalse);
+        async.elapse(const Duration(minutes: 1));
+        async.flushMicrotasks();
+        expect(target.calls, isEmpty);
+      });
+    });
+
+    test('notifies only when the visible failure state changes', () {
+      fakeAsync((async) {
+        build();
+        fail(async);
+        expect(changes, 0, reason: "a silent retry changes nothing on screen");
+
+        fail(async);
+        fail(async);
+        fail(async);
+
+        expect(policy.loadFailed, isTrue);
+        expect(changes, 1, reason: "only the overlay appearing is visible");
+      });
+    });
+  });
+}


### PR DESCRIPTION
## What

Extracts the webview load-failure retry logic out of `_HomePageState` into `LoadRetryPolicy`, a plain-Dart state machine, and covers it with 9 tests.

The logic added in 4c98d07 (#314) lived entirely in private fields of a `ConsumerState`, so nothing could reach it — covering it needed either a faked `WebViewController` platform implementation or an extraction. Extracting is the better design: the rules are plain data, and the widget only ever needed to know whether to paint the error overlay.

## How

- `LoadRetryPolicy` owns the failed-navigation flag, the bounded retry count with its 2s/4s/6s backoff, the pending-retry timer, and the reissue-vs-reload decision.
- It reaches the webview through `LoadRetryTarget` — `currentUrl` / `reload` / `loadRequest` — which the home page adapts onto `WebViewController`. That keeps the policy free of Flutter and testable without a device.
- `onChanged` fires only when the *visible* state flips, so a quiet background retry does not rebuild the page.
- Behaviour is unchanged; the doc comments explaining *why* each rule exists moved with the code.

## Tests

`fake_async` added as a dev dependency (it was already resolved transitively) so the timers can be driven deterministically. The cases pin the parts that were easy to get wrong:

- the error page's own `onPageFinished` must **not** clear the retry count (Android finishes a failed main-frame load like any other document)
- the delay escalates 2s → 4s → 6s, and the fourth failure shows the overlay instead of retrying
- a genuine success resets the count and cancels a superseded retry, rather than reloading a healthy page and throwing the user back to the top of the feed
- a failed *first* load with no committed navigation must `loadRequest`, not `reload` — on iOS `reload()` there does nothing and fires no callbacks at all
- a manual retry and `dispose()` both cancel a pending retry
- subresource failures are ignored

`flutter test`: 234 passed. `flutter analyze`: no new issues (47, all pre-existing info-level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)