### PR TITLE
Messenger made usable again, pinch zoom, selectable posts, clean shares, no feed jump

### DIFF
--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -22,6 +22,7 @@ import 'package:slimsocial_for_facebook/utils/dark_theme.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/load_retry_policy.dart';
 import 'package:slimsocial_for_facebook/utils/telemetry.dart';
+import 'package:slimsocial_for_facebook/utils/url_cleaner.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -69,6 +70,15 @@ class _HomePageState extends ConsumerState<HomePage> {
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setBackgroundColor(FacebookColors.darkBlue)
       ..setUserAgent(PrefController.getUserAgent())
+      //Facebook ships `maximum-scale=1, user-scalable=no` in its viewport, and
+      //that meta tag is the only thing standing between the reader and pinch
+      //zoom: the webview's own gesture is already on, because
+      //webview_flutter_android's controller sets `builtInZoomControls` itself
+      //(android_webview_controller.dart:91 in 4.3.4) and Android's
+      //`setSupportZoom` defaults to true. Asked for explicitly all the same —
+      //`webview_flutter_android` is pinned as `any` here, so that default is
+      //not ours to rely on. CustomJs.unlockZoomFunc does the other half.
+      ..enableZoom(true)
       ..addJavaScriptChannel(
         kAdCountChannelName,
         onMessageReceived: onAdCountMessage,
@@ -95,6 +105,15 @@ class _HomePageState extends ConsumerState<HomePage> {
 
             //inject the css as soon as the DOM is loaded
             await injectCss();
+            if (!mounted) return;
+
+            //before the dark theme, because unlocking the viewport reflows the
+            //page and the theme script reads colours back out of it
+            await runIsolatedJs(
+              'zoom unlock',
+              () => _controller
+                  .runJavaScript(CustomJs.whenDomReady(CustomJs.unlockZoomFunc())),
+            );
             if (!mounted) return;
 
             //the dark theme's text colours ship in that css, but the surfaces
@@ -275,6 +294,27 @@ class _HomePageState extends ConsumerState<HomePage> {
     //is collected as a breadcrumb on anything reported afterwards
     if (kDebugMode) debugPrint("onNavigationRequest: ${request.url}");
 
+    //Facebook's mobile web opens its own video player through an `fb://` link
+    //meant for the native app. Nothing below handles a scheme that is not http,
+    //so these used to fall all the way through to the Custom Tab — which either
+    //hands the reader to the official Facebook app or, if it is not installed,
+    //does nothing at all. Either way the tap is lost. Sent back to the web
+    //address for the same video instead.
+    //
+    //Skipped in basic mode: `/reel/` is a touch-layout address, mbasic does not
+    //serve it, and navigating the one webview to a page that 404s would strand
+    //the reader somewhere worse than where they started.
+    if (uri.scheme == "fb" && !(sp.getBool(SpKeys.useMbasic) ?? false)) {
+      final target = facebookAppLinkTarget(
+        uri,
+        host: Uri.parse(PrefController.getHomePage()).host,
+      );
+      if (target != null) {
+        await _controller.loadRequest(target);
+        return NavigationDecision.prevent;
+      }
+    }
+
     for (final other in kPermittedHostnamesFb) {
       if (uri.host.endsWith(other)) {
         return NavigationDecision.navigate;
@@ -401,7 +441,12 @@ class _HomePageState extends ConsumerState<HomePage> {
               switch (item) {
                 case "share_url":
                   final url = await _controller.currentUrl();
-                  if (url != null) Share.share(url);
+                  //a Facebook address picked up off the feed carries `fbclid`,
+                  //`mibextid` and friends, and those identify the person who
+                  //did the sharing rather than the post being shared. Sending
+                  //them on hands that to every recipient and to whatever app
+                  //they paste it into.
+                  if (url != null) Share.share(stripTrackingParams(url));
                   break;
                 case "refresh":
                   _controller.reload();
@@ -570,6 +615,7 @@ class _HomePageState extends ConsumerState<HomePage> {
       'slim-messenger-download': CustomCss.removeMessengerDownloadCss.code,
       'slim-browser-notice': CustomCss.removeBrowserNotSupportedCss.code,
       'slim-app-upsell': CustomCss.hideAppUpsellCss.code,
+      'slim-selectable': CustomCss.selectableContentCss.code,
       'slim-ad-placeholder': CustomCss.adPlaceholderCss.code,
       'slim-user-sheet':
           CustomCss.buildFacebookCss(PrefController.getUserCustomCss()),

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -168,7 +168,12 @@ class _HomePageState extends ConsumerState<MessengerPage> {
     if (!mounted) return NavigationDecision.prevent;
 
     // open on webview
-    print("Launching external url: ${request.url}");
+    //the address of a link the user tapped is their browsing, and this line
+    //used to run in release builds through a bare `print`: Sentry collects
+    //stdout as a breadcrumb, so every conversation and every link opened out of
+    //Messenger travelled with the next report. Gated the way the feed's own
+    //navigation logging in home_page.dart already was.
+    if (kDebugMode) debugPrint("Launching external url: ${request.url}");
     launchInAppUrl(context, request.url);
     return NavigationDecision.prevent;
   }

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -12,6 +12,7 @@ import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
 import 'package:slimsocial_for_facebook/main.dart';
 import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
+import 'package:slimsocial_for_facebook/utils/fb_navigation.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
@@ -153,6 +154,15 @@ class _HomePageState extends ConsumerState<MessengerPage> {
         return NavigationDecision.navigate;
       }
     }
+
+    //Signing in belongs to this screen even though it is served from
+    //facebook.com. Messenger authenticates against Facebook, so the login-code
+    //prompt is a facebook.com page — and the branch below, which exists for a
+    //Facebook link tapped inside a conversation, used to send it to the feed.
+    //The screen closed itself half way through authenticating and the prompt
+    //surfaced in a webview that could not finish it, so Messenger could not be
+    //signed into at all.
+    if (isFacebookAuthUrl(uri)) return NavigationDecision.navigate;
 
     for (final other in kPermittedHostnamesFb) {
       if (uri.host.endsWith(other)) {

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -283,6 +283,7 @@ class _HomePageState extends ConsumerState<MessengerPage> {
 
     final sheets = <String, String>{
       'slim-messenger-adapt': CustomCss.adaptMessengerPageCss.code,
+      'slim-messenger-list-height': CustomCss.messengerListHeightCss.code,
       'slim-user-sheet':
           CustomCss.buildMessengerCss(PrefController.getUserCustomCss()),
     };

--- a/SlimSocial_for_Facebook/lib/utils/ad_filter.dart
+++ b/SlimSocial_for_Facebook/lib/utils/ad_filter.dart
@@ -361,6 +361,10 @@ const List<String> kPeopleYouMayKnowLabels = [
 /// placeholder: the running total reported over [kAdCountChannelName] is how
 /// the app shows the filter is working.
 ///
+/// Collapsing a post above the viewport takes the height it gave up off the
+/// scroll offset in the same turn, so the feed does not slide under a reader who
+/// is scrolling while the pass runs.
+///
 /// The script also reports on its own health over [kDiagnosticsChannelName]:
 /// the selectors here match markup Facebook rewrites without warning, and when
 /// they stop matching nothing throws and nothing crashes. Those signals carry
@@ -596,8 +600,75 @@ String adFilterScript({
     return seen !== null && +seen === rendered;
   }
 
+  // Which element actually scrolls has to be found rather than assumed: the
+  // touch layout renders the feed inside a div[data-type="vscroller"] that
+  // scrolls on its own, while the app also scrolls the document itself — the
+  // screens save and restore position through `getScrollPosition` and
+  // `scrollTo`, which are the document's. An ancestor only qualifies if it is
+  // both allowed to scroll and genuinely overflowing: an `overflow-y: auto` box
+  // that fits its content moves nothing, and correcting its offset would throw
+  // the correction away while the real scroller keeps the jump.
+  function scrollerFor(post) {
+    var node = post.parentElement;
+    while (node && node !== document.body && node !== document.documentElement) {
+      var overflowY = '';
+      try {
+        overflowY = window.getComputedStyle(node).overflowY;
+      } catch (e) {}
+      var scrollable =
+        overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay';
+      if (scrollable && node.scrollHeight > node.clientHeight) {
+        return { el: node, win: null };
+      }
+      node = node.parentElement;
+    }
+    // The document scroller reports its offset on the window, not on itself.
+    return {
+      el: document.scrollingElement || document.documentElement,
+      win: window
+    };
+  }
+
   function collapse(post) {
     post.classList.add('slim-ad-handled');
+
+    // Taking a post out of layout above the viewport used to slide the whole
+    // feed up under the reader's thumb. That is the common case rather than the
+    // corner one: the filter re-runs as posts stream in below and the observer
+    // fires while the reader scrolls, so the advert being retired has usually
+    // been scrolled past already — and a sponsored post is several hundred
+    // pixels leaving layout at once, which lands the reader mid-way through a
+    // different post. Measured here, given back to the offset after the hide.
+    var anchor = null;
+    try {
+      var scroller = scrollerFor(post);
+      var viewportTop = scroller.win
+        ? 0
+        : scroller.el.getBoundingClientRect().top;
+      // Two of the three positions need nothing done. A post below the fold
+      // takes its height out of a region the reader cannot see. A post still on
+      // screen is the one being looked at, and there is no offset that both
+      // removes it and leaves the view still. Only a post entirely above the
+      // viewport shortens the run of content the offset is measured against,
+      // and that is the one that drags the page.
+      if (post.getBoundingClientRect().bottom <= viewportTop) {
+        // Both numbers are read now, before anything is hidden. The offset
+        // matters as much as the height: Android WebView ships Chromium's
+        // scroll anchoring switched on (`overflow-anchor` defaults to `auto`,
+        // and nothing here sets it otherwise), so the engine may move the
+        // offset by itself the moment layout is recomputed. Reading the offset
+        // afterwards and subtracting from *that* counted the engine's own
+        // correction a second time and threw the feed a whole advert further up
+        // than it started — measured in Chromium 148 on both scroller kinds,
+        // and again, without anchoring, whenever the reader sat near the end of
+        // the feed and the engine clamped the offset to the shorter document.
+        anchor = {
+          scroller: scroller,
+          height: scroller.el.scrollHeight,
+          offset: scroller.win ? scroller.win.scrollY : scroller.el.scrollTop
+        };
+      }
+    } catch (e) {}
 
     // The post is removed from layout below, so it occupies nothing. Telling
     // the virtualising scroller it is still 60px tall leaves its model
@@ -632,6 +703,47 @@ String adFilterScript({
     // the running total the app reports is a better way to show the filter is
     // working than a placeholder in the feed.
     post.style.display = 'none';
+
+    // Hiding the advert is the job; not jumping is only the improvement — so
+    // the restore is guarded on its own, and a scroller that refuses to be
+    // measured or written still loses its advert.
+    try {
+      if (anchor) {
+        // Asking for scrollHeight here forces the layout the hide just
+        // invalidated. That is deliberate, and it has to happen in this same
+        // synchronous block: a correction deferred to a later frame is a
+        // correction the reader watches happen.
+        var lost = anchor.height - anchor.scroller.el.scrollHeight;
+        if (lost > 0) {
+          var win = anchor.scroller.win;
+          // Written as an absolute position derived from the pre-hide offset,
+          // never as a delta applied to whatever the offset reads now. The
+          // content above the viewport got `lost` shorter, so this is where the
+          // offset has to land for the view to hold still — and stating it
+          // absolutely means it lands there whether or not the engine already
+          // moved the offset on its own. See the note on scroll anchoring where
+          // the anchor is taken.
+          var next = anchor.offset - lost;
+          // A scroller can shed more height than there was offset above it —
+          // the feed's first advert, with the reader barely past it — and a
+          // negative offset bounces on one engine and is ignored on the next.
+          if (next < 0) next = 0;
+          if (win) {
+            // `scroll-behavior: smooth` anywhere up the tree would turn the
+            // two-argument form into an animation, which is the jump this is
+            // meant to prevent, arriving slowly. The object form can say
+            // otherwise; older WebViews that reject it fall back.
+            try {
+              win.scrollTo({ top: next, left: win.scrollX, behavior: 'instant' });
+            } catch (e) {
+              win.scrollTo(win.scrollX, next);
+            }
+          } else {
+            anchor.scroller.el.scrollTop = next;
+          }
+        }
+      }
+    } catch (e) {}
   }
 
   function isPeopleYouMayKnow(post) {
@@ -667,8 +779,9 @@ String adFilterScript({
       if (post.classList.contains('slim-ad-checked')) continue;
 
       // A friend carousel is not an advert, but it is taken out of the page the
-      // same way: the scroller's bookkeeping is about the hole left behind, not
-      // about why the post went.
+      // same way: the scroller's bookkeeping, and the scroll correction for the
+      // height that disappears, are about the hole left behind rather than about
+      // why the post went.
       if (isPeopleYouMayKnow(post)) {
         collapse(post);
         handled++;

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -242,6 +242,47 @@ class CustomCss {
         ' { display: none !important; }',
   );
 
+  /// Hands the post text back to the reader: selectable, and so copyable.
+  ///
+  /// The touch layout declares `user-select: none` across the feed, so a long
+  /// press on a post yields nothing — no handles, no copy. That takes with it
+  /// every reason someone presses a post in the first place: a quoted
+  /// paragraph, an address, a phone number posted in a group. The same layout
+  /// sets `pointer-events: none` on feed images, which is why a long press on a
+  /// photo never reaches the browser at all and it never offers to save or
+  /// share it.
+  ///
+  /// Both prefixes are spelled out. Current Chromium reads the unprefixed
+  /// `user-select`; older Android WebViews only ever knew
+  /// `-webkit-user-select`, and those are exactly the devices whose owners are
+  /// least able to fall back to the native app. `!important` because what is
+  /// being overridden is Facebook's own author rule, not a default.
+  ///
+  /// `.native-text` is the post's text wrapper — see [centerTextPostsCss] for
+  /// why the message body has no selector of its own — and the descendant rule
+  /// catches the `span` runs inside it.
+  ///
+  /// Scoped to the post container on purpose, and that scoping is the whole
+  /// design of the rule: making the document selectable turns every mis-tap on
+  /// the app's own chrome into a text selection, complete with handles to
+  /// dismiss, which is a worse daily annoyance than the one being fixed.
+  /// [removeMessengerDownloadCss] already carries a far narrower version of the
+  /// selection half, for `input` elements only.
+  ///
+  /// Deliberately not in [cssList]: like [hideAppUpsellCss], this is a
+  /// structural fix rather than a preference, so there is nothing to toggle.
+  static MyCss selectableContentCss = MyCss(
+    key: 'selectable_content',
+    description: 'Let post text be selected and photos be long-pressed',
+    defaultEnabled: true,
+    code: 'div[data-tracking-duration-id] .native-text, '
+        'div[data-tracking-duration-id] .native-text * '
+        '{ -webkit-user-select: text !important; '
+        'user-select: text !important; } '
+        'div[data-tracking-duration-id] img '
+        '{ pointer-events: auto !important; }',
+  );
+
   static MyCss hideAdsAndPeopleYouMayKnowCss = MyCss(
     key: 'hideAdsAndPeopleYouMayKnow',
     description: 'Hide ads and people you may know',

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -301,6 +301,64 @@ class CustomCss {
         '-webkit-tap-highlight-color: rgba(0, 0, 0, 0); }',
   );
 
+  /// Gives Messenger's conversation list the height it forgot to take.
+  ///
+  /// ## The bug
+  ///
+  /// Measured on a Pixel 10 Pro at the 349px layout viewport a phone gives this
+  /// app: the conversation list resolves to **100px tall**, and so do its three
+  /// nearest ancestors, while the scroll container inside it holds 2168px of
+  /// conversations. Sixteen conversations were in the document and one was
+  /// reachable. The list could not be scrolled to the rest, because the box
+  /// doing the clipping was not the box that scrolls.
+  ///
+  /// It is Messenger's own layout collapsing, not ours. Every ancestor from the
+  /// list up to `body` was checked against every selector this app injects, at
+  /// all eighteen levels: nothing of ours matched. Nothing *declares* that
+  /// 100px either — it is what the flex chain resolves to when a `flex-grow: 0`
+  /// item in the middle of it is asked for its content height, and the content
+  /// it measures is a virtualised list whose own height comes from the parent.
+  /// A newer user agent does not change it, so it is not the 2018 agent either.
+  ///
+  /// ## The fix, and the two ways it goes wrong
+  ///
+  /// Only the chain is expanded, by letting each ancestor that contains the
+  /// list grow and sizing it to its content. Both of the obvious extras were
+  /// tried on a device and both broke it:
+  ///
+  ///  * `overflow: visible` on the ancestors — the chain expanded and the list
+  ///    stopped scrolling entirely. Messenger's own scroller is one of those
+  ///    descendants and it already carries `overflow-y: auto`; overriding
+  ///    overflow up the chain takes the scroller away from the virtualised list
+  ///    that depends on it. So **no overflow property is touched here at all**.
+  ///  * `height: 100%` instead of `height: auto` — every ancestor then took its
+  ///    parent's full height and the content ran past the viewport with nothing
+  ///    to scroll it.
+  ///
+  /// Verified after the change: the list went from 100px to 548px, the scroll
+  /// container kept `overflow-y: auto` with 2168px of content, and setting its
+  /// offset to 400 moved it to 400.
+  ///
+  /// `:has()` needs Chromium 105. On an older WebView the whole selector list is
+  /// invalid and dropped, which costs the fix and nothing else — so it is kept
+  /// in a rule of its own, away from the `[role="grid"]` rule below, exactly as
+  /// [hideStoriesCss] keeps its own `:has()` selectors separate.
+  ///
+  /// Deliberately not in [cssList]: structural, like [hideAppUpsellCss], not a
+  /// preference.
+  static MyCss messengerListHeightCss = MyCss(
+    key: 'messenger_list_height',
+    description: 'Give the Messenger conversation list its full height',
+    defaultEnabled: true,
+    code: 'div:has(> [role="grid"]), div:has(> div > [role="grid"]), '
+        'div:has(> div > div > [role="grid"]), '
+        'div:has(> div > div > div > [role="grid"]) '
+        '{ flex-grow: 1 !important; flex-basis: auto !important; '
+        'min-height: 0 !important; max-height: none !important; '
+        'height: auto !important; } '
+        '[role="grid"] { min-height: 0 !important; max-height: none !important; }',
+  );
+
   static MyCss adaptMessengerPageCss = MyCss(
     key: 'adaptMessenger',
     description: 'Adapt messenger',

--- a/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
+++ b/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
@@ -1,0 +1,81 @@
+/// First path segments of Facebook's sign-in and account-verification flow.
+///
+/// One entry per *first* segment, matched exactly rather than as a prefix, so
+/// `/login/checkpoint/` matches on `login` while a page merely starting with
+/// those letters — `/loginhelp`, a page named `securityreview` — does not.
+///
+/// `login.php` and `checkpoint` are the two the flow actually starts from; the
+/// rest are the branches it can take once it has decided the sign-in needs
+/// confirming.
+const Set<String> _kAuthFirstSegments = {
+  'authenticate',
+  'checkpoint',
+  'confirmemail.php',
+  'login',
+  'login.php',
+  'recover',
+  'security',
+  'two_factor',
+};
+
+/// Two-segment prefixes of the same flow.
+///
+/// These lead with a segment that is emphatically *not* authentication on its
+/// own — `/privacy/` and `/dialog/` are ordinary pages, and `/unified/` fronts
+/// several unrelated surfaces — so matching them needs the second segment too.
+const List<List<String>> _kAuthSegmentPairs = [
+  ['unified', 'login_via'],
+  ['privacy', 'consent'],
+  ['dialog', 'oauth'],
+  ['x', 'oauth'],
+];
+
+/// Whether [uri] belongs to Facebook's own sign-in flow rather than being a
+/// page the reader asked to see.
+///
+/// ## Why this has to exist
+///
+/// Messenger authenticates against `facebook.com`, not `messenger.com`. Signing
+/// in on the Messenger screen therefore navigates *out* of the Messenger host
+/// and into a checkpoint page — the one that asks for a login code — and only
+/// comes back once the code has been accepted.
+///
+/// The Messenger screen sends any `facebook.com` address to the feed, because
+/// that is what a Facebook link tapped inside a conversation should do. Sign-in
+/// looked exactly like such a link, so the screen closed itself half way
+/// through authenticating: the code prompt arrived in the feed's webview, which
+/// had no idea what to do with it, and Messenger could not be signed into at
+/// all.
+///
+/// Measured on a device, the flow walks `/checkpoint/start/`, `/checkpoint/`,
+/// `/login/checkpoint/` and `/unified/login_via/app/` — hence both tiers of
+/// matching above.
+///
+/// Deliberately narrow. Anything not recognised here keeps the old behaviour of
+/// handing the address to the feed, which is the right answer for every
+/// ordinary Facebook link and the safe answer for one this does not know about:
+/// a missed auth path costs a failed sign-in, while a content page wrongly kept
+/// here would strand the reader on a page the Messenger screen cannot navigate
+/// away from.
+bool isFacebookAuthUrl(Uri uri) {
+  //`pathSegments` yields a trailing empty string for a path ending in `/`, and
+  //an empty list for `/` itself, so the empties go before anything is compared.
+  final segments = uri.pathSegments
+      .where((segment) => segment.isNotEmpty)
+      .map((segment) => segment.toLowerCase())
+      .toList();
+
+  if (segments.isEmpty) return false;
+
+  if (_kAuthFirstSegments.contains(segments.first)) return true;
+
+  for (final pair in _kAuthSegmentPairs) {
+    if (segments.length >= 2 &&
+        segments[0] == pair[0] &&
+        segments[1] == pair[1]) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -48,6 +48,113 @@ class CustomJs {
     ''';
   }
 
+  /// Builds JavaScript that hands pinch-to-zoom back to the reader.
+  ///
+  /// Facebook ships `width=device-width, initial-scale=1, maximum-scale=1,
+  /// user-scalable=no` as its viewport, and those last two clauses are exactly
+  /// what the browser reads as "this page does not zoom". The text-zoom setting
+  /// is no substitute: it reflows text and leaves an image, a screenshot
+  /// somebody posted, or a fixed-width table at whatever size it arrived in.
+  ///
+  /// Only the clauses that block the gesture are dropped. `minimum-scale` goes
+  /// with them because a `minimum-scale=1` is what stops the page being pinched
+  /// back out again. Every clause we do not recognise is copied through in
+  /// place: replacing the whole content string would take `width=device-width`
+  /// with it, and the page would come back laid out for a 980px desktop.
+  ///
+  /// The rewrite cannot be a one-shot. Metas are queried as a list because an
+  /// in-page navigation can leave a second viewport tag behind, and the
+  /// observer is there because that same navigation can replace the tag after
+  /// this script has already finished — the one we fixed is gone, and its
+  /// replacement carries `user-scalable=no` again.
+  ///
+  /// Everything is swallowed by a try/catch: on iOS a page exception comes back
+  /// through `runJavaScript`, and a throw here would take the injection steps
+  /// queued behind it down as well.
+  ///
+  /// This only lifts the lock the page puts on itself. The WebView has to allow
+  /// the gesture too (`enableZoom`), or none of this reaches the user.
+  static String unlockZoomFunc() {
+    return """
+(function () {
+  try {
+    var MARK = 'data-slim-zoom';
+
+    function unlockedContent(content) {
+      var out = [];
+      var sawUserScalable = false;
+      var clauses = content.split(',');
+      for (var i = 0; i < clauses.length; i++) {
+        var clause = clauses[i].trim();
+        if (!clause) continue;
+        var key = clause.split('=')[0].trim().toLowerCase();
+        if (key === 'maximum-scale' || key === 'minimum-scale') continue;
+        if (key === 'user-scalable') {
+          // Rewritten where it stands rather than dropped and re-appended, so
+          // a viewport that spells out its own order keeps it.
+          out.push('user-scalable=yes');
+          sawUserScalable = true;
+          continue;
+        }
+        out.push(clause);
+      }
+      if (!sawUserScalable) out.push('user-scalable=yes');
+      return out.join(', ');
+    }
+
+    function unlockAll() {
+      var metas = document.querySelectorAll('meta[name="viewport"]');
+      for (var i = 0; i < metas.length; i++) {
+        var meta = metas[i];
+        // Same guard as the stylesheet injection: this runs on every
+        // navigation, and Facebook navigates in-page constantly.
+        if (meta.getAttribute(MARK) === '1') continue;
+        var current = meta.getAttribute('content') || '';
+        var next = unlockedContent(current);
+        meta.setAttribute(MARK, '1');
+        // Assigning an identical value still produces a mutation record, and
+        // the observer below clears the mark before it re-runs: writing
+        // unconditionally is an endless ping-pong between the two.
+        if (next !== current) meta.setAttribute('content', next);
+      }
+    }
+
+    unlockAll();
+
+    // Kept on `window` for the same reason as the ad observer: a fresh
+    // injection cannot otherwise tell that one is already watching, and every
+    // page load would leave another observer behind on the same head.
+    if (!window.slimViewportObserver) {
+      window.slimViewportObserver = new MutationObserver(function (records) {
+        for (var i = 0; i < records.length; i++) {
+          // A `content` that has been written again can put maximum-scale
+          // back, so the mark from the previous pass has to go or the tag is
+          // skipped for the rest of the page's life.
+          if (records[i].type === 'attributes') {
+            records[i].target.removeAttribute(MARK);
+          }
+        }
+        unlockAll();
+      });
+
+      // `document.head` is still null while the head is being parsed, and
+      // injection starts from onPageStarted; documentElement exists from the
+      // first byte and its subtree covers the head once it arrives.
+      window.slimViewportObserver.observe(
+        document.head || document.documentElement,
+        {
+          childList: true,
+          subtree: true,
+          attributes: true,
+          attributeFilter: ['content']
+        }
+      );
+    }
+  } catch (e) {}
+})();
+""";
+  }
+
   static String exampleJs = """
 javascript:function foo() {
 	     document.body.innerHTML = '';

--- a/SlimSocial_for_Facebook/lib/utils/url_cleaner.dart
+++ b/SlimSocial_for_Facebook/lib/utils/url_cleaner.dart
@@ -1,0 +1,247 @@
+/// Query parameters that describe *who is reading* or *how they got here*
+/// rather than what they are looking at.
+///
+/// Facebook rewrites nearly every link in the feed to carry a few of these, so
+/// a url copied out of the app — or handed to a Custom Tab, or shared to
+/// another app — otherwise carries the reading session with it. Dropping them
+/// is safe in the direction that matters: a Facebook permalink resolves to the
+/// same story without any of them, because the story id lives in the path or in
+/// `story_fbid`/`id`, never in the tracking blob.
+///
+/// Only ever add a parameter here that is genuinely *about the reader*. A
+/// parameter that turns out to select content is not merely useless to strip,
+/// it breaks the link, and the failure looks like Facebook being down rather
+/// than like this list being wrong — which is why `story_fbid`, `id`, `v` and
+/// `sk` (the feed-order suffix this app itself appends) are all absent.
+const List<String> kTrackingParams = [
+  // Facebook's own click and referral instrumentation.
+  //
+  // `ref`, `__cft__`, `__tn__` and `__xts__` are the awkward ones: they are on
+  // the shared links people actually paste, and they look load-bearing because
+  // they are long and opaque. They are not — they encode the *reading session*
+  // (which surface the click came from, which ranking pass produced the item),
+  // and the same permalink opens fine with them removed. `__cft__` and
+  // `__xts__` additionally arrive indexed, as `__cft__[0]` — sometimes with the
+  // brackets percent-escaped — so they are listed here unindexed and matched on
+  // the name up to the bracket.
+  'fbclid',
+  'mibextid',
+  'referral_source',
+  'referral_story_type',
+  'surface_type',
+  'comment_tracking',
+  'notif_id',
+  'notif_t',
+  'ref',
+  '__cft__',
+  '__tn__',
+  '__xts__',
+  // The set the current mobile site appends, added after a review pointed out
+  // that the group above is the *old* vocabulary: a link copied out of the feed
+  // today usually carries these instead. `sfnsn` names the surface, `paipv` and
+  // `eav` are per-view tokens, and `_rdr` is the redirector's own marker.
+  'sfnsn',
+  'paipv',
+  'eav',
+  '_rdr',
+  'idorvanity',
+  'wtsid',
+  'rdid',
+  // Generic UTM tags. Not Facebook's; they ride along on outbound links that
+  // pages post, and they identify the campaign a click is being attributed to.
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+  'utm_id',
+  'utm_name',
+  'utm_referrer',
+  // Ad-network click ids. Each one is a single click's identifier minted by the
+  // network, so it is per-reader by construction.
+  'gclid',
+  'gbraid',
+  'wbraid',
+  'msclkid',
+  'twclid',
+  'yclid',
+  'igshid',
+  'igsh',
+  // Email and marketing-automation recipient ids. `mc_eid` in particular is a
+  // stable per-subscriber identifier.
+  'mc_cid',
+  'mc_eid',
+  '_hsenc',
+  '_hsmi',
+  // Referrer echoes: the page telling the destination where the reader came
+  // from.
+  'ref_src',
+  'ref_url',
+  'share_id',
+];
+
+/// [kTrackingParams] folded to lowercase and de-duplicated, for lookup.
+///
+/// The list is already lowercase, but matching is case-insensitive because
+/// Facebook is not consistent about the case of a parameter it generates, and a
+/// future entry typed with a capital would otherwise stop matching anything
+/// without failing any test.
+final Set<String> _trackingParams =
+    kTrackingParams.map((name) => name.toLowerCase()).toSet();
+
+/// Returns [url] with every [kTrackingParams] entry removed from its query.
+///
+/// A string this function does not fully understand is returned *byte for
+/// byte*, and so is a url that had nothing to strip. That is deliberate: the
+/// result is fed straight back to the webview, and a url that has been
+/// normalised for no reason is a url that can no longer be compared against the
+/// one the webview is already showing.
+String stripTrackingParams(String url) {
+  final uri = Uri.tryParse(url);
+
+  //`tryParse` only rejects the genuinely malformed ("http://["); "not a url at
+  //all" parses happily as a relative reference whose `toString` then
+  //percent-encodes the spaces. Rebuilding that would silently corrupt a string
+  //we were only asked to filter, so both cases — and every scheme-less href the
+  //page hands over before the webview resolves it — come back untouched.
+  if (uri == null || !uri.hasScheme) return url;
+
+  final all = uri.queryParametersAll;
+
+  final kept = <String, List<String>>{};
+  for (final param in all.entries) {
+    if (_isTrackingParam(param.key)) continue;
+    //`queryParametersAll`, not `queryParameters`: the collapsing form keeps
+    //only the last value of a repeated parameter, so `?a=1&a=2` would come out
+    //as `?a=2` and this function would be quietly deleting content while
+    //claiming to only remove tracking.
+    kept[param.key] = param.value;
+  }
+
+  //Keys are unique in `queryParametersAll`, so an equal count means no
+  //parameter matched. Returning the original string is not just an
+  //optimisation: it is the only way to guarantee a url with nothing to strip
+  //comes back untouched, `+` and `%20` and a missing `?` included.
+  if (kept.length == all.length) return url;
+
+  if (kept.isEmpty) return _withoutQuery(uri);
+
+  //Rebuilding decodes and re-encodes every value, which normalises a few
+  //things we do not fight: a space becomes `+` whether it arrived as `+` or as
+  //`%20`, and a parameter with an empty value loses its `=` (`?y=` becomes
+  //`?y`). Both round-trip to the same query as far as any server is concerned,
+  //and this path is only reached once we are already rewriting the url.
+  return uri.replace(queryParameters: kept).toString();
+}
+
+/// Whether [name] identifies the reader rather than the content.
+bool _isTrackingParam(String name) {
+  final lower = name.toLowerCase();
+  if (_trackingParams.contains(lower)) return true;
+
+  //Facebook emits its blob parameters indexed — `__cft__[0]`, `__xts__[0]` —
+  //so an exact-name test misses every real one of them.
+  final bracket = lower.indexOf('[');
+  if (bracket <= 0) return false;
+
+  return _trackingParams.contains(lower.substring(0, bracket));
+}
+
+/// [uri] as text with its query, and only its query, gone.
+///
+/// Neither `replace(queryParameters: {})` nor `replace(query: '')` can express
+/// this: both leave `https://m.facebook.com/story.php?` — a bare trailing `?`
+/// — and `replace(query: null)` means "keep the query" and changes nothing.
+/// Reassembling through the `Uri` constructor instead is worse, because it
+/// forces an authority on a url that has none (`mailto:a@b.com` comes back as
+/// `mailto:///a@b.com`).
+String _withoutQuery(Uri uri) {
+  if (!uri.hasQuery) return uri.toString();
+
+  //The query is the last thing before the fragment, so once the fragment is
+  //off, dropping `?` plus the query text is an exact cut. `Uri.query` is the
+  //encoded text as it appears in `toString`, so the arithmetic holds even for
+  //values carrying percent escapes.
+  final head = uri.removeFragment().toString();
+  final base = head.substring(0, head.length - uri.query.length - 1);
+
+  //`Uri.fragment` also hands back still-encoded text, so re-appending it is
+  //byte-for-byte rather than a second round of encoding.
+  return uri.hasFragment ? '$base#${uri.fragment}' : base;
+}
+
+/// The `fb:` scheme Facebook's mobile web uses to hand a link to its own app.
+const String _appLinkScheme = 'fb';
+
+/// The only `fb:` target this app knows how to serve itself.
+const String _fullscreenVideoTarget = 'fullscreen_video';
+
+/// Ids are numeric everywhere Facebook uses them. Anchored and ASCII-only on
+/// purpose: the id is about to become a path segment on our own host, and a
+/// value that is not plainly a run of digits — an escaped slash, a `..`, an
+/// Arabic-Indic digit no Facebook id has ever contained — has no business being
+/// interpolated into a url this app then navigates to.
+final RegExp _numericId = RegExp(r'^[0-9]+$');
+
+/// The web address that shows what an `fb://` link points at, or null.
+///
+/// Tapping a video in the feed navigates the webview to
+/// `fb://fullscreen_video/<id>`, which no webview can load. Today that reaches
+/// `launchInAppUrl` and leaves for a Custom Tab, which either bounces the user
+/// into the official Facebook app or fails outright — the single thing someone
+/// who installed this app has chosen against. Mapping the shape back onto
+/// `https://<host>/reel/<id>/` keeps the video inside the webview.
+///
+/// [host] is a parameter rather than a read of the preferences so this stays
+/// pure and testable, but also because only the caller knows which of the two
+/// Facebook layouts is live: the touch site and `mbasic` are different hosts,
+/// and sending a reel to the wrong one is a redirect at best.
+///
+/// Returns null for every shape not recognised, including an `fb://` target
+/// this function has never seen and any other scheme. Null means "caller keeps
+/// doing whatever it did before", so it has to be what an unknown link gets:
+/// guessing a web url for an app link we cannot read would replace a working
+/// hand-off with a 404.
+Uri? facebookAppLinkTarget(Uri uri, {required String host}) {
+  if (uri.scheme != _appLinkScheme) return null;
+
+  //`Uri` lower-cases the scheme and the host while parsing, so both of these
+  //comparisons are already case-insensitive.
+  if (uri.host != _fullscreenVideoTarget) return null;
+
+  //An empty host builds `https:///reel/<id>/`, which is not a page anything can
+  //load, so it is treated as another shape we cannot serve.
+  if (host.isEmpty) return null;
+
+  final id = _fullscreenVideoId(uri);
+  if (id == null) return null;
+
+  //Built through the constructor, not interpolated into `Uri.parse`: the
+  //constructor refuses a host that carries a path of its own, so a mistaken
+  //[host] cannot smuggle extra segments in.
+  return Uri(scheme: 'https', host: host, path: '/reel/$id/');
+}
+
+/// The video id carried by an `fb://fullscreen_video` link, or null.
+String? _fullscreenVideoId(Uri uri) {
+  //A trailing slash produces an empty last segment — `fb://fullscreen_video/1/`
+  //parses to `['1', '']` — which would otherwise read as two segments and be
+  //rejected as an unknown shape.
+  final segments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+
+  if (segments.length > 1) return null;
+
+  if (segments.length == 1) {
+    final segment = segments.single;
+    return _numericId.hasMatch(segment) ? segment : null;
+  }
+
+  //Some builds put the id in the query instead of the path. `id` is the one
+  //observed most; `v` is the spelling the desktop video urls use, and it turns
+  //up here too. The path form wins when both are present, since it is the one
+  //Facebook's own player reads.
+  final param = uri.queryParameters['id'] ?? uri.queryParameters['v'];
+  if (param == null) return null;
+
+  return _numericId.hasMatch(param) ? param : null;
+}

--- a/SlimSocial_for_Facebook/test/utils/ad_filter_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/ad_filter_test.dart
@@ -214,6 +214,140 @@ void main() {
     });
   });
 
+  group('a collapse that does not move the feed', () {
+    final collapse = _functionBody(script, 'function collapse(post)');
+    final resolve = _functionBody(script, 'function scrollerFor(post)');
+
+    test('reads the offset off whichever element actually scrolls', () {
+      // The touch layout scrolls the feed inside div[data-type="vscroller"],
+      // and the app scrolls the document itself as well — the screens' saved
+      // position goes through the document scroller — so a fixed choice of
+      // either one is wrong half the time.
+      expect(collapse, contains('scrollerFor(post)'));
+      expect(resolve, contains('node = node.parentElement;'));
+      expect(resolve, contains('window.getComputedStyle(node).overflowY'));
+    });
+
+    test('accepts every overflow value that scrolls, and only if it does', () {
+      for (final value in const ['auto', 'scroll', 'overlay']) {
+        expect(resolve, contains("overflowY === '$value'"), reason: value);
+      }
+
+      // An `overflow-y: auto` box that fits its content scrolls nothing, so
+      // correcting its offset discards the correction and leaves the jump on
+      // whichever ancestor is really moving.
+      expect(resolve, contains('node.scrollHeight > node.clientHeight'));
+    });
+
+    test('falls back to the document scroller', () {
+      expect(
+        resolve,
+        contains('document.scrollingElement || document.documentElement'),
+      );
+      // The document's offset is read off the window rather than off the
+      // element, which is why the fallback has to say which one it is.
+      expect(resolve, contains('win: window'));
+      expect(
+        collapse,
+        contains('scroller.win ? scroller.win.scrollY : scroller.el.scrollTop'),
+      );
+    });
+
+    test('corrects only for a post that was entirely above the viewport', () {
+      // Below the fold the height leaves a region the reader cannot see, and a
+      // post still on screen is the one being looked at — no offset both
+      // removes it and holds the view still. Both must reach the hide with no
+      // anchor taken.
+      expect(collapse, contains('var anchor = null;'));
+      expect(
+        collapse,
+        contains('post.getBoundingClientRect().bottom <= viewportTop'),
+      );
+      expect(collapse, contains('if (anchor) {'));
+    });
+
+    test('takes the vanished height off the offset in the same turn', () {
+      // Asking for scrollHeight forces the layout the hide invalidated, inside
+      // the same synchronous block. A correction deferred to a later frame is
+      // one the reader watches happen.
+      expect(
+        collapse,
+        contains('anchor.height - anchor.scroller.el.scrollHeight'),
+      );
+      expect(collapse, isNot(contains('requestAnimationFrame')));
+      expect(collapse, isNot(contains('setTimeout')));
+    });
+
+    test('measures the offset before the hide, not after it', () {
+      // The regression this exists to prevent: Android WebView has Chromium's
+      // scroll anchoring on by default, so the engine can move the offset
+      // itself as soon as the forced layout runs. Reading the offset after the
+      // hide and subtracting from that applied the correction twice and threw
+      // the feed a whole advert too far up. So the offset is captured into the
+      // anchor alongside the height, and the write is absolute.
+      final anchorAssignment = collapse.substring(
+        collapse.indexOf('anchor = {'),
+        collapse.indexOf('};', collapse.indexOf('anchor = {')),
+      );
+      expect(anchorAssignment, contains('offset:'));
+      expect(collapse, contains('var next = anchor.offset - lost;'));
+      // Nothing may re-read the live offset on the restore path: that is the
+      // shape of the bug.
+      final restore = collapse.substring(collapse.indexOf('if (anchor) {'));
+      expect(restore, isNot(contains('.scrollY')));
+      expect(restore, isNot(contains('.scrollTop;')));
+    });
+
+    test('writes the corrected offset without animating it', () {
+      // `scroll-behavior: smooth` up the tree would turn the two-argument
+      // scrollTo into an animation, which is the jump arriving slowly rather
+      // than not at all. Older WebViews that reject the object form fall back.
+      expect(collapse, contains("behavior: 'instant'"));
+      expect(collapse, contains('win.scrollTo(win.scrollX, next);'));
+    });
+
+    test('clamps the corrected offset at zero', () {
+      // A scroller can shed more height than there was offset above it, and a
+      // negative offset is a bounce on one engine and ignored on the next.
+      expect(collapse, contains('if (next < 0) next = 0;'));
+    });
+
+    test('never lets the restore stop the advert being hidden', () {
+      // Hiding the advert is the job and not jumping is the improvement, so
+      // every line of the measure-and-restore is guarded and none of the hide
+      // is: a scroller that cannot be measured still loses its advert.
+      final guarded = _guardedBlocks(collapse);
+
+      // Three now: the measure, the restore, and the object-form scrollTo whose
+      // own fallback sits inside the restore.
+      expect(guarded, hasLength(3));
+      expect(guarded.first, contains('post.getBoundingClientRect().bottom'));
+
+      final restore = guarded.firstWhere(
+        (block) => block.contains('var next = anchor.offset - lost;'),
+      );
+      expect(restore, contains("behavior: 'instant'"));
+      expect(restore, contains('anchor.scroller.el.scrollTop = next;'));
+      expect(restore, endsWith('catch (e) {}'));
+
+      for (final block in guarded) {
+        expect(block, isNot(contains('slim-ad-handled')));
+        expect(block, isNot(contains("post.style.height = '0px'")));
+        expect(block, isNot(contains("post.style.display = 'none'")));
+      }
+    });
+
+    test('covers the friend carousel without a branch of its own', () {
+      // Both ways out of the loop hide the post by calling collapse, so the
+      // correction is not something the carousel can be missing.
+      final loop = _functionBody(script, 'function runPass()');
+
+      expect(_pymkBranch(script), contains('collapse(post)'));
+      expect(loop, isNot(contains('scrollerFor')));
+      expect(loop, isNot(contains('scrollTop')));
+    });
+  });
+
   group('the label the live layout actually uses', () {
     test('bundles the two-character "ad" label', () {
       // Observed on a real feed: the label node is "Ad" plus two private-use
@@ -829,6 +963,30 @@ String _pymkBranch(String script) => script.substring(
       script.indexOf('if (isPeopleYouMayKnow(post))'),
       script.indexOf('if (!isSponsoredPost(post))'),
     );
+
+/// Every `try { … } catch (…) { … }` region in [body], braces included.
+///
+/// The catch is part of the region on purpose: a `try` whose failure path is
+/// somewhere else swallows nothing, and what these tests assert is which lines
+/// a failure cannot take down with it.
+List<String> _guardedBlocks(String body) => RegExp(r'try\s*\{')
+    .allMatches(body)
+    .map((m) => body.substring(m.start, _blockEnd(body, _blockEnd(body, m.start)) + 1))
+    .toList();
+
+/// The index of the closing brace of the first `{ … }` block at or after [from].
+int _blockEnd(String body, int from) {
+  final open = body.indexOf('{', from);
+  var depth = 0;
+  for (var i = open; i < body.length; i++) {
+    if (body[i] == '{') depth++;
+    if (body[i] == '}') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  throw StateError('unbalanced braces after offset $from');
+}
 
 /// The body of a JavaScript function in [script], braces included.
 String _functionBody(String script, String header) {

--- a/SlimSocial_for_Facebook/test/utils/css_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_test.dart
@@ -369,6 +369,90 @@ article {
     });
   });
 
+  group('selectable post content', () {
+    test('ships switched on', () {
+      // Nothing toggles it, so the default is the only setting it will ever
+      // have.
+      expect(CustomCss.selectableContentCss.key, 'selectable_content');
+      expect(CustomCss.selectableContentCss.isEnabled(), isTrue);
+    });
+
+    test('is not offered as a user-facing toggle', () {
+      // Same treatment as the other structural fixes: a reader who cannot copy
+      // a phone number out of a post is looking at a bug, not at a preference
+      // they forgot to switch on.
+      final keys = CustomCss.cssList.map((c) => c.key);
+
+      expect(keys, isNot(contains('selectable_content')));
+    });
+
+    test('sets user-select both prefixed and unprefixed', () {
+      // The unprefixed property is what current Chromium honours; the older
+      // Android WebViews this app still runs on only ever knew the -webkit-
+      // one, and shipping one of the two leaves half the fleet unable to
+      // select.
+      final code = CustomCss.selectableContentCss.code;
+
+      expect(code, contains('-webkit-user-select: text'));
+      expect(
+        RegExp(r'[;{]\s*user-select:\s*text').hasMatch(code),
+        isTrue,
+        reason: 'the unprefixed property is missing: $code',
+      );
+    });
+
+    test('re-enables pointer events on post images', () {
+      // pointer-events: none on feed images is what makes a long press on a
+      // photo do nothing at all, so the browser never gets as far as offering
+      // to save or share it.
+      final code = CustomCss.selectableContentCss.code;
+
+      expect(code, contains('div[data-tracking-duration-id] img'));
+      expect(code, contains('pointer-events: auto !important'));
+    });
+
+    test('scopes every selector to the post container', () {
+      // A document-wide rule here is not a bigger fix, it is a different bug:
+      // every mis-tap on the app's own chrome becomes a text selection with
+      // handles to dismiss. One escaped selector is enough to cause that, so
+      // each one is checked rather than the stylesheet as a whole.
+      final rules = CustomCss.selectableContentCss.code
+          .split('}')
+          .where((rule) => rule.contains('{'));
+
+      expect(rules, isNotEmpty);
+      for (final rule in rules) {
+        for (final selector in rule.split('{').first.split(',')) {
+          expect(
+            selector,
+            contains('div[data-tracking-duration-id]'),
+            reason: selector,
+          );
+        }
+      }
+    });
+
+    test('survives the whitespace collapsing intact', () {
+      // MyCss collapses the authored formatting, and stripping whitespace
+      // outright — which an earlier version of that collapse did — would fuse
+      // `-webkit-user-select:text!important` to the declaration after it and
+      // cost both.
+      final code = CustomCss.selectableContentCss.code;
+
+      expect(code, isNot(contains('\n')));
+      expect(code, isNot(contains('  ')));
+      expect(
+        code,
+        'div[data-tracking-duration-id] .native-text, '
+        'div[data-tracking-duration-id] .native-text * '
+        '{ -webkit-user-select: text !important; '
+        'user-select: text !important; } '
+        'div[data-tracking-duration-id] img '
+        '{ pointer-events: auto !important; }',
+      );
+    });
+  });
+
   group('theme-aware stylesheets', () {
     test('no bundled stylesheet hardcodes the legacy accent hex', () {
       for (final css in CustomCss.cssList) {

--- a/SlimSocial_for_Facebook/test/utils/css_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_test.dart
@@ -5,6 +5,57 @@ import 'package:slimsocial_for_facebook/main.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 
 void main() {
+  group('messenger conversation list height', () {
+    final code = CustomCss.messengerListHeightCss.code;
+
+    test('ships switched on', () {
+      expect(CustomCss.messengerListHeightCss.isEnabled(), isTrue);
+    });
+
+    test('is not a settings toggle', () {
+      // Structural, like hideAppUpsellCss: cssList drives the settings screen.
+      expect(CustomCss.cssList, isNot(contains(CustomCss.messengerListHeightCss)));
+    });
+
+    test('never touches overflow', () {
+      // The regression this exists to prevent. Messenger's own scroller is a
+      // descendant of the list and already carries `overflow-y: auto`;
+      // overriding overflow up the chain took the scroller away from the
+      // virtualised list and scrolling stopped entirely. Measured on a device.
+      expect(code, isNot(contains('overflow')));
+    });
+
+    test('sizes the chain to content, not to the parent', () {
+      // `height: 100%` made every ancestor take its parent's full height and
+      // the content ran past the viewport with nothing to scroll it.
+      expect(code, contains('height: auto !important'));
+      expect(code, isNot(contains('height: 100%')));
+    });
+
+    test('lets each ancestor of the list grow', () {
+      expect(code, contains('flex-grow: 1 !important'));
+      expect(code, contains('min-height: 0 !important'));
+      expect(code, contains('max-height: none !important'));
+    });
+
+    test('keeps the :has() selectors in a rule of their own', () {
+      // An unsupported selector invalidates the whole list it sits in, so on a
+      // WebView older than Chromium 105 this must cost the fix and nothing
+      // else — the same guard hideStoriesCss documents.
+      final rules = code.split('}').where((r) => r.trim().isNotEmpty).toList();
+      final hasRules = rules.where((r) => r.contains(':has(')).toList();
+      expect(hasRules, hasLength(1));
+      expect(hasRules.single, isNot(contains('[role="grid"] {')));
+    });
+
+    test('targets the list by role rather than by a generated class', () {
+      // The lesson from adaptMessengerPageCss, whose hash-class selectors now
+      // match nothing at all: role attributes outlive Facebook's build hashes.
+      expect(code, contains('[role="grid"]'));
+      expect(code, isNot(matches(RegExp(r'\.x[0-9a-z]{5,}'))));
+    });
+  });
+
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
     sp = await SharedPreferences.getInstance();

--- a/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/fb_navigation.dart';
+
+bool isAuth(String url) => isFacebookAuthUrl(Uri.parse(url));
+
+void main() {
+  group('isFacebookAuthUrl keeps the observed sign-in flow', () {
+    // These four are the exact addresses the Messenger sign-in walked through
+    // on a device, in order, on 2026-08-28. Each one used to close the Messenger
+    // screen and reappear in the feed, which is why signing in could not be
+    // completed. They are listed individually rather than as a loop so a
+    // regression names the step that broke.
+    test('checkpoint start', () {
+      expect(isAuth('https://m.facebook.com/checkpoint/start/'), isTrue);
+    });
+
+    test('checkpoint itself', () {
+      expect(isAuth('https://m.facebook.com/checkpoint/'), isTrue);
+    });
+
+    test('checkpoint reached under login', () {
+      expect(isAuth('https://m.facebook.com/login/checkpoint/'), isTrue);
+    });
+
+    test('the app login handoff', () {
+      expect(isAuth('https://m.facebook.com/unified/login_via/app/'), isTrue);
+    });
+  });
+
+  group('isFacebookAuthUrl recognises the rest of the flow', () {
+    test('the classic login form', () {
+      expect(isAuth('https://m.facebook.com/login.php?next=%2F'), isTrue);
+      expect(isAuth('https://m.facebook.com/login'), isTrue);
+      expect(
+        isAuth('https://www.facebook.com/login/device-based/regular/login/'),
+        isTrue,
+      );
+    });
+
+    test('two-factor and recovery', () {
+      expect(isAuth('https://m.facebook.com/two_factor/authenticate/'), isTrue);
+      expect(isAuth('https://m.facebook.com/authenticate/'), isTrue);
+      expect(isAuth('https://m.facebook.com/recover/initiate/'), isTrue);
+      expect(isAuth('https://m.facebook.com/security/'), isTrue);
+      expect(isAuth('https://m.facebook.com/confirmemail.php'), isTrue);
+    });
+
+    test('the consent and oauth interstitials', () {
+      expect(isAuth('https://m.facebook.com/privacy/consent/gdp/'), isTrue);
+      expect(isAuth('https://www.facebook.com/dialog/oauth?client_id=1'), isTrue);
+      expect(isAuth('https://www.facebook.com/x/oauth/'), isTrue);
+    });
+
+    test('a path ending without a trailing slash matches too', () {
+      // pathSegments hands back a trailing empty string for `/checkpoint/` and
+      // nothing extra for `/checkpoint` — both have to reach the same answer,
+      // and the empty-segment filter is what makes that true.
+      expect(isAuth('https://m.facebook.com/checkpoint'), isTrue);
+      expect(isAuth('https://m.facebook.com/checkpoint/'), isTrue);
+    });
+
+    test('matching ignores case', () {
+      expect(isAuth('https://m.facebook.com/CheckPoint/Start/'), isTrue);
+    });
+
+    test('a query string or fragment is not part of the decision', () {
+      expect(
+        isAuth('https://m.facebook.com/checkpoint/?next=https%3A%2F%2Fx'),
+        isTrue,
+      );
+      expect(isAuth('https://m.facebook.com/checkpoint/#step2'), isTrue);
+    });
+  });
+
+  group('isFacebookAuthUrl leaves ordinary pages to the feed', () {
+    test('the feed itself', () {
+      expect(isAuth('https://touch.facebook.com/home.php'), isFalse);
+      expect(isAuth('https://touch.facebook.com/'), isFalse);
+      // `/` yields no segments at all, which must not be read as a match.
+      expect(isAuth('https://touch.facebook.com'), isFalse);
+    });
+
+    test('content a reader taps out of a conversation', () {
+      expect(isAuth('https://m.facebook.com/DIYCraftsAmerica/videos/123/'), isFalse);
+      expect(isAuth('https://m.facebook.com/groups/12345'), isFalse);
+      expect(isAuth('https://m.facebook.com/marketplace/'), isFalse);
+      expect(isAuth('https://m.facebook.com/photo.php?fbid=1'), isFalse);
+      expect(isAuth('https://m.facebook.com/notifications.php'), isFalse);
+      expect(isAuth('https://m.facebook.com/messages/'), isFalse);
+    });
+
+    test('a first segment that merely begins with an auth word', () {
+      // The whole reason the first tier matches segments rather than prefixes:
+      // a profile or page whose name starts with "login" is not a login page.
+      expect(isAuth('https://m.facebook.com/loginhelp/'), isFalse);
+      expect(isAuth('https://m.facebook.com/securityreview/'), isFalse);
+      expect(isAuth('https://m.facebook.com/checkpoints/'), isFalse);
+    });
+
+    test('a two-segment prefix with only its first segment present', () {
+      // `/privacy/` and `/dialog/` are ordinary pages on their own — that is
+      // why they need the second segment to count.
+      expect(isAuth('https://m.facebook.com/privacy/policy/'), isFalse);
+      expect(isAuth('https://m.facebook.com/privacy/'), isFalse);
+      expect(isAuth('https://m.facebook.com/unified/'), isFalse);
+      expect(isAuth('https://m.facebook.com/unified/something_else/'), isFalse);
+      expect(isAuth('https://m.facebook.com/dialog/share'), isFalse);
+      expect(isAuth('https://m.facebook.com/x/'), isFalse);
+    });
+
+    test('a relative or hostless uri does not throw', () {
+      expect(isFacebookAuthUrl(Uri.parse('/checkpoint/')), isTrue);
+      expect(isFacebookAuthUrl(Uri.parse('')), isFalse);
+      expect(isFacebookAuthUrl(Uri.parse('about:blank')), isFalse);
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/js_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/js_test.dart
@@ -76,6 +76,105 @@ void main() {
     });
   });
 
+  group('CustomJs.unlockZoomFunc', () {
+    test('rewrites every viewport meta on the page', () {
+      // Facebook's SPA navigation can leave a second viewport tag behind, so
+      // fixing only the first one leaves the later tag deciding the scale.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains('querySelectorAll'));
+      expect(js, contains('meta[name="viewport"]'));
+    });
+
+    test('skips a meta it has already rewritten', () {
+      // Injection runs on every navigation; without the mark each pass would
+      // walk and rewrite tags that are already unlocked.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains("var MARK = 'data-slim-zoom';"));
+      expect(js, contains("if (meta.getAttribute(MARK) === '1') continue;"));
+    });
+
+    test('drops the two clauses that block the gesture', () {
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains("key === 'maximum-scale'"));
+      expect(js, contains("key === 'minimum-scale'"));
+    });
+
+    test('forces user-scalable on, and adds it when it is absent', () {
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains("key === 'user-scalable'"));
+      expect(js, contains("out.push('user-scalable=yes');"));
+      expect(js, contains('if (!sawUserScalable)'));
+    });
+
+    test('never rewrites the whole content string', () {
+      // The other clauses have to survive: a hardcoded replacement would drop
+      // `width=device-width` and hand back the 980px desktop layout.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains('out.push(clause);'));
+      expect(js, isNot(contains('width=device-width')));
+      expect(js, isNot(contains('initial-scale=1')));
+    });
+
+    test('installs exactly one observer, guarded by a global', () {
+      // The ad observer has the history here: a guard that never sees the
+      // previous observer stacks a new one on every page load.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains('if (!window.slimViewportObserver) {'));
+      expect(js, contains('window.slimViewportObserver = new MutationObserver'));
+      expect('new MutationObserver'.allMatches(js), hasLength(1));
+      expect('.observe('.allMatches(js), hasLength(1));
+    });
+
+    test('watches the head for a replaced viewport tag', () {
+      // A single-page navigation can swap the tag out after this script has
+      // finished, and the replacement arrives locked again.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains('document.head || document.documentElement'));
+      expect(js, contains('childList: true'));
+      expect(js, contains('attributes: true'));
+      expect(js, contains("attributeFilter: ['content']"));
+    });
+
+    test('clears the mark when the content was written again', () {
+      // Otherwise the tag keeps the mark from the first pass and is skipped
+      // forever, with maximum-scale back in place.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains("if (records[i].type === 'attributes')"));
+      expect(js, contains('records[i].target.removeAttribute(MARK);'));
+    });
+
+    test('does not write a value it did not change', () {
+      // setAttribute produces a mutation record either way, and the observer
+      // clears the mark before re-running: an unconditional write ping-pongs.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains('if (next !== current)'));
+    });
+
+    test('runs as a self-invoking function that swallows its own failure', () {
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js.trim(), startsWith('(function () {'));
+      expect(js.trim(), endsWith('})();'));
+      expect(js, contains('try {'));
+      expect(js, contains('} catch (e) {}'));
+    });
+
+    test('carries no javascript: prefix', () {
+      // This is passed straight to runJavaScript, which evaluates the string as
+      // script; the prefix belongs to the older members that were used as URLs.
+      expect(CustomJs.unlockZoomFunc(), isNot(contains('javascript:')));
+    });
+  });
+
   group('CustomJs.removeAdsObserver', () {
     test('installs the observer when none is running yet', () {
       // The guard used to be `typeof newPostsObserver !== 'undefined'` against

--- a/SlimSocial_for_Facebook/test/utils/url_cleaner_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/url_cleaner_test.dart
@@ -1,0 +1,536 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/url_cleaner.dart';
+
+void main() {
+  group('kTrackingParams', () {
+    test('is not empty', () {
+      expect(kTrackingParams, isNotEmpty);
+    });
+
+    test('is entirely lowercase so matching can be case-insensitive', () {
+      for (final param in kTrackingParams) {
+        expect(param, param.toLowerCase(), reason: '"$param" is not lowercase');
+      }
+    });
+
+    test('has no duplicates', () {
+      expect(kTrackingParams.toSet().length, kTrackingParams.length);
+    });
+
+    test('has no stray surrounding whitespace', () {
+      for (final param in kTrackingParams) {
+        expect(param, param.trim(), reason: '"$param" has stray whitespace');
+      }
+    });
+
+    test('stores the blob parameters unindexed', () {
+      // Facebook sends them as `__cft__[0]`, but the index is matched off in
+      // the lookup — an entry that carried its own `[0]` would only ever match
+      // the first index and silently miss `__cft__[1]`.
+      for (final param in kTrackingParams) {
+        expect(param, isNot(contains('[')), reason: '"$param" is indexed');
+      }
+    });
+
+    test('covers the Facebook, utm, ad-network and email families', () {
+      expect(kTrackingParams, contains('fbclid'));
+      expect(kTrackingParams, contains('mibextid'));
+      expect(kTrackingParams, contains('__cft__'));
+      expect(kTrackingParams, contains('utm_source'));
+      expect(kTrackingParams, contains('gclid'));
+      expect(kTrackingParams, contains('igshid'));
+      expect(kTrackingParams, contains('mc_eid'));
+      expect(kTrackingParams, contains('ref_src'));
+    });
+
+    test('leaves the content-bearing parameters alone', () {
+      // Any of these in the list would turn a working permalink into a 404,
+      // and the breakage would read as Facebook being down.
+      expect(kTrackingParams, isNot(contains('story_fbid')));
+      expect(kTrackingParams, isNot(contains('id')));
+      expect(kTrackingParams, isNot(contains('v')));
+      expect(kTrackingParams, isNot(contains('sk')));
+      expect(kTrackingParams, isNot(contains('fbid')));
+    });
+  });
+
+  group('stripTrackingParams', () {
+    test('removes fbclid from a story permalink', () {
+      expect(
+        stripTrackingParams(
+          'https://m.facebook.com/story.php?story_fbid=99&id=7&fbclid=IwAR1x',
+        ),
+        'https://m.facebook.com/story.php?story_fbid=99&id=7',
+      );
+    });
+
+    test('removes every family at once', () {
+      expect(
+        stripTrackingParams(
+          'https://m.facebook.com/watch?v=123&utm_source=n&gclid=g&mc_eid=e'
+          '&ref_src=twsrc&igshid=i',
+        ),
+        'https://m.facebook.com/watch?v=123',
+      );
+    });
+
+    test("drops Facebook's own click blobs, index and all", () {
+      // `__cft__` and `__xts__` arrive indexed. They look load-bearing because
+      // they are long and opaque; the permalink resolves without them.
+      expect(
+        stripTrackingParams(
+          'https://m.facebook.com/groups/1/posts/2/?__cft__[0]=AZXabc'
+          '&__tn__=R&__xts__[0]=68.ARB&ref=notif',
+        ),
+        'https://m.facebook.com/groups/1/posts/2/',
+      );
+    });
+
+    test('drops a blob parameter whose brackets arrived percent-escaped', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?__cft__%5B0%5D=AZX&a=1'),
+        'https://m.facebook.com/x?a=1',
+      );
+    });
+
+    test('matches the parameter name case-insensitively', () {
+      // Facebook is not consistent about the case of a parameter it generates,
+      // and a case-sensitive test would leave `FBCLID` on the url.
+      expect(
+        stripTrackingParams(
+          'https://m.facebook.com/x?FBCLID=a&UtM_Source=b&k=1',
+        ),
+        'https://m.facebook.com/x?k=1',
+      );
+    });
+
+    test('returns an unparsable string completely unchanged', () {
+      // `Uri.parse` accepts this as a relative reference and its `toString`
+      // percent-encodes the spaces, which would corrupt a string we were only
+      // asked to filter.
+      expect(stripTrackingParams('not a url at all'), 'not a url at all');
+    });
+
+    test('returns a string Uri.tryParse rejects outright unchanged', () {
+      expect(stripTrackingParams('http://['), 'http://[');
+    });
+
+    test('leaves a scheme-less relative href alone', () {
+      // These are what an in-page link looks like before the webview resolves
+      // it, and rewriting one against no base would produce nonsense.
+      expect(stripTrackingParams('/story.php?fbclid=a'), '/story.php?fbclid=a');
+      expect(
+        stripTrackingParams('//m.facebook.com/x?fbclid=a'),
+        '//m.facebook.com/x?fbclid=a',
+      );
+      expect(stripTrackingParams('#comments'), '#comments');
+    });
+
+    test('leaves an empty string alone', () {
+      expect(stripTrackingParams(''), '');
+    });
+
+    test('does not introduce a trailing ? on a url that had no query', () {
+      // `Uri.replace` leaves a bare `?` behind, so a rebuild-always
+      // implementation turns every clean url into a subtly different string.
+      expect(
+        stripTrackingParams('https://m.facebook.com/home.php'),
+        'https://m.facebook.com/home.php',
+      );
+    });
+
+    test('returns a query with nothing to strip byte for byte', () {
+      // Untouched means untouched: no re-encoding, so the result can still be
+      // compared against the url the webview is showing.
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?a=b+c&d=e%20f&g=%C3%A9'),
+        'https://m.facebook.com/x?a=b+c&d=e%20f&g=%C3%A9',
+      );
+    });
+
+    test('keeps the surviving parameters in their original order', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?z=1&fbclid=q&a=2&m=3'),
+        'https://m.facebook.com/x?z=1&a=2&m=3',
+      );
+    });
+
+    test('keeps a value that needs percent-encoding', () {
+      expect(
+        stripTrackingParams(
+          'https://m.facebook.com/search?q=%C3%A8%C3%A9&ref=x',
+        ),
+        'https://m.facebook.com/search?q=%C3%A8%C3%A9',
+      );
+    });
+
+    test('keeps a literal plus distinct from a space', () {
+      // `%2B` is a real `+` in the value and must survive as one, or a search
+      // for "c++" silently becomes a search for "c  ".
+      expect(
+        stripTrackingParams('https://m.facebook.com/search?q=c%2B%2B&fbclid=x'),
+        'https://m.facebook.com/search?q=c%2B%2B',
+      );
+    });
+
+    test('normalises %20 to + once it has to rebuild the query', () {
+      // Documenting what `Uri` imposes rather than fighting it: a space is
+      // re-encoded as `+` however it arrived. Both forms decode to the same
+      // query, and this only happens on a url already being rewritten.
+      expect(
+        stripTrackingParams('https://m.facebook.com/search?q=a%20b&fbclid=x'),
+        'https://m.facebook.com/search?q=a+b',
+      );
+      expect(
+        stripTrackingParams('https://m.facebook.com/search?q=a+b&fbclid=x'),
+        'https://m.facebook.com/search?q=a+b',
+      );
+    });
+
+    test('keeps both values of a repeated parameter', () {
+      // `queryParameters` keeps only the last value, so an implementation
+      // built on it would answer `?a=2` and delete content while claiming to
+      // only remove tracking.
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?a=1&a=2&fbclid=z'),
+        'https://m.facebook.com/x?a=1&a=2',
+      );
+    });
+
+    test('keeps a repeated parameter untouched when nothing is stripped', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?a=1&a=2'),
+        'https://m.facebook.com/x?a=1&a=2',
+      );
+    });
+
+    test('removes every occurrence of a repeated tracking parameter', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?ref=a&ref=b&k=1'),
+        'https://m.facebook.com/x?k=1',
+      );
+    });
+
+    test('preserves the fragment', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?a=1&fbclid=z#comments'),
+        'https://m.facebook.com/x?a=1#comments',
+      );
+    });
+
+    test('preserves the fragment when the query is emptied', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?fbclid=z#comments'),
+        'https://m.facebook.com/x#comments',
+      );
+    });
+
+    test('preserves a percent-escaped fragment without double-encoding it', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?fbclid=z#a%20b'),
+        'https://m.facebook.com/x#a%20b',
+      );
+    });
+
+    test('preserves the path, including a trailing slash', () {
+      expect(
+        stripTrackingParams(
+          'https://m.facebook.com/groups/123/posts/456/?mibextid=abc',
+        ),
+        'https://m.facebook.com/groups/123/posts/456/',
+      );
+    });
+
+    test('preserves a non-default port and the userinfo', () {
+      // Rebuilding through the `Uri` constructor drops or mangles these; the
+      // proxy setting means a port really can show up here.
+      expect(
+        stripTrackingParams('https://m.facebook.com:8080/x?fbclid=z'),
+        'https://m.facebook.com:8080/x',
+      );
+    });
+
+    test('removes a tracking parameter that has an empty value', () {
+      // Facebook emits `?fbclid=` when it has nothing to put in it, and an
+      // implementation keyed on the value rather than the name keeps it.
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?fbclid=&a=1'),
+        'https://m.facebook.com/x?a=1',
+      );
+    });
+
+    test('removes a tracking parameter that has no value at all', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?fbclid&a=1'),
+        'https://m.facebook.com/x?a=1',
+      );
+    });
+
+    test('drops the ? entirely when the query is emptied', () {
+      expect(
+        stripTrackingParams('https://m.facebook.com/story.php?fbclid=IwAR1x'),
+        'https://m.facebook.com/story.php',
+      );
+    });
+
+    test(
+      'drops the ? when the emptied query was the only one on a bare host',
+      () {
+        expect(
+          stripTrackingParams('https://m.facebook.com?fbclid=z'),
+          'https://m.facebook.com',
+        );
+      },
+    );
+
+    test('leaves a bare ? alone rather than rebuilding it away', () {
+      // There is nothing to strip, so the string is not ours to normalise.
+      expect(
+        stripTrackingParams('https://m.facebook.com/x?'),
+        'https://m.facebook.com/x?',
+      );
+    });
+
+    test('does not force an authority onto a url that has none', () {
+      // `mailto:` is absolute and parsable, and reassembling it through the
+      // `Uri` constructor turns it into `mailto:///dev@example.com`.
+      expect(
+        stripTrackingParams('mailto:dev@example.com?subject=Hi&utm_source=x'),
+        'mailto:dev@example.com?subject=Hi',
+      );
+    });
+
+    test('does not treat a tracking name inside a value as a parameter', () {
+      expect(
+        stripTrackingParams(
+          'https://m.facebook.com/x?u=http%3A%2F%2Fa.b%3Fref%3D1',
+        ),
+        'https://m.facebook.com/x?u=http%3A%2F%2Fa.b%3Fref%3D1',
+      );
+    });
+
+    test(
+      'does not strip a parameter that merely starts with a tracked name',
+      () {
+        // `ref` is in the list; `referrer` and `refid` are not, and a prefix
+        // match would take content-bearing parameters with it.
+        expect(
+          stripTrackingParams(
+            'https://m.facebook.com/x?referrer=a&refid=17&ref=b',
+          ),
+          'https://m.facebook.com/x?referrer=a&refid=17',
+        );
+      },
+    );
+  });
+
+  group('facebookAppLinkTarget', () {
+    const host = 'touch.facebook.com';
+
+    test('maps fb://fullscreen_video/<id> onto a reel url', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/1234567890'),
+          host: host,
+        ),
+        Uri.parse('https://touch.facebook.com/reel/1234567890/'),
+      );
+    });
+
+    test('uses the host it is handed, not a hardcoded one', () {
+      // The app serves two different Facebook layouts and only the caller
+      // knows which one is live; a reel sent to the wrong host is a redirect
+      // at best.
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/55'),
+          host: 'mbasic.facebook.com',
+        ),
+        Uri.parse('https://mbasic.facebook.com/reel/55/'),
+      );
+    });
+
+    test('tolerates a trailing slash on the app link', () {
+      // The trailing slash parses to an empty second segment, which would
+      // otherwise read as an unknown two-segment shape.
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/321/'),
+          host: host,
+        ),
+        Uri.parse('https://touch.facebook.com/reel/321/'),
+      );
+    });
+
+    test('accepts the id arriving as ?id=', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/?id=246'),
+          host: host,
+        ),
+        Uri.parse('https://touch.facebook.com/reel/246/'),
+      );
+    });
+
+    test('accepts the id arriving as ?v=', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video?v=808'),
+          host: host,
+        ),
+        Uri.parse('https://touch.facebook.com/reel/808/'),
+      );
+    });
+
+    test('prefers the path id over a query id', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/111?id=222'),
+          host: host,
+        ),
+        Uri.parse('https://touch.facebook.com/reel/111/'),
+      );
+    });
+
+    test('is case-insensitive because Uri lower-cases scheme and host', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('FB://FullScreen_Video/77'),
+          host: host,
+        ),
+        Uri.parse('https://touch.facebook.com/reel/77/'),
+      );
+    });
+
+    test('returns null for an fb:// target it does not recognise', () {
+      // Null means "caller keeps its existing behaviour". Guessing a web url
+      // for an app link we cannot read would replace a working hand-off with
+      // a 404.
+      expect(
+        facebookAppLinkTarget(Uri.parse('fb://profile/123'), host: host),
+        isNull,
+      );
+      expect(
+        facebookAppLinkTarget(Uri.parse('fb://page/123'), host: host),
+        isNull,
+      );
+    });
+
+    test('returns null for a non-fb scheme', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('https://m.facebook.com/reel/1/'),
+          host: host,
+        ),
+        isNull,
+      );
+      expect(
+        facebookAppLinkTarget(Uri.parse('fbmessenger://x/1'), host: host),
+        isNull,
+      );
+      expect(
+        facebookAppLinkTarget(Uri.parse('intent://x/1'), host: host),
+        isNull,
+      );
+    });
+
+    test(
+      'returns null when the target sits in the path instead of the host',
+      () {
+        // `fb:///fullscreen_video/1` has an empty authority, so this is not the
+        // shape we measured and we do not know what it means.
+        expect(
+          facebookAppLinkTarget(
+            Uri.parse('fb:///fullscreen_video/1'),
+            host: host,
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test('returns null when there is no id at all', () {
+      expect(
+        facebookAppLinkTarget(Uri.parse('fb://fullscreen_video'), host: host),
+        isNull,
+      );
+      expect(
+        facebookAppLinkTarget(Uri.parse('fb://fullscreen_video/'), host: host),
+        isNull,
+      );
+    });
+
+    test('returns null for a non-numeric id rather than building a url', () {
+      // The id becomes a path segment on our own host, so anything that is not
+      // a digit is refused instead of interpolated.
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/abc'),
+          host: host,
+        ),
+        isNull,
+      );
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/12ab'),
+          host: host,
+        ),
+        isNull,
+      );
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/?id=not-a-number'),
+          host: host,
+        ),
+        isNull,
+      );
+    });
+
+    test('refuses an id that tries to escape its path segment', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/?id=..%2F..%2Fsettings'),
+          host: host,
+        ),
+        isNull,
+      );
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/?id=1%2Fevil'),
+          host: host,
+        ),
+        isNull,
+      );
+    });
+
+    test('refuses non-ASCII digits', () {
+      // They are digits to a human and to `RegExp` under Unicode mode, but not
+      // to any Facebook id, and the point of the check is what ends up in the
+      // path.
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/%D9%A1%D9%A2%D9%A3'),
+          host: host,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for a path with more segments than we understand', () {
+      expect(
+        facebookAppLinkTarget(
+          Uri.parse('fb://fullscreen_video/123/456'),
+          host: host,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null instead of building a host-less url', () {
+      expect(
+        facebookAppLinkTarget(Uri.parse('fb://fullscreen_video/1'), host: ''),
+        isNull,
+      );
+    });
+  });
+}

--- a/docs/research/2026-08-28-nora-comparative-study.md
+++ b/docs/research/2026-08-28-nora-comparative-study.md
@@ -1,0 +1,229 @@
+# Nora comparative study — techniques worth adopting
+
+**Date:** 2026-08-28
+**Subject:** [nonbili/Nora](https://github.com/nonbili/Nora) @ `777009e` (v0.8.8 Android, 2026-08-23) — a React Native / Expo browser for ten social networks, AGPL-3.0, ~1.1k stars, actively maintained.
+**Purpose:** identify techniques Nora has solved that SlimSocial has not, record how each one works, and cost it against this codebase.
+
+Nora solves the same problem as SlimSocial — wrap a social network in a WebView, inject code, remove the advertising — for ten sites instead of one. That overlap makes it the most useful reference implementation available. This document is the distilled result of reading its source: content scripts, blocklist engine, Android module (~1,900 lines of Kotlin), notification pollers, and state layer.
+
+---
+
+## 0. Licence policy — read before using anything here
+
+**Nora is AGPL-3.0. SlimSocial is GPL-2.0.** Code cannot move from the former into the latter: GPL-2.0 and AGPL-3.0 are incompatible, and the compatibility that does exist for AGPL-3.0 code requires the GPL-3.0 level (AGPLv3 §13 / GPLv3 §13).
+
+Therefore this document is a **specification, not a source of code**. Everything below describes *behaviour* — which attribute holds the video URL, which query parameters are tracking, which API endpoint carries the badge counts, how a scroll offset must be corrected. Facts and interfaces are not copyrightable; expression is. Every adoption must be written from scratch in Dart, in this codebase's own idiom.
+
+If verbatim reuse ever becomes desirable, the prerequisite is relicensing SlimSocial to GPL-3.0-or-later, which needs sign-off from prior code contributors. That is a deliberate decision to take separately, not a side effect of a feature.
+
+> The reading above is engineering judgement recorded for planning purposes, not legal advice.
+
+---
+
+## 1. Architectural difference that explains everything else
+
+| Layer | Nora | SlimSocial |
+|---|---|---|
+| Shell | React Native / Expo 56, TypeScript; Android + iOS + Electron desktop from one tree | Flutter, Android-first |
+| WebView | **Own native module** (`NoraView`): full `WebViewClient` / `WebChromeClient` ownership | `webview_flutter` 4.10 — the plugin owns the client, the app sees only exposed callbacks |
+| Injection | One esbuild IIFE bundle per page, plus true document-start scripts via `WebViewCompat.addDocumentStartJavaScript` for guards that must beat page scripts | Dart-assembled JS at `onPageStarted` / `onPageFinished`, idempotent by element id, each step isolated with health telemetry |
+| Scope | 10 networks, multi-tab, tab groups, desktop deck view | Facebook + Messenger |
+| Accounts | Multi-profile via androidx `ProfileStore` (real cookie-jar isolation) | Single session |
+| State | legend-state + MMKV, versioned JSON backup, optional server sync | `shared_preferences` with a disciplined key registry |
+
+The single fact that matters: **Nora owns its `WebViewClient`.** That is what unlocks request interception, document-start scripts, popup windows, renderer-crash recovery, cookie reads, profiles and proxy control. SlimSocial rents its WebView from `webview_flutter`, which exposes none of those. Every item in §4 is tagged by whether it clears that wall.
+
+---
+
+## 2. Ad-blocking is three independent layers
+
+Nora runs all three. SlimSocial runs one — and runs it better than Nora does.
+
+### Layer 1 — Network (host blocking)
+
+`shouldInterceptRequest` returns an empty `WebResourceResponse` for any **non-main-frame** request whose host matches a blocklist compiled from EasyList, EasyPrivacy and two Brave first-party lists. Matching walks the host's labels from most to least specific; `@@` exception rules win only if they match at a *more specific* level than the block rule.
+
+Relevance to Facebook: **partial.** Facebook serves its feed advertising first-party, so this layer removes third-party *tracking* rather than feed ads. It is a privacy feature, not an ad-blocking one.
+
+### Layer 2 — Response rewriting
+
+Patch `XMLHttpRequest` and `fetch` on the prototype, then filter advertising out of the JSON before the page ever parses it: Instagram GraphQL (`edges.filter(!node.ad)`), Twitter timeline instructions (drop entries whose `entryId` contains `promoted`), YouTube `/youtubei/v1/*` plus a setter trap on `ytInitialPlayerResponse` for the inlined first video.
+
+Relevance to Facebook: **none.** Nora does not response-filter Facebook, because Facebook's mobile feed arrives server-rendered. Both apps fight Facebook in the DOM. This layer only pays off on sites SlimSocial does not wrap.
+
+### Layer 3 — DOM
+
+Nora hooks the same container SlimSocial does — `[data-tracking-duration-id]` on `m.facebook.com` — and tests it with a plain `textContent.includes()` against ~30 localised labels.
+
+**SlimSocial's matcher is materially stricter:** a three-tier cascade (attribute → marker selector → text), a per-label length window, private-use and bidi character stripping, and a separate exact-match path so two-character CJK labels can be matched safely. Nora's bare `includes()` over a label as short as `"Ad"` is the false-positive mode SlimSocial's length gates exist to prevent. SlimSocial's label list is a superset of Nora's.
+
+Four DOM techniques are nonetheless worth taking:
+
+1. **Collapse without moving the feed.** Hiding a post above the viewport slides everything below it upward, and the feed jumps under the reader's thumb. Measure the scroller's height *and its offset* before hiding; if the post was entirely above the viewport, write the offset back as `offsetBefore - heightLost` in the same synchronous turn. Write it absolutely, not as a delta applied to the current offset: Android WebView has Chromium's scroll anchoring on by default (`overflow-anchor: auto`), so the engine may have already corrected the offset by the time the forced layout completes, and subtracting again moves the feed by a whole post in the wrong direction. Inside a scroll-snap container (Reels) the same bug additionally causes Chromium to re-snap to the *previous* clip.
+2. **Verdict caching with mutation invalidation.** Scan a post once, stamp the result. Any DOM change inside the post drops the cached verdict, because Facebook inserts the "Sponsored" label *after* the post is inserted. SlimSocial's `slim-ad-checked` plus `isSettled` already approximates this; Nora's version is invalidation-driven rather than stability-driven.
+3. **One sweep per frame.** Mutation records only *schedule* a `requestAnimationFrame`-coalesced sweep; nothing is scanned inline. This was Nora's fix for "Facebook hangs" (commit `d5ebc57`) — a batch holds hundreds of records touching the same handful of posts. SlimSocial's 250 ms debounce is close in effect.
+4. **"Open in app" banner by structure, not text.** The banner is: exactly one `.native-text`, exactly one focusable button, a gradient container — and *no* form control, article or feed descendant. Locale-proof. SlimSocial's `hideAppUpsellCss` already uses the negative form-control guard; the positive structural test is the part not yet borrowed.
+
+---
+
+## 3. Where SlimSocial is ahead
+
+Recorded so these are not accidentally traded away while porting.
+
+- **Hostile-input discipline.** SlimSocial's JS channels validate everything: allowlisted diagnostic kinds, fields and values; integer bounds; describe-don't-quote logging so the page cannot exfiltrate through Sentry breadcrumbs. Nora's `onMessage` switch trusts payload shapes and logs freely.
+- **Sponsored-label matching.** See §2, layer 3.
+- **Selector health telemetry.** `no_posts_matched` / `filter_missing` mean SlimSocial *learns* when Facebook rewrites its markup. Nora finds out from GitHub issues. This is the instrument that de-risks every experiment below — particularly the user-agent one.
+- **Load-retry policy.** Escalating delays tuned to observed wake-from-sleep failure sequences, including the iOS no-committed-navigation case. Nora reloads on renderer crash but has no equivalent for transient load failure.
+- **Dark theme.** Luminance-based palette extraction from the page's own stylesheet, because Facebook renumbers its `bg-sN` surface classes per render. Nora's Facebook dark mode is whatever the site serves.
+
+---
+
+## 4. Adoption dossiers
+
+Ordered by value ÷ cost.
+
+### A. Video download — pure DOM scraping ✅ works with `webview_flutter`
+
+**Corrects an assumption in [`2026-08-04-media-viewer-and-downloads.md`](../superpowers/plans/2026-08-04-media-viewer-and-downloads.md)**, which excludes video download on the grounds that MSE video exposes only a `blob:` URL and that supporting it would require intercepting network requests. It does not: the real HTTPS URLs are in the page.
+
+Pipeline:
+
+1. Normalise the URL first. Any `facebook.com/watch?v=<id>`, `/…/videos/…/<id>`, `/reel/<id>`, or `fb://fullscreen_video/<id>` collapses to one canonical page shape — the reel page — so there is a single DOM to scrape.
+2. Collect candidates and score them:
+   - `[data-video-url]` attributes — usually muxed with audio, moderate quality (score ~400).
+   - `data-extra` JSON on the same nodes, walked recursively for `browser_native_hd_url` (520), `playable_url_quality_hd` (500), `browser_native_sd_url` (380), `playable_url` (360).
+   - The raw document HTML and every `<script>.textContent`, regexed for the same keys — including the `"`-escaped variants, which is how they appear inside inlined JSON.
+   - DASH `<BaseURL>` entries (also `<BaseURL>` escaped), scored by representation height, skipping `audio/*` mime types.
+3. Decode escapes: `\/`→`/`, `&`→`&`, `/`→`/`, `&amp;`→`&`.
+4. If the best DASH candidate (video-only) and the best progressive candidate (muxed) differ, **offer the choice**: "HD, no audio" vs "Standard quality, with audio". This is honest about Facebook's DASH split instead of silently saving a video with no sound.
+5. Genuine `blob:` fallback: `fetch(blobUrl)` → `FileReader.readAsDataURL` → base64 over a JS channel → write to Downloads. Nora additionally keeps a small `Map` of recent `URL.createObjectURL` arguments so a revoked blob URL can still be saved without `fetch` — which also sidesteps strict `connect-src` policies that reject `blob:`.
+
+**Cost:** 1–2 days, no new dependencies. All of it runs through `runJavaScript` plus one JS channel.
+
+### B. Quality-of-life pack ✅ works with `webview_flutter`
+
+- **Pinch-to-zoom.** Facebook ships `maximum-scale=1, user-scalable=no`. Rewrite the viewport meta, dropping those clauses. Text zoom cannot enlarge a posted screenshot; this can.
+- **Text selection and image long-press.** Two CSS rules. The touch layout sets `user-select: none` on post text and `pointer-events: none` on feed images, which is why a photo cannot be long-pressed and a posted phone number cannot be copied.
+- **Tracking-parameter stripping.** ~30 parameters (`fbclid`, `mibextid`, `referral_source`, `surface_type`, `utm_*`, `share_id`, `gclid`, `ref_src`, …) removed before sharing a URL, and again inside the page by wrapping `navigator.clipboard.writeText` so Facebook's own "Copy link" button also yields a clean URL.
+- **`fb://` link rescue.** `fb://fullscreen_video/<id>` currently reaches the Custom Tab handler, which either hands the user to the official Facebook app or fails. Map it back to a web URL inside the webview.
+
+**Cost:** ~½ day total.
+
+*Nora also runs a system-wide Android clipboard listener that rewrites any copied social URL. Deliberately not adopted: a background clipboard reader is a large privacy surface for a small gain, and on modern Android it raises a visible paste notification.*
+
+### C. Notifications without FCM ⚠️ needs one small platform channel
+
+Nora's design needs no Facebook API, no push service and no separate login:
+
+1. Read the session from the WebView cookie jar — `CookieManager.getCookie("https://m.facebook.com")` returns the header string. `webview_flutter`'s cookie manager is set-only, but this is a **five-line `MethodChannel`**; the full engine migration in dossier E is *not* a prerequisite.
+2. Proceed only if `c_user` and `xs` are present, i.e. actually signed in.
+3. `GET m.facebook.com/menu/bookmarks/` with those cookies and a mobile Chrome user agent. Parse the anchors: hrefs containing `/friends/center/requests`, `/messages`, `/groups`, `/notifications.php`; take the badge count from `aria-label`, `title` or the link text (`\b(\d+)\+?\b` after stripping commas).
+4. Store last-seen counts per category; notify only when a count **rises**. Tapping opens the matching URL in the webview.
+5. Schedule: foreground timer every ~5 minutes, background task at the OS floor of 15 minutes. Flutter equivalent: `workmanager` + `flutter_local_notifications`.
+
+**Cost:** 2–3 days. **Ship behind an off-by-default toggle** — see the risk register.
+
+### D. EasyList, in two stages
+
+Nora's parser is deliberately limited, and that restraint is the insight — it keeps only what is cheap and safe to evaluate:
+
+- **Host rules:** `||host^` anchored rules and hosts-file lines only. Any rule carrying `$domain=` scoping or `badfilter` is skipped, because a site-scoped rule must never become a global host block. No path matching, no regex rules — which is what keeps a match O(labels) per request.
+- **Cosmetic rules:** `##selector` and `#@#exception` lines, skipping extended syntax (`:has-text(`, `+js(`, `:-abp-`, `:style(`, `:upward(`, `:xpath(`). These become one injected stylesheet.
+- **Freshness:** honour each list's `! Expires:` header (default 4 days), revalidate with ETag / Last-Modified, background refresh at 7 days. Persist the merged parsed result stamped with a **parser version**, so changing the parser rebuilds from the cached raw lists rather than shipping a stale snapshot.
+- **Never block the main thread:** Nora yields every 4,000 lines. Flutter's better answer is `compute()`.
+
+**Stage 1 (available now, ~1 day):** fetch, parse and inject the *cosmetic* filters for facebook.com through the existing `injectCssFunc` pipeline.
+**Stage 2 (after E, ~1 day):** feed the host set to `shouldInterceptRequest`.
+
+Sources: `https://easylist.to/easylist/easylist.txt`, `https://easylist.to/easylist/easyprivacy.txt`.
+
+### E. Engine migration: `webview_flutter` → `flutter_inappwebview` ⚠️ the wall itself
+
+| Capability | Android API Nora uses | `flutter_inappwebview` equivalent |
+|---|---|---|
+| Host-level request blocking | `shouldInterceptRequest` → empty response | `shouldInterceptRequest` (Android) |
+| Guards that beat page scripts | `WebViewCompat.addDocumentStartJavaScript` | `UserScript(injectionTime: AT_DOCUMENT_START)` — genuine document-start where `WebViewFeature.DOCUMENT_START_SCRIPT` exists, best-effort otherwise; real `WKUserScript` on iOS |
+| Renderer crash → reload | `onRenderProcessGone` | `onRenderProcessGone` |
+| Cookie read | `CookieManager.getCookie` | `CookieManager.getCookies()` |
+| `window.open` popups | `setSupportMultipleWindows` + `onCreateWindow` | `onCreateWindow` |
+| Package-name leak | `setRequestedWithHeaderOriginAllowList(∅)` | exposed as a setting |
+| iOS blocking | — | `contentBlockers` → `WKContentRuleList` |
+
+**Costs, honestly:** a larger dependency with its own bug tail, and re-verification of behaviour this codebase paid for once already — the load-retry hooks, fullscreen video via `setCustomWidgetCallbacks`, the file selector, geolocation prompts, text zoom. Doing D-stage-2, F or the `X-Requested-With` fix *without* it means hand-rolling platform channels against a WebView instance `webview_flutter` will not hand over — effectively a fork.
+
+**Cost:** 3–5 days plus a device regression pass.
+
+### F. WebRTC IP-leak guard ⚠️ needs document-start (E)
+
+SlimSocial ships a proxy setting; WebRTC walks around it, because STUN discovers the real public address outside the page's HTTP stack. The guard:
+
+- Patch `RTCPeerConnection` **on the prototype**, not via a subclass — a subclass hands the untouched constructor back to the page through its own prototype chain, and connections built from that gather everything.
+- Force `iceTransportPolicy: 'relay'` in the constructor config and in `setConfiguration`.
+- Filter `icecandidate` events to relay candidates only, wrapping listeners through a `WeakMap` so `removeEventListener` still works.
+- Scrub non-relay `a=candidate:` lines from SDP in `createOffer` / `createAnswer` and in descriptions.
+
+Must run at document start: once page scripts hold a reference to the original constructor, overriding the global is pointless.
+
+*Also worth noting:* Nora drives its proxy through androidx `ProxyController`, which scopes the override to the WebView. That is cleaner than `native_flutter_proxy`, which sets a process-wide proxy.
+
+### G. User-agent modernisation — a dated string is a standing risk
+
+SlimSocial's feed agent claims Firefox 70 (2019). The codebase already carries the scar tissue: `removeBrowserNotSupportedCss` exists because Facebook serves a "browser not supported" notice to agents it considers dead.
+
+Nora never fights that battle. It pins a **current Chrome agent** (142 at time of reading), updates it every release, and controls the served layout by **host** instead: every `www.facebook.com` navigation is rewritten to `m.facebook.com` while in mobile mode, and Messenger paths get a desktop Linux agent.
+
+The existing comment in `consts.dart` is right that the agent decides which markup every injected selector must match — so this is an experiment, not an edit:
+
+1. Add a "modern user agent" toggle, paired with the `www` → mobile-host rewrite in `onNavigationRequest`.
+2. Watch the `no_posts_matched` diagnostic. **This is precisely what that signal was built for.**
+3. Promote to default only if it stays quiet in the field.
+
+Also available from the same file: a Google-OAuth shim (masks `navigator.webdriver`, stubs `window.chrome`) for the `disallowed_useragent` class of sign-in failure on third-party pages reached from Facebook links.
+
+### H. Screen-time limits ✅ pure Dart
+
+Per-service daily budgets with a PIN-gated lockout. A one-minute tick increments today's usage while the app is foregrounded; at the budget a full-screen overlay replaces the feed showing "used X of Y today"; the PIN allows a bypass for the rest of the day; usage prunes after seven days.
+
+For an app called *Slim*Social, "use Facebook less" is on-thesis, cheap, and a listing feature. **Cost:** ~2 days.
+
+### I. Settings export / import ✅ pure Dart
+
+A versioned JSON envelope (`kind`, `version`, `appVersion`, `exportedAt`), with every section normalised field-by-field on import so a hand-edited or older file cannot leave holes in the store, and a newer-version file rejected with its own message. Users of the custom CSS / JS / user-agent fields stop losing their setups on reinstall. `share_plus` and `file_picker` are already dependencies. **Cost:** ~½ day.
+
+### J. Long-term shelf — known, not scheduled
+
+- **Multi-account.** androidx `ProfileStore` gives real cookie-jar isolation (WebView ≥ 114). Neither `webview_flutter` nor `flutter_inappwebview` exposes it — custom native either way. Nora goes further and reads Chromium's cookie SQLite directly, using a probe cookie to map a profile name to its on-disk directory, in order to export `cookies.txt`.
+- **On-device translation.** Double-tap a post for an ML Kit translation card. The transferable part is the **build split**: a `full` / `foss` source-set pair isolating the GMS dependency so the F-Droid variant compiles it out. That is the pattern to copy if SlimSocial ever adds a GMS-touching feature while keeping an F-Droid build.
+- **File-chooser accept types.** `params.acceptTypes` can carry extensions (`.jpg`), bare MIME types, or comma-separated lists in a single entry; Android's own `createIntent()` honours only the first and passes it to `setType()` verbatim, so an extension-based list leaves the picker with an invalid filter and no visible photos. SlimSocial currently ignores `acceptTypes` entirely and single-selects — a pure-Dart improvement is available since `FileSelectorParams` carries them.
+
+---
+
+## 5. Risk register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| AGPL contamination while porting | **Blocker** | §0. This document is the specification; write original Dart. |
+| Notification poller looks like automated access to Facebook | Medium | Off by default; reuse the webview's own user agent; ≥15 min cadence; one lightweight page per poll; kill switch. |
+| 2019 user agent stops being served the touch layout | Medium, rising | Dossier G now, while there is time to gather field data. |
+| Engine-migration regressions | Medium | Branch; the existing test suite; a device checklist mirroring the existing plans. |
+| EasyList rules matching Facebook's own hosts | Low | Never block main-frame requests; implement the `@@` specificity precedence; keep the toggle separate from the DOM filter. |
+
+---
+
+## 6. Suggested sequence
+
+1. **QoL pack** (~½ day, no new deps) — dossier B.
+2. **Video download** (~1–2 days, no new deps) — dossier A; supersedes the "not in scope" note in the media-viewer plan.
+3. **Notifications** (~2–3 days, five-line cookie channel) — dossier C.
+4. **Identity features** (~3 days, pure Dart) — screen-time limits (H), settings backup (I), user-agent experiment behind a toggle (G).
+5. **Engine swap, then the locked doors** (~1–2 weeks) — dossier E, then EasyList host blocking (D2), WebRTC guard (F), `X-Requested-With` suppression, renderer-crash reload, `window.open` popups.
+
+Cosmetic EasyList filtering (D, stage 1) can be slotted anywhere from step 2 onward, since it needs nothing from the engine swap.
+
+---
+
+## 7. Attribution
+
+Nora is the work of [nonbili](https://github.com/nonbili) and its contributors, published under the AGPL-3.0. It is a well-engineered project and its source comments — which explain measured browser behaviour rather than restating code — were as useful as the code itself.
+
+Code adopted from the techniques described here is written independently, per §0. That rule needs enforcing rather than asserting: on the first adoption (the collapse fix in `lib/utils/ad_filter.dart`) a review caught two comment blocks that had drifted into close paraphrases of Nora's own wording — same argument order, same coined phrase — even though the surrounding algorithm was independently written. They were rewritten before the change landed. **Treat prose as carefully as code when working from this document**: a comment explaining a technique is the easiest place for the upstream author's expression to survive, and it is the hardest place to notice it.


### PR DESCRIPTION
## Why

Messenger was unusable on a phone in two separate ways. Both are fixed here, along with five smaller fixes to the Facebook webview and the research note the fixes came from.

Everything below was verified on a **Pixel 10 Pro**, not just in tests.

## 1. Messenger could not be signed into

Messenger authenticates against `facebook.com`, not `messenger.com`, so the login-code prompt is a `facebook.com` page — and the Messenger screen sent every `facebook.com` address to the feed. It closed itself half way through authenticating and the prompt surfaced in a webview that could not finish it.

Caught from the device log; these four all arrived in the *feed's* navigation delegate, which is only possible after the Messenger route had already popped:

```
m.facebook.com/checkpoint/start/
m.facebook.com/checkpoint/
m.facebook.com/login/checkpoint/
m.facebook.com/unified/login_via/app/
```

`isFacebookAuthUrl` keeps that flow on the Messenger screen. It matches whole path segments rather than prefixes, so `/loginhelp` and `/securityreview` stay content; the two-segment entries (`/unified/login_via`, `/privacy/consent`, `/dialog/oauth`, `/x/oauth`) need both segments because their first fronts ordinary pages. Anything unrecognised keeps the old behaviour — a missed auth path costs one failed sign-in, a content page wrongly kept there would strand the reader.

## 2. Only one conversation was reachable

Once sign-in worked, the next problem was visible: the conversation list rendered **one** row and clipped the rest.

At the 349px layout viewport a phone gives this app, the list resolves to **100px tall** — and so do its three nearest ancestors — while the scroll container inside it holds **2168px** of conversations. Sixteen were in the document; fifteen could not be reached, because the box doing the clipping was not the box that scrolls.

It is Messenger's own layout collapsing, not ours. Every ancestor from the list up to `body` was checked against every selector this app injects, at all eighteen levels, and nothing of ours matched. Nothing *declares* that 100px either — it is what the flex chain resolves to when a `flex-grow: 0` item in the middle is asked for its content height and the content it measures is a virtualised list taking its own height from the parent. A modern user agent does not change it, so the 2018 agent is not the cause.

The fix expands the chain and nothing else. Both obvious extras were tried on the device and both broke it:

- **`overflow: visible` on the ancestors** — chain expanded, list stopped scrolling completely. Messenger's own scroller is one of those descendants and already carries `overflow-y: auto`; overriding overflow up the chain takes it away from the virtualised list that depends on it. So no overflow property is touched at all.
- **`height: 100%` instead of `height: auto`** — every ancestor took its parent's full height and the content ran past the viewport with nothing to scroll it.

Verified after the change: 100px → 548px, the scroller kept `overflow-y: auto` with 2168px of content, and setting its offset to 400 moved it to 400. Confirmed by hand on the device afterwards.

Selectors key on the `grid` role, not on Facebook's generated class hashes. Worth knowing: the neighbouring `adaptMessengerPageCss` is built entirely from those hashes and **exactly one of its rules still matches anything** on today's Messenger. The `:has()` selectors sit in a rule of their own so a WebView older than Chromium 105 loses the fix and nothing else.

## 3. The rest

| Fix | Detail |
|---|---|
| **Pinch-to-zoom** | Facebook ships `maximum-scale=1, user-scalable=no`; that meta tag was the only thing stopping the gesture, since `webview_flutter_android` already enables `builtInZoomControls`. Rewritten clause by clause, reinstalled through a `MutationObserver` because in-page navigation replaces the tag. Text zoom could never enlarge a posted screenshot. |
| **Selectable post text, long-pressable images** | The touch layout sets `user-select: none` on post text and `pointer-events: none` on images. Re-enabled, scoped to the post container so app chrome is unaffected. |
| **Shared links no longer carry the reader** | 44 parameters stripped before the share sheet — `fbclid`, `mibextid`, `sfnsn`, `paipv`, `__cft__[0]` and friends. A URL the cleaner does not fully understand comes back byte for byte, so nothing is normalised for no reason. |
| **`fb://fullscreen_video/<id>`** | Used to fall through to the Custom Tab, which either handed the reader to the official app or did nothing. Now mapped back to the web address. Skipped in basic mode, which does not serve `/reel/`. |
| **Feed stops jumping** | Hiding an advert above the viewport slid everything below it up under the reader's thumb. Height *and* offset are read before the hide and the offset written back absolutely. |
| **Messenger privacy leak** | A bare `print` of the tapped URL — and Sentry collects stdout as a breadcrumb, so every link opened out of a conversation travelled with the next report. Gated behind `kDebugMode`, matching the feed. |

### On the feed-jump fix

The first version was wrong in an instructive way. It read the scroll offset *after* hiding — but Android WebView has Chromium's scroll anchoring on by default (`overflow-anchor: auto`), so the engine had already corrected the offset. Subtracting again threw the feed **up by a whole advert**: the exact symptom the change exists to remove, inverted. Reproduced in Chromium 148 on both the document and element scroller paths, then fixed by writing the offset absolutely from the pre-hide value. The same bug appears independently whenever the reader sits near the end of the feed and the engine clamps to the shorter document.

## Verified on device

Read out of the running webview's DevTools socket:

- viewport became `width=device-width, initial-scale=1, user-scalable=yes` — `maximum-scale` and `user-scalable=no` gone, tag marked
- computed `-webkit-user-select` on `.native-text` is `text` (was `none`)
- all injected stylesheets present, including the two new ones
- `window.slimRemoveAds` present, ad observer installed
- Messenger: sign-in completes, list expands, list scrolls
- no Dart exceptions, no injection failures, no health diagnostics fired

## Provenance

The techniques in §3 come from reading [nonbili/Nora](https://github.com/nonbili/Nora), which is **AGPL-3.0** while this project is **GPL-2.0** — so nothing was copied, only re-implemented from behaviour. `docs/research/2026-08-28-nora-comparative-study.md` records the study, states that clean-room rule in §0, and notes in §7 that the rule has to cover comment prose too: review caught two comment blocks that had drifted into paraphrasing upstream wording even though the algorithm was original, and they were rewritten before landing.

Both Messenger fixes are original — Nora has neither.

That doc is the one part of this PR that is not a fix. Drop the first commit if you would rather it stayed out of a public repo.

## Numbers

- Tests **306 → 409**, all passing
- Analyzer **49 → 48** infos, zero errors or warnings
- No new dependencies

## Not done

`WillPopScope` → `PopScope` in both screens. Deprecated, but the manifest has no `enableOnBackInvokedCallback` so predictive back is off and it works today. Invisible to users, and getting it wrong visibly breaks back navigation — its own commit, not alongside user-facing work.

Also left alone: `adaptMessengerPageCss`, ~40 lines of Facebook hash classes now matching nothing. Inert rather than harmful, and deleting it is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)