### PR TITLE
Build releases from the tag, and pass the Sentry DSN in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,15 @@ name: Release
 # The workflow can also be re-run for an existing tag via workflow_dispatch
 # (e.g. if Codemagic or the release step failed).
 
+# Deliberately NOT triggered by a tag push. Codemagic subscribes to tag pushes
+# itself (see triggering: in codemagic.yaml) and builds, publishes to Google Play
+# and needs no API token to do it. If this workflow also fired on a tag, two
+# builds would race to upload the same version code and one would be rejected.
+#
+# Kept as a manual entry point: once CODEMAGIC_API_TOKEN exists, running this by
+# hand against an existing tag rebuilds it and attaches the APK to a GitHub
+# release, which the Codemagic-only path does not do.
 on:
-  push:
-    tags:
-      - '[0-9]*.[0-9]*.[0-9]*\+[0-9]*'
   workflow_dispatch:
     inputs:
       tag:

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -1,7 +1,7 @@
 name: slimsocial_for_facebook
 description: Webview to securely navigate Facebook
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 26.08.28+121
+version: 26.08.29+122
 
 environment:
   sdk: ">=3.7.0 <4.0.0"

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -1,7 +1,7 @@
 name: slimsocial_for_facebook
 description: Webview to securely navigate Facebook
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 26.08.05+119
+version: 26.08.28+121
 
 environment:
   sdk: ">=3.7.0 <4.0.0"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,46 +1,177 @@
 # Codemagic CI configuration (https://docs.codemagic.io/)
 #
-# The release-android workflow is not triggered by Codemagic webhooks: it is
-# started through the Codemagic REST API by the GitHub Actions workflow
-# .github/workflows/release.yml whenever a release tag (e.g. 26.08.05+119)
-# is pushed to master. The GitHub workflow then waits for this build,
-# downloads the universal APK and publishes the GitHub release.
+# The git tag is the single source of the version. Nothing here reads
+# pubspec.yaml's `version:` field: pubspec always describes the PREVIOUS
+# release, and reusing its build number is rejected by Play with
+# "Version code N has already been used" — which is exactly what happened
+# when the web-UI workflow built this app from pubspec.
+#
+# One build produces three things:
+#   * app bundle (.aab)    -> Google Play internal track, as a draft
+#   * universal APK (.apk) -> attached to the GitHub release by release.yml
+#   * mapping.txt          -> kept for crash deobfuscation
+#
+# Exactly ONE .apk is ever emitted. release.yml picks its release asset with
+#   jq -r '[.build.artefacts[] | select(.name | endswith(".apk"))][0].url'
+# which takes the first match with no tie-break, so a second .apk (from a
+# `flutter build apk` step, or --split-per-abi) would make the released binary
+# non-deterministic. Do not add one.
 
 workflows:
   release-android:
-    name: Release Android APK
+    # The workflow KEY must stay `release-android`: release.yml hardcodes it as
+    # CODEMAGIC_WORKFLOW_ID. The `name` below is cosmetic.
+    name: Release Android (Play internal draft + GitHub APK)
     instance_type: mac_mini_m2
+    # Kept at 45 deliberately: release.yml polls 90 times with sleep 30 (~45
+    # min). Raising this alone would let GitHub give up on a live build.
     max_build_duration: 45
     working_directory: SlimSocial_for_Facebook
     environment:
       android_signing:
-        # Must match the reference name of the upload keystore stored in
-        # Codemagic > Team settings > Code signing identities > Android.
-        # It exports CM_KEYSTORE_PATH / CM_KEYSTORE_PASSWORD / CM_KEY_ALIAS /
-        # CM_KEY_PASSWORD, which android/app/build.gradle.kts picks up.
+        # Reference name of the upload keystore in Codemagic > Team settings >
+        # Code signing identities > Android. Exports CM_KEYSTORE_PATH,
+        # CM_KEYSTORE_PASSWORD, CM_KEY_ALIAS and CM_KEY_PASSWORD, used by
+        # android/app/build.gradle.kts and by build-universal-apk below.
         - keystore_reference
+      groups:
+        # Must hold the secure variable GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS
+        # (the full service-account JSON). Rename to the group's real name in
+        # the Codemagic UI.
+        - google_play
       flutter: fvm # version taken from .fvmrc in the repository root
       java: 17
     scripts:
       - name: Flutter pub get
         script: flutter pub get
-      - name: Build universal release APK with the version from the tag
+
+      - name: Resolve the version from the release tag
         script: |
           #!/usr/bin/env bash
           set -euo pipefail
-          # RELEASE_TAG is passed by the GitHub Actions workflow; CM_TAG is set
-          # by Codemagic itself when the build is started from a tag.
+          # RELEASE_TAG is passed by .github/workflows/release.yml in the REST
+          # API payload. CM_TAG is only set for builds started from a tag
+          # webhook, so it is unset on API-started builds; it is kept as
+          # defence in depth.
+          echo "trigger: ${CM_TRIGGER_SOURCE:-unknown} | CM_TAG='${CM_TAG:-}' | RELEASE_TAG='${RELEASE_TAG:-}'"
           TAG="${RELEASE_TAG:-${CM_TAG:-}}"
           if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$ ]]; then
             echo "ERROR: no release tag found (RELEASE_TAG/CM_TAG)."
-            echo "Expected a tag like 26.08.05+119, got: '${TAG}'"
+            echo "Expected a tag like 26.08.28+121, got: '${TAG}'"
+            echo "This build publishes to Google Play, so it refuses to guess a version."
+            echo "To start it by hand, add RELEASE_TAG=<tag> as an environment variable"
+            echo "in the Codemagic 'Start new build' dialog. Picking the tag in the ref"
+            echo "selector is not enough - that is still an api-sourced build."
             exit 1
           fi
-          BUILD_NAME="${TAG%%+*}"
-          BUILD_NUMBER="${TAG##*+}"
+          BUILD_NAME="${TAG%%+*}"   # 26.08.28+121 -> 26.08.28  (versionName)
+          BUILD_NUMBER="${TAG##*+}" # 26.08.28+121 -> 121       (versionCode)
           echo "Building version ${BUILD_NAME} (build ${BUILD_NUMBER})"
-          flutter build apk --release \
+          mkdir -p build
+          {
+            echo "RELEASE_TAG_VALIDATED=${TAG}"
+            echo "BUILD_NAME=${BUILD_NAME}"
+            echo "BUILD_NUMBER=${BUILD_NUMBER}"
+          } > build/release_version.env
+
+      - name: Build the Android App Bundle with the version from the tag
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          . build/release_version.env
+          flutter build appbundle --release \
             --build-name="$BUILD_NAME" \
             --build-number="$BUILD_NUMBER"
+
+      - name: Build the universal APK from the app bundle
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          # Derived from the bundle so the GitHub APK and the Play artefact come
+          # from the same build and carry the same version code.
+          android-app-bundle build-universal-apk \
+            --bundle 'build/**/outputs/**/*.aab' \
+            --ks "$CM_KEYSTORE_PATH" \
+            --ks-pass "$CM_KEYSTORE_PASSWORD" \
+            --ks-key-alias "$CM_KEY_ALIAS" \
+            --key-pass "$CM_KEY_PASSWORD"
+
+      - name: Collect the release artefacts
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          . build/release_version.env
+
+          # `sed -n 1p` rather than `head -1`: head closes the pipe early and
+          # SIGPIPE would trip `set -o pipefail`.
+          AAB="$(find build -type f -name '*.aab' | sed -n 1p)"
+          AAB_COUNT="$(find build -type f -name '*.aab' | wc -l | tr -d ' ')"
+          APK="$(find build -type f -name '*-universal.apk' | sed -n 1p)"
+          if [ -z "${APK}" ]; then
+            APK="$(find build -type f -name '*.apk' | sed -n 1p)"
+          fi
+          APK_COUNT="$(find build -type f -name '*.apk' | wc -l | tr -d ' ')"
+
+          if [ "$AAB_COUNT" != "1" ] || [ -z "$AAB" ]; then
+            echo "ERROR: expected exactly 1 .aab under build/, found ${AAB_COUNT}:"
+            find build -type f -name '*.aab'
+            exit 1
+          fi
+          if [ "$APK_COUNT" != "1" ] || [ -z "$APK" ]; then
+            echo "ERROR: expected exactly 1 .apk under build/, found ${APK_COUNT}:"
+            find build -type f -name '*.apk'
+            echo "release.yml attaches the FIRST .apk artefact to the GitHub release,"
+            echo "so more than one would make the released binary non-deterministic."
+            exit 1
+          fi
+
+          OUT="build/release_artifacts"
+          rm -rf "$OUT"
+          mkdir -p "$OUT"
+          BASE="SlimSocial-${BUILD_NAME}-${BUILD_NUMBER}"
+          cp "$AAB" "${OUT}/${BASE}.aab"
+          cp "$APK" "${OUT}/${BASE}.apk"
+          MAPPING="$(find build -type f -name 'mapping.txt' | sed -n 1p)"
+          if [ -n "$MAPPING" ]; then
+            cp "$MAPPING" "${OUT}/mapping.txt"
+          else
+            echo "note: no mapping.txt produced (code shrinking is probably off)."
+          fi
+          ls -lh "$OUT"
+
+      - name: Publish the app bundle to Google Play (internal track, draft)
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [ ! -f build/release_version.env ]; then
+            echo "ERROR: build/release_version.env missing - refusing to publish."
+            exit 1
+          fi
+          . build/release_version.env
+          # Re-validated so this step can never publish from a build that did
+          # not pass the tag check above.
+          if [[ ! "${RELEASE_TAG_VALIDATED:-}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\+[0-9]+$ ]]; then
+            echo "ERROR: no validated release tag - refusing to publish to Google Play."
+            exit 1
+          fi
+          if [ -z "${GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS:-}" ]; then
+            echo "ERROR: GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS is not set."
+            echo "Add the Codemagic environment variable group that holds it to"
+            echo "environment.groups in codemagic.yaml (currently: 'google_play')."
+            exit 1
+          fi
+          AAB="build/release_artifacts/SlimSocial-${BUILD_NAME}-${BUILD_NUMBER}.aab"
+          echo "Publishing ${AAB} as versionCode ${BUILD_NUMBER} to the internal track (draft)"
+          # `@env:` is CLI-tools syntax and is correct here; it would be wrong
+          # inside a `publishing: google_play:` YAML block, which uses $VAR.
+          google-play bundles publish \
+            --credentials @env:GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS \
+            --bundle "$AAB" \
+            --track internal \
+            --in-app-update-priority 0 \
+            --draft
     artifacts:
-      - SlimSocial_for_Facebook/build/**/outputs/**/*.apk
+      # Relative to the clone root, so the SlimSocial_for_Facebook/ prefix stays
+      # even though working_directory is that folder. This directory is wiped
+      # and repopulated by the collect step: one .aab, one .apk, maybe mapping.
+      - SlimSocial_for_Facebook/build/release_artifacts/*

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -90,9 +90,14 @@ workflows:
           #!/usr/bin/env bash
           set -euo pipefail
           . build/release_version.env
+          # SENTRY_DSN comes from the Codemagic environment variable group.
+          # When it is empty the app compiles the reporting out entirely and
+          # behaves exactly as a build without it, so an unset variable is a
+          # quiet no-op rather than a broken release.
           flutter build appbundle --release \
             --build-name="$BUILD_NAME" \
-            --build-number="$BUILD_NUMBER"
+            --build-number="$BUILD_NUMBER" \
+            --dart-define=SENTRY_DSN="${SENTRY_DSN:-}"
 
       - name: Build the universal APK from the app bundle
         script: |

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -27,6 +27,17 @@ workflows:
     # min). Raising this alone would let GitHub give up on a live build.
     max_build_duration: 45
     working_directory: SlimSocial_for_Facebook
+    # A tag push starts this build directly, so no API token is needed. CM_TAG
+    # is populated on a tag-triggered build and is what the version step reads.
+    # Because of this, .github/workflows/release.yml no longer starts a build on
+    # tag push - two builds racing to upload the same version code to Play is
+    # the failure this file exists to prevent.
+    triggering:
+      events:
+        - tag
+      tag_patterns:
+        - pattern: '*'
+          include: true
     environment:
       android_signing:
         # Reference name of the upload keystore in Codemagic > Team settings >


### PR DESCRIPTION
Brings `master` onto the release pipeline the maintenance release (`26.08.28+121`) shipped through, and wires up the DSN that [#323](https://github.com/rignaneseleo/SlimSocial-for-Facebook/pull/323) needs to do anything.

## Why

The Codemagic build read `pubspec.yaml` for its version. `pubspec` always describes the *previous* release, so the last attempt submitted version code 119 — which Play had already consumed — and was rejected. Version codes are burned permanently, even by a draft that reached nobody.

## What changes

- **The tag is the only source of the version.** `26.08.29+122` builds version name `26.08.29`, code `122`. There is deliberately no `pubspec` fallback: a build that cannot find a valid tag stops rather than guessing a number Play will reject.
- **The tag starts the build directly**, so no API token is required. `release.yml` no longer fires on tags — two builds racing to upload the same version code is the failure being fixed — but stays available to run by hand, which is the only path that attaches an APK to a GitHub release.
- **One build produces** the bundle published to the Play internal track as a draft, the universal APK, and `mapping.txt`, all carrying the same version code. Exactly one APK is emitted, because the GitHub release picks the first artefact ending in `.apk` with no tie-break.
- **`SENTRY_DSN` is passed at build time** from the Codemagic environment, never stored in the repo. Unset compiles reporting out entirely, so a build without it behaves exactly as today.

## Verification

- `flutter build apk --debug` with a DSN define — succeeds
- `flutter build apk --debug` with none — succeeds
- `flutter test` — 306 passing

## Before the next release

- Add `SENTRY_DSN` to the Codemagic environment variable group (create the SlimSocial project in Sentry first — the `leorigna` org has none).
- Switch the Codemagic app to **codemagic.yaml** (App settings → Build). Until then the UI workflow runs and the tag is not authoritative.
- Confirm the group holding `GOOGLE_PLAY_SERVICE_ACCOUNT_CREDENTIALS` is really named `google_play`, and the signing identity `keystore_reference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)