### PR TITLE
Stop the webview callbacks touching a disposed screen

### DIFF
--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -82,6 +82,12 @@ class _HomePageState extends ConsumerState<HomePage> {
           onNavigationRequest: onNavigationRequest,
           onWebResourceError: onWebResourceError,
           onPageStarted: (String url) async {
+            //the controller outlives this State: its callbacks keep firing for
+            //a load already in flight after the widget is gone, and setState
+            //then dereferences a null element and takes the app down with it.
+            //Checked again after each await, because the widget can go away
+            //while one is outstanding.
+            if (!mounted) return;
             _retryPolicy.onNavigationStarted();
             setState(() {
               isScontentUrl = Uri.parse(url).host.contains("scontent");
@@ -89,23 +95,27 @@ class _HomePageState extends ConsumerState<HomePage> {
 
             //inject the css as soon as the DOM is loaded
             await injectCss();
+            if (!mounted) return;
 
             //the dark theme's text colours ship in that css, but the surfaces
             //they sit on are repainted by the script below. Running it only at
             //page finish leaves pale text on still-white cards for as long as
             //the rest of the page takes to arrive.
             await injectDarkTheme();
+            if (!mounted) return;
 
             //re-read the zoom, so changing it in the settings takes effect on
             //the next load instead of needing the app restarted
             await _androidController?.setTextZoom(PrefController.getTextZoom());
           },
           onPageFinished: (String url) async {
+            if (!mounted) return;
             _retryPolicy.onNavigationFinished();
             await runJs();
             if (kDebugMode) debugPrint(url);
           },
           onProgress: (int progress) {
+            if (!mounted) return;
             setState(() {
               isLoading = progress < 100;
             });
@@ -551,6 +561,9 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   Future<void> injectCss() async {
+    //reads the theme off this element's context, so it is only safe while the
+    //widget is still in the tree
+    if (!mounted) return;
     final accent = cssColorFromColor(Theme.of(context).colorScheme.primary);
 
     final sheets = <String, String>{

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -1,7 +1,7 @@
 name: slimsocial_for_facebook
 description: Webview to securely navigate Facebook
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-version: 26.08.29+122
+version: 26.08.30+123
 
 environment:
   sdk: ">=3.7.0 <4.0.0"


### PR DESCRIPTION
Fixes [SLIMSOCIAL-3](https://leorigna.sentry.io/issues/SLIMSOCIAL-3) — a **fatal, unhandled** crash reported by a real install within an hour of the `26.08.29+122` rollout starting.

```
TypeError: Null check operator used on a null value
  at _HomePageState._initWebViewController.<fn> (home_page.dart:86)
  at State.setState (framework.dart:1219)
```

Samsung Galaxy J5, Android 9, `armeabi-v7a`, low-end device class.

## Cause

The `WebViewController` outlives the `State`. A load already in flight keeps firing `onPageStarted` / `onProgress` / `onPageFinished` after the widget is gone, and `setState` then dereferences `_element!` — which is null once disposed — killing the app. The theme lookup at the top of `injectCss` has the same problem: it reads the element's `context`.

`messenger_page` was given exactly this treatment in [#323](https://github.com/rignaneseleo/SlimSocial-for-Facebook/pull/323); `home_page` was deliberately left out, on the argument that a root route never unmounts. Production disproved that in under a day — worth remembering that "effectively unreachable" is a hypothesis, not a fact.

## Fix

Every webview callback checks `mounted` before touching `setState` or `context`, and checks **again after each await**, since the widget can be disposed while one is outstanding. `onPageFinished` is guarded too, though it had not been seen crashing.

## Verification

- `flutter test` — 306 passing
- `flutter analyze` — zero errors, zero warnings
- `flutter build apk --debug` — succeeds

`pubspec` bumped to `26.08.30+123`.

## Note on the rollout

`122` is live at 10%. This is the first crash the new reporting caught, which is the system working as intended — but it is fatal, so it argues for shipping `123` before widening the rollout rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)