### PR TITLE
Ask for a rating, and capture the reason when it is low

### DIFF
--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -81,7 +81,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -74,5 +74,14 @@
   "hide_people_you_may_know": "Hide \"People you may know\"",
   "hide_reels": "Hide reels",
   "telemetry_reports": "Send anonymous reports",
-  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time."
+  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/af-ZA.json
+++ b/SlimSocial_for_Facebook/assets/lang/af-ZA.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} tot dusver versteek",
   "telemetry_reports": "Stuur anonieme verslae",
   "telemetry_reports_desc": "Anonieme fout- en breukverslae help om raak te sien wanneer 'n verandering by Facebook die app breek. Geen persoonlike data en geen bladsy-inhoud word gestuur nie. Skakel dit enige tyd af.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Geniet jy SlimSocial?",
+  "rate_subtitle": "Tik op 'n ster om te beoordeel",
+  "rate_later": "Nie nou nie",
+  "rate_low_title": "Jammer om dit te hoor",
+  "rate_low_hint": "Wat het verkeerd geloop?",
+  "rate_send": "Stuur",
+  "rate_sends_notice": "Dit stuur jou boodskap saam met die programweergawe, toestelmodel en Android-weergawe aan die ontwikkelaar. Jou instelling vir foutverslae bly af.",
+  "rate_thanks": "Dankie — dit help.",
+  "rate_failed": "Kon nie stuur nie. Probeer later weer."
 }

--- a/SlimSocial_for_Facebook/assets/lang/af-ZA.json
+++ b/SlimSocial_for_Facebook/assets/lang/af-ZA.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/af-ZA.json
+++ b/SlimSocial_for_Facebook/assets/lang/af-ZA.json
@@ -80,5 +80,14 @@
   "retry": "Probeer weer",
   "ads_blocked_count": "{} tot dusver versteek",
   "telemetry_reports": "Stuur anonieme verslae",
-  "telemetry_reports_desc": "Anonieme fout- en breukverslae help om raak te sien wanneer 'n verandering by Facebook die app breek. Geen persoonlike data en geen bladsy-inhoud word gestuur nie. Skakel dit enige tyd af."
+  "telemetry_reports_desc": "Anonieme fout- en breukverslae help om raak te sien wanneer 'n verandering by Facebook die app breek. Geen persoonlike data en geen bladsy-inhoud word gestuur nie. Skakel dit enige tyd af.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ar-AR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ar-AR.json
@@ -80,5 +80,14 @@
   "retry": "إعادة المحاولة",
   "ads_blocked_count": "تم إخفاء {} حتى الآن",
   "telemetry_reports": "إرسال تقارير مجهولة",
-  "telemetry_reports_desc": "تساعد تقارير الأعطال والأخطاء المجهولة في اكتشاف الحالات التي يؤدي فيها تغيير في فيسبوك إلى تعطّل التطبيق. لا يتم إرسال أي بيانات شخصية ولا محتوى الصفحات. يمكنك إيقاف ذلك في أي وقت."
+  "telemetry_reports_desc": "تساعد تقارير الأعطال والأخطاء المجهولة في اكتشاف الحالات التي يؤدي فيها تغيير في فيسبوك إلى تعطّل التطبيق. لا يتم إرسال أي بيانات شخصية ولا محتوى الصفحات. يمكنك إيقاف ذلك في أي وقت.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ar-AR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ar-AR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "تم إخفاء {} حتى الآن",
   "telemetry_reports": "إرسال تقارير مجهولة",
   "telemetry_reports_desc": "تساعد تقارير الأعطال والأخطاء المجهولة في اكتشاف الحالات التي يؤدي فيها تغيير في فيسبوك إلى تعطّل التطبيق. لا يتم إرسال أي بيانات شخصية ولا محتوى الصفحات. يمكنك إيقاف ذلك في أي وقت.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "هل يعجبك SlimSocial؟",
+  "rate_subtitle": "المس نجمة للتقييم",
+  "rate_later": "ليس الآن",
+  "rate_low_title": "يؤسفنا سماع ذلك",
+  "rate_low_hint": "ما الذي حدث؟",
+  "rate_send": "إرسال",
+  "rate_sends_notice": "سيؤدي هذا إلى إرسال رسالتك إلى المطور، مع إصدار التطبيق وطراز الجهاز وإصدار Android. يبقى إعداد تقارير الأعطال لديك متوقفًا.",
+  "rate_thanks": "شكرًا — هذا يساعدنا.",
+  "rate_failed": "تعذّر الإرسال. حاول مرة أخرى لاحقًا."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ar-AR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ar-AR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/bg-BG.json
+++ b/SlimSocial_for_Facebook/assets/lang/bg-BG.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/bg-BG.json
+++ b/SlimSocial_for_Facebook/assets/lang/bg-BG.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Скрити до момента: {}",
   "telemetry_reports": "Изпращане на анонимни доклади",
   "telemetry_reports_desc": "Анонимните доклади за сривове и повреди помагат да се забележи, когато промяна във Facebook счупи приложението. Не се изпращат лични данни, нито съдържание на страници. Можете да го изключите по всяко време.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Харесва ли ви SlimSocial?",
+  "rate_subtitle": "Докоснете звезда, за да оцените",
+  "rate_later": "Не сега",
+  "rate_low_title": "Съжаляваме да го чуем",
+  "rate_low_hint": "Какво се обърка?",
+  "rate_send": "Изпрати",
+  "rate_sends_notice": "Това изпраща съобщението ви на разработчика заедно с версията на приложението, модела на устройството и версията на Android. Настройката ви за отчети за грешки остава изключена.",
+  "rate_thanks": "Благодарим — това помага.",
+  "rate_failed": "Изпращането не бе успешно. Опитайте отново по-късно."
 }

--- a/SlimSocial_for_Facebook/assets/lang/bg-BG.json
+++ b/SlimSocial_for_Facebook/assets/lang/bg-BG.json
@@ -80,5 +80,14 @@
   "retry": "Опитайте отново",
   "ads_blocked_count": "Скрити до момента: {}",
   "telemetry_reports": "Изпращане на анонимни доклади",
-  "telemetry_reports_desc": "Анонимните доклади за сривове и повреди помагат да се забележи, когато промяна във Facebook счупи приложението. Не се изпращат лични данни, нито съдържание на страници. Можете да го изключите по всяко време."
+  "telemetry_reports_desc": "Анонимните доклади за сривове и повреди помагат да се забележи, когато промяна във Facebook счупи приложението. Не се изпращат лични данни, нито съдържание на страници. Можете да го изключите по всяко време.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/bn-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/bn-IN.json
@@ -80,5 +80,14 @@
   "retry": "আবার চেষ্টা করুন",
   "ads_blocked_count": "এখন পর্যন্ত {} লুকানো হয়েছে",
   "telemetry_reports": "বেনামী রিপোর্ট পাঠান",
-  "telemetry_reports_desc": "বেনামী ক্র্যাশ ও ত্রুটির রিপোর্ট Facebook-এর কোনও পরিবর্তনে অ্যাপটি ভেঙে গেলে তা শনাক্ত করতে সাহায্য করে। কোনও ব্যক্তিগত তথ্য বা পৃষ্ঠার বিষয়বস্তু পাঠানো হয় না। আপনি যেকোনো সময় এটি বন্ধ করতে পারেন।"
+  "telemetry_reports_desc": "বেনামী ক্র্যাশ ও ত্রুটির রিপোর্ট Facebook-এর কোনও পরিবর্তনে অ্যাপটি ভেঙে গেলে তা শনাক্ত করতে সাহায্য করে। কোনও ব্যক্তিগত তথ্য বা পৃষ্ঠার বিষয়বস্তু পাঠানো হয় না। আপনি যেকোনো সময় এটি বন্ধ করতে পারেন।",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/bn-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/bn-IN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/bn-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/bn-IN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "এখন পর্যন্ত {} লুকানো হয়েছে",
   "telemetry_reports": "বেনামী রিপোর্ট পাঠান",
   "telemetry_reports_desc": "বেনামী ক্র্যাশ ও ত্রুটির রিপোর্ট Facebook-এর কোনও পরিবর্তনে অ্যাপটি ভেঙে গেলে তা শনাক্ত করতে সাহায্য করে। কোনও ব্যক্তিগত তথ্য বা পৃষ্ঠার বিষয়বস্তু পাঠানো হয় না। আপনি যেকোনো সময় এটি বন্ধ করতে পারেন।",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial ভালো লাগছে?",
+  "rate_subtitle": "রেটিং দিতে একটি তারায় ট্যাপ করুন",
+  "rate_later": "এখন নয়",
+  "rate_low_title": "এটা শুনে দুঃখিত",
+  "rate_low_hint": "কী সমস্যা হয়েছে?",
+  "rate_send": "পাঠান",
+  "rate_sends_notice": "এটি আপনার বার্তা অ্যাপ সংস্করণ, ডিভাইস মডেল এবং Android সংস্করণ সহ ডেভেলপারের কাছে পাঠাবে। আপনার ক্র্যাশ রিপোর্ট সেটিং বন্ধ থাকবে।",
+  "rate_thanks": "ধন্যবাদ — এতে সাহায্য হয়।",
+  "rate_failed": "পাঠানো যায়নি। অনুগ্রহ করে পরে আবার চেষ্টা করুন।"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ca-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/ca-ES.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ca-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/ca-ES.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} amagats fins ara",
   "telemetry_reports": "Envia informes anònims",
   "telemetry_reports_desc": "Els informes anònims de fallades i errors ajuden a detectar quan un canvi de Facebook trenca l'aplicació. No s'envia cap dada personal ni cap contingut de les pàgines. Pots desactivar-ho quan vulguis.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "T'agrada SlimSocial?",
+  "rate_subtitle": "Toca una estrella per valorar",
+  "rate_later": "Ara no",
+  "rate_low_title": "Lamentem sentir-ho",
+  "rate_low_hint": "Què ha fallat?",
+  "rate_send": "Envia",
+  "rate_sends_notice": "Això envia el teu missatge al desenvolupador, juntament amb la versió de l'aplicació, el model del dispositiu i la versió d'Android. La teva configuració d'informes d'errors continua desactivada.",
+  "rate_thanks": "Gràcies — això ajuda.",
+  "rate_failed": "No s'ha pogut enviar. Torna-ho a provar més tard."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ca-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/ca-ES.json
@@ -80,5 +80,14 @@
   "retry": "Torna-ho a provar",
   "ads_blocked_count": "{} amagats fins ara",
   "telemetry_reports": "Envia informes anònims",
-  "telemetry_reports_desc": "Els informes anònims de fallades i errors ajuden a detectar quan un canvi de Facebook trenca l'aplicació. No s'envia cap dada personal ni cap contingut de les pàgines. Pots desactivar-ho quan vulguis."
+  "telemetry_reports_desc": "Els informes anònims de fallades i errors ajuden a detectar quan un canvi de Facebook trenca l'aplicació. No s'envia cap dada personal ni cap contingut de les pàgines. Pots desactivar-ho quan vulguis.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
+++ b/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
+++ b/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
@@ -80,5 +80,14 @@
   "retry": "Zkusit znovu",
   "ads_blocked_count": "Zatím skryto: {}",
   "telemetry_reports": "Odesílat anonymní hlášení",
-  "telemetry_reports_desc": "Anonymní hlášení o pádech a chybách pomáhají odhalit, když změna na Facebooku rozbije aplikaci. Neodesílají se žádné osobní údaje ani obsah stránek. Můžete to kdykoli vypnout."
+  "telemetry_reports_desc": "Anonymní hlášení o pádech a chybách pomáhají odhalit, když změna na Facebooku rozbije aplikaci. Neodesílají se žádné osobní údaje ani obsah stránek. Můžete to kdykoli vypnout.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
+++ b/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Zatím skryto: {}",
   "telemetry_reports": "Odesílat anonymní hlášení",
   "telemetry_reports_desc": "Anonymní hlášení o pádech a chybách pomáhají odhalit, když změna na Facebooku rozbije aplikaci. Neodesílají se žádné osobní údaje ani obsah stránek. Můžete to kdykoli vypnout.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Líbí se vám SlimSocial?",
+  "rate_subtitle": "Klepnutím na hvězdičku aplikaci ohodnotíte",
+  "rate_later": "Teď ne",
+  "rate_low_title": "To nás mrzí",
+  "rate_low_hint": "Co se pokazilo?",
+  "rate_send": "Odeslat",
+  "rate_sends_notice": "Tímto odešlete vývojáři svou zprávu spolu s verzí aplikace, modelem zařízení a verzí Androidu. Vaše nastavení hlášení chyb zůstává vypnuté.",
+  "rate_thanks": "Děkujeme — to pomáhá.",
+  "rate_failed": "Odeslání se nezdařilo. Zkuste to prosím později."
 }

--- a/SlimSocial_for_Facebook/assets/lang/da-DK.json
+++ b/SlimSocial_for_Facebook/assets/lang/da-DK.json
@@ -80,5 +80,14 @@
   "retry": "Prøv igen",
   "ads_blocked_count": "{} skjult indtil videre",
   "telemetry_reports": "Send anonyme rapporter",
-  "telemetry_reports_desc": "Anonyme nedbruds- og fejlrapporter hjælper med at opdage, når en ændring på Facebook ødelægger appen. Der sendes ingen personlige data og intet sideindhold. Du kan slå det fra når som helst."
+  "telemetry_reports_desc": "Anonyme nedbruds- og fejlrapporter hjælper med at opdage, når en ændring på Facebook ødelægger appen. Der sendes ingen personlige data og intet sideindhold. Du kan slå det fra når som helst.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/da-DK.json
+++ b/SlimSocial_for_Facebook/assets/lang/da-DK.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/da-DK.json
+++ b/SlimSocial_for_Facebook/assets/lang/da-DK.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} skjult indtil videre",
   "telemetry_reports": "Send anonyme rapporter",
   "telemetry_reports_desc": "Anonyme nedbruds- og fejlrapporter hjælper med at opdage, når en ændring på Facebook ødelægger appen. Der sendes ingen personlige data og intet sideindhold. Du kan slå det fra når som helst.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
+  "rate_title": "Kan du lide SlimSocial?",
+  "rate_subtitle": "Tryk på en stjerne for at bedømme",
+  "rate_later": "Ikke nu",
+  "rate_low_title": "Det er vi kede af at høre",
+  "rate_low_hint": "Hvad gik galt?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_sends_notice": "Dette sender din besked til udvikleren sammen med appversionen, enhedsmodellen og Android-versionen. Din indstilling for fejlrapporter forbliver slået fra.",
+  "rate_thanks": "Tak — det hjælper.",
+  "rate_failed": "Kunne ikke sende. Prøv igen senere."
 }

--- a/SlimSocial_for_Facebook/assets/lang/de-DE.json
+++ b/SlimSocial_for_Facebook/assets/lang/de-DE.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Bisher {} ausgeblendet",
   "telemetry_reports": "Anonyme Berichte senden",
   "telemetry_reports_desc": "Anonyme Absturz- und Fehlerberichte helfen zu erkennen, wenn eine Änderung bei Facebook die App kaputt macht. Es werden keine personenbezogenen Daten und keine Seiteninhalte gesendet. Du kannst das jederzeit ausschalten.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Gefällt dir SlimSocial?",
+  "rate_subtitle": "Tippe auf einen Stern, um zu bewerten",
+  "rate_later": "Jetzt nicht",
+  "rate_low_title": "Das tut uns leid",
+  "rate_low_hint": "Was hat nicht funktioniert?",
+  "rate_send": "Senden",
+  "rate_sends_notice": "Dies sendet deine Nachricht zusammen mit der App-Version, dem Gerätemodell und der Android-Version an den Entwickler. Deine Einstellung für Fehlerberichte bleibt ausgeschaltet.",
+  "rate_thanks": "Danke — das hilft.",
+  "rate_failed": "Senden fehlgeschlagen. Bitte versuche es später erneut."
 }

--- a/SlimSocial_for_Facebook/assets/lang/de-DE.json
+++ b/SlimSocial_for_Facebook/assets/lang/de-DE.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/de-DE.json
+++ b/SlimSocial_for_Facebook/assets/lang/de-DE.json
@@ -80,5 +80,14 @@
   "retry": "Erneut versuchen",
   "ads_blocked_count": "Bisher {} ausgeblendet",
   "telemetry_reports": "Anonyme Berichte senden",
-  "telemetry_reports_desc": "Anonyme Absturz- und Fehlerberichte helfen zu erkennen, wenn eine Änderung bei Facebook die App kaputt macht. Es werden keine personenbezogenen Daten und keine Seiteninhalte gesendet. Du kannst das jederzeit ausschalten."
+  "telemetry_reports_desc": "Anonyme Absturz- und Fehlerberichte helfen zu erkennen, wenn eine Änderung bei Facebook die App kaputt macht. Es werden keine personenbezogenen Daten und keine Seiteninhalte gesendet. Du kannst das jederzeit ausschalten.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/el-GR.json
+++ b/SlimSocial_for_Facebook/assets/lang/el-GR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Έχουν αποκρυφτεί {} μέχρι τώρα",
   "telemetry_reports": "Αποστολή ανώνυμων αναφορών",
   "telemetry_reports_desc": "Οι ανώνυμες αναφορές σφαλμάτων και βλαβών βοηθούν να εντοπίζεται πότε μια αλλαγή του Facebook χαλάει την εφαρμογή. Δεν αποστέλλονται προσωπικά δεδομένα ούτε περιεχόμενο σελίδων. Μπορείτε να το απενεργοποιήσετε όποτε θέλετε.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Σας αρέσει το SlimSocial;",
+  "rate_subtitle": "Πατήστε ένα αστέρι για βαθμολόγηση",
+  "rate_later": "Όχι τώρα",
+  "rate_low_title": "Λυπούμαστε που το ακούμε",
+  "rate_low_hint": "Τι πήγε στραβά;",
+  "rate_send": "Αποστολή",
+  "rate_sends_notice": "Αυτό στέλνει το μήνυμά σας στον προγραμματιστή, μαζί με την έκδοση της εφαρμογής, το μοντέλο της συσκευής και την έκδοση Android. Η ρύθμισή σας για τις αναφορές σφαλμάτων παραμένει απενεργοποιημένη.",
+  "rate_thanks": "Ευχαριστούμε — αυτό βοηθάει.",
+  "rate_failed": "Η αποστολή απέτυχε. Δοκιμάστε ξανά αργότερα."
 }

--- a/SlimSocial_for_Facebook/assets/lang/el-GR.json
+++ b/SlimSocial_for_Facebook/assets/lang/el-GR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/el-GR.json
+++ b/SlimSocial_for_Facebook/assets/lang/el-GR.json
@@ -80,5 +80,14 @@
   "retry": "Δοκιμή ξανά",
   "ads_blocked_count": "Έχουν αποκρυφτεί {} μέχρι τώρα",
   "telemetry_reports": "Αποστολή ανώνυμων αναφορών",
-  "telemetry_reports_desc": "Οι ανώνυμες αναφορές σφαλμάτων και βλαβών βοηθούν να εντοπίζεται πότε μια αλλαγή του Facebook χαλάει την εφαρμογή. Δεν αποστέλλονται προσωπικά δεδομένα ούτε περιεχόμενο σελίδων. Μπορείτε να το απενεργοποιήσετε όποτε θέλετε."
+  "telemetry_reports_desc": "Οι ανώνυμες αναφορές σφαλμάτων και βλαβών βοηθούν να εντοπίζεται πότε μια αλλαγή του Facebook χαλάει την εφαρμογή. Δεν αποστέλλονται προσωπικά δεδομένα ούτε περιεχόμενο σελίδων. Μπορείτε να το απενεργοποιήσετε όποτε θέλετε.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -80,5 +80,14 @@
   "retry": "Try again",
   "ads_blocked_count": "{} hidden so far",
   "telemetry_reports": "Send anonymous reports",
-  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time."
+  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/es-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/es-ES.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/es-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/es-ES.json
@@ -80,5 +80,14 @@
   "retry": "Reintentar",
   "ads_blocked_count": "{} ocultados hasta ahora",
   "telemetry_reports": "Enviar informes anónimos",
-  "telemetry_reports_desc": "Los informes anónimos de fallos y errores ayudan a detectar cuándo un cambio de Facebook rompe la aplicación. No se envían datos personales ni el contenido de las páginas. Puedes desactivarlo cuando quieras."
+  "telemetry_reports_desc": "Los informes anónimos de fallos y errores ayudan a detectar cuándo un cambio de Facebook rompe la aplicación. No se envían datos personales ni el contenido de las páginas. Puedes desactivarlo cuando quieras.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/es-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/es-ES.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} ocultados hasta ahora",
   "telemetry_reports": "Enviar informes anónimos",
   "telemetry_reports_desc": "Los informes anónimos de fallos y errores ayudan a detectar cuándo un cambio de Facebook rompe la aplicación. No se envían datos personales ni el contenido de las páginas. Puedes desactivarlo cuando quieras.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "¿Te gusta SlimSocial?",
+  "rate_subtitle": "Toca una estrella para valorar",
+  "rate_later": "Ahora no",
+  "rate_low_title": "Lamentamos oír eso",
+  "rate_low_hint": "¿Qué ha fallado?",
+  "rate_send": "Enviar",
+  "rate_sends_notice": "Esto envía tu mensaje al desarrollador, junto con la versión de la aplicación, el modelo del dispositivo y la versión de Android. Tu ajuste de informes de errores sigue desactivado.",
+  "rate_thanks": "Gracias — esto ayuda.",
+  "rate_failed": "No se pudo enviar. Inténtalo de nuevo más tarde."
 }

--- a/SlimSocial_for_Facebook/assets/lang/et-EE.json
+++ b/SlimSocial_for_Facebook/assets/lang/et-EE.json
@@ -80,5 +80,14 @@
   "retry": "Proovi uuesti",
   "ads_blocked_count": "Seni peidetud: {}",
   "telemetry_reports": "Saada anonüümseid raporteid",
-  "telemetry_reports_desc": "Anonüümsed krahhi- ja tõrkeraportid aitavad märgata, kui Facebooki muudatus rakenduse katki teeb. Isikuandmeid ega lehtede sisu ei saadeta. Saad selle igal ajal välja lülitada."
+  "telemetry_reports_desc": "Anonüümsed krahhi- ja tõrkeraportid aitavad märgata, kui Facebooki muudatus rakenduse katki teeb. Isikuandmeid ega lehtede sisu ei saadeta. Saad selle igal ajal välja lülitada.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/et-EE.json
+++ b/SlimSocial_for_Facebook/assets/lang/et-EE.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/et-EE.json
+++ b/SlimSocial_for_Facebook/assets/lang/et-EE.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Seni peidetud: {}",
   "telemetry_reports": "Saada anonüümseid raporteid",
   "telemetry_reports_desc": "Anonüümsed krahhi- ja tõrkeraportid aitavad märgata, kui Facebooki muudatus rakenduse katki teeb. Isikuandmeid ega lehtede sisu ei saadeta. Saad selle igal ajal välja lülitada.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Kas SlimSocial meeldib?",
+  "rate_subtitle": "Hindamiseks puuduta tärni",
+  "rate_later": "Mitte praegu",
+  "rate_low_title": "Kahju kuulda",
+  "rate_low_hint": "Mis läks valesti?",
+  "rate_send": "Saada",
+  "rate_sends_notice": "See saadab arendajale sinu sõnumi koos rakenduse versiooni, seadme mudeli ja Androidi versiooniga. Sinu veaaruannete säte jääb välja lülitatuks.",
+  "rate_thanks": "Aitäh — sellest on abi.",
+  "rate_failed": "Saatmine ebaõnnestus. Proovi hiljem uuesti."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fa-IR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fa-IR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fa-IR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fa-IR.json
@@ -80,5 +80,14 @@
   "retry": "تلاش دوباره",
   "ads_blocked_count": "تاکنون {} مورد پنهان شد",
   "telemetry_reports": "ارسال گزارش‌های ناشناس",
-  "telemetry_reports_desc": "گزارش‌های ناشناس خرابی و اشکال کمک می‌کنند تشخیص دهیم چه زمانی تغییری در فیسبوک برنامه را خراب کرده است. هیچ داده شخصی و هیچ محتوای صفحه‌ای ارسال نمی‌شود. هر زمان بخواهید می‌توانید آن را خاموش کنید."
+  "telemetry_reports_desc": "گزارش‌های ناشناس خرابی و اشکال کمک می‌کنند تشخیص دهیم چه زمانی تغییری در فیسبوک برنامه را خراب کرده است. هیچ داده شخصی و هیچ محتوای صفحه‌ای ارسال نمی‌شود. هر زمان بخواهید می‌توانید آن را خاموش کنید.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fa-IR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fa-IR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "تاکنون {} مورد پنهان شد",
   "telemetry_reports": "ارسال گزارش‌های ناشناس",
   "telemetry_reports_desc": "گزارش‌های ناشناس خرابی و اشکال کمک می‌کنند تشخیص دهیم چه زمانی تغییری در فیسبوک برنامه را خراب کرده است. هیچ داده شخصی و هیچ محتوای صفحه‌ای ارسال نمی‌شود. هر زمان بخواهید می‌توانید آن را خاموش کنید.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "از SlimSocial راضی هستید؟",
+  "rate_subtitle": "برای امتیازدهی روی یک ستاره ضربه بزنید",
+  "rate_later": "الان نه",
+  "rate_low_title": "متأسفیم که این را می‌شنویم",
+  "rate_low_hint": "چه مشکلی پیش آمد؟",
+  "rate_send": "ارسال",
+  "rate_sends_notice": "با این کار پیام شما همراه با نسخهٔ برنامه، مدل دستگاه و نسخهٔ Android برای توسعه‌دهنده ارسال می‌شود. تنظیم گزارش خطای شما خاموش باقی می‌ماند.",
+  "rate_thanks": "ممنون — این کمک می‌کند.",
+  "rate_failed": "ارسال نشد. لطفاً بعداً دوباره تلاش کنید."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fi-FI.json
+++ b/SlimSocial_for_Facebook/assets/lang/fi-FI.json
@@ -80,5 +80,14 @@
   "retry": "Yritä uudelleen",
   "ads_blocked_count": "Piilotettu {} tähän mennessä",
   "telemetry_reports": "Lähetä nimettömiä raportteja",
-  "telemetry_reports_desc": "Nimettömät kaatumis- ja virheraportit auttavat huomaamaan, kun Facebookin muutos rikkoo sovelluksen. Henkilötietoja tai sivujen sisältöä ei lähetetä. Voit kytkeä tämän pois päältä milloin tahansa."
+  "telemetry_reports_desc": "Nimettömät kaatumis- ja virheraportit auttavat huomaamaan, kun Facebookin muutos rikkoo sovelluksen. Henkilötietoja tai sivujen sisältöä ei lähetetä. Voit kytkeä tämän pois päältä milloin tahansa.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fi-FI.json
+++ b/SlimSocial_for_Facebook/assets/lang/fi-FI.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fi-FI.json
+++ b/SlimSocial_for_Facebook/assets/lang/fi-FI.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Piilotettu {} tähän mennessä",
   "telemetry_reports": "Lähetä nimettömiä raportteja",
   "telemetry_reports_desc": "Nimettömät kaatumis- ja virheraportit auttavat huomaamaan, kun Facebookin muutos rikkoo sovelluksen. Henkilötietoja tai sivujen sisältöä ei lähetetä. Voit kytkeä tämän pois päältä milloin tahansa.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Pidätkö SlimSocialista?",
+  "rate_subtitle": "Anna arvio napauttamalla tähteä",
+  "rate_later": "Ei nyt",
+  "rate_low_title": "Ikävä kuulla",
+  "rate_low_hint": "Mikä meni pieleen?",
+  "rate_send": "Lähetä",
+  "rate_sends_notice": "Tämä lähettää viestisi kehittäjälle sekä sovelluksen version, laitemallin ja Android-version. Virheraporttien asetuksesi pysyy pois päältä.",
+  "rate_thanks": "Kiitos — tästä on apua.",
+  "rate_failed": "Lähetys epäonnistui. Yritä myöhemmin uudelleen."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fr-FR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fr-FR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} masqués jusqu'à présent",
   "telemetry_reports": "Envoyer des rapports anonymes",
   "telemetry_reports_desc": "Les rapports anonymes de plantage et de dysfonctionnement aident à repérer quand un changement de Facebook casse l'application. Aucune donnée personnelle ni contenu de page n'est envoyé. Vous pouvez le désactiver à tout moment.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial vous plaît ?",
+  "rate_subtitle": "Touchez une étoile pour noter",
+  "rate_later": "Pas maintenant",
+  "rate_low_title": "Désolé de l'apprendre",
+  "rate_low_hint": "Qu'est-ce qui n'a pas fonctionné ?",
+  "rate_send": "Envoyer",
+  "rate_sends_notice": "Cela envoie votre message au développeur, ainsi que la version de l'application, le modèle de votre appareil et la version d'Android. Votre réglage des rapports d'erreur reste désactivé.",
+  "rate_thanks": "Merci — c'est utile.",
+  "rate_failed": "Envoi impossible. Réessayez plus tard."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fr-FR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fr-FR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/fr-FR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fr-FR.json
@@ -80,5 +80,14 @@
   "retry": "Réessayer",
   "ads_blocked_count": "{} masqués jusqu'à présent",
   "telemetry_reports": "Envoyer des rapports anonymes",
-  "telemetry_reports_desc": "Les rapports anonymes de plantage et de dysfonctionnement aident à repérer quand un changement de Facebook casse l'application. Aucune donnée personnelle ni contenu de page n'est envoyé. Vous pouvez le désactiver à tout moment."
+  "telemetry_reports_desc": "Les rapports anonymes de plantage et de dysfonctionnement aident à repérer quand un changement de Facebook casse l'application. Aucune donnée personnelle ni contenu de page n'est envoyé. Vous pouvez le désactiver à tout moment.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ha-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ha-NG.json
@@ -80,5 +80,14 @@
   "retry": "Sake gwadawa",
   "ads_blocked_count": "An ɓoye {} zuwa yanzu",
   "telemetry_reports": "Send anonymous reports",
-  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time."
+  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ha-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ha-NG.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ha-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ha-NG.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "An ɓoye {} zuwa yanzu",
   "telemetry_reports": "Send anonymous reports",
   "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Kana jin daɗin SlimSocial?",
+  "rate_subtitle": "Taɓa tauraro don ba da kima",
+  "rate_later": "Ba yanzu ba",
+  "rate_low_title": "Mun yi hakuri da jin haka",
+  "rate_low_hint": "Me ya faru?",
+  "rate_send": "Aika",
+  "rate_sends_notice": "Wannan yana aika saƙonka ga mai haɓakawa, tare da sigar manhaja, samfurin na'ura da sigar Android. Saitin rahoton kuskure naka zai kasance a kashe.",
+  "rate_thanks": "Na gode — wannan yana taimakawa.",
+  "rate_failed": "An kasa aikawa. Da fatan a sake gwadawa daga baya."
 }

--- a/SlimSocial_for_Facebook/assets/lang/he-IL.json
+++ b/SlimSocial_for_Facebook/assets/lang/he-IL.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} הוסתרו עד כה",
   "telemetry_reports": "שליחת דוחות אנונימיים",
   "telemetry_reports_desc": "דוחות אנונימיים על קריסות ותקלות עוזרים לזהות מתי שינוי בפייסבוק שובר את האפליקציה. לא נשלחים נתונים אישיים ולא תוכן של דפים. אפשר לכבות את זה בכל רגע.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "נהנים מ-SlimSocial?",
+  "rate_subtitle": "הקישו על כוכב כדי לדרג",
+  "rate_later": "לא עכשיו",
+  "rate_low_title": "מצטערים לשמוע",
+  "rate_low_hint": "מה השתבש?",
+  "rate_send": "שליחה",
+  "rate_sends_notice": "פעולה זו שולחת את ההודעה שלך למפתח, יחד עם גרסת האפליקציה, דגם המכשיר וגרסת Android. ההגדרה שלך לדוחות קריסה נשארת כבויה.",
+  "rate_thanks": "תודה — זה עוזר.",
+  "rate_failed": "השליחה נכשלה. נסו שוב מאוחר יותר."
 }

--- a/SlimSocial_for_Facebook/assets/lang/he-IL.json
+++ b/SlimSocial_for_Facebook/assets/lang/he-IL.json
@@ -80,5 +80,14 @@
   "retry": "נסה שוב",
   "ads_blocked_count": "{} הוסתרו עד כה",
   "telemetry_reports": "שליחת דוחות אנונימיים",
-  "telemetry_reports_desc": "דוחות אנונימיים על קריסות ותקלות עוזרים לזהות מתי שינוי בפייסבוק שובר את האפליקציה. לא נשלחים נתונים אישיים ולא תוכן של דפים. אפשר לכבות את זה בכל רגע."
+  "telemetry_reports_desc": "דוחות אנונימיים על קריסות ותקלות עוזרים לזהות מתי שינוי בפייסבוק שובר את האפליקציה. לא נשלחים נתונים אישיים ולא תוכן של דפים. אפשר לכבות את זה בכל רגע.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/he-IL.json
+++ b/SlimSocial_for_Facebook/assets/lang/he-IL.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hi-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/hi-IN.json
@@ -80,5 +80,14 @@
   "retry": "फिर से कोशिश करें",
   "ads_blocked_count": "अब तक {} छिपाए गए",
   "telemetry_reports": "गुमनाम रिपोर्ट भेजें",
-  "telemetry_reports_desc": "गुमनाम क्रैश और खराबी की रिपोर्ट यह पहचानने में मदद करती हैं कि Facebook में कोई बदलाव कब ऐप को तोड़ देता है। कोई निजी जानकारी या पेज की सामग्री नहीं भेजी जाती। आप इसे कभी भी बंद कर सकते हैं।"
+  "telemetry_reports_desc": "गुमनाम क्रैश और खराबी की रिपोर्ट यह पहचानने में मदद करती हैं कि Facebook में कोई बदलाव कब ऐप को तोड़ देता है। कोई निजी जानकारी या पेज की सामग्री नहीं भेजी जाती। आप इसे कभी भी बंद कर सकते हैं।",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hi-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/hi-IN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hi-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/hi-IN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "अब तक {} छिपाए गए",
   "telemetry_reports": "गुमनाम रिपोर्ट भेजें",
   "telemetry_reports_desc": "गुमनाम क्रैश और खराबी की रिपोर्ट यह पहचानने में मदद करती हैं कि Facebook में कोई बदलाव कब ऐप को तोड़ देता है। कोई निजी जानकारी या पेज की सामग्री नहीं भेजी जाती। आप इसे कभी भी बंद कर सकते हैं।",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial पसंद आ रहा है?",
+  "rate_subtitle": "रेटिंग देने के लिए किसी सितारे पर टैप करें",
+  "rate_later": "अभी नहीं",
+  "rate_low_title": "यह जानकर खेद हुआ",
+  "rate_low_hint": "क्या गड़बड़ हुई?",
+  "rate_send": "भेजें",
+  "rate_sends_notice": "इससे आपका संदेश ऐप संस्करण, डिवाइस मॉडल और Android संस्करण के साथ डेवलपर को भेजा जाएगा। आपकी क्रैश रिपोर्ट सेटिंग बंद रहेगी।",
+  "rate_thanks": "धन्यवाद — इससे मदद मिलती है।",
+  "rate_failed": "भेजा नहीं जा सका। कृपया बाद में पुनः प्रयास करें।"
 }

--- a/SlimSocial_for_Facebook/assets/lang/hr-HR.json
+++ b/SlimSocial_for_Facebook/assets/lang/hr-HR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Dosad skriveno: {}",
   "telemetry_reports": "Šalji anonimne izvještaje",
   "telemetry_reports_desc": "Anonimni izvještaji o rušenjima i kvarovima pomažu uočiti kada promjena na Facebooku pokvari aplikaciju. Ne šalju se nikakvi osobni podaci ni sadržaj stranica. To možete isključiti u bilo kojem trenutku.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Sviđa li vam se SlimSocial?",
+  "rate_subtitle": "Dodirnite zvjezdicu za ocjenu",
+  "rate_later": "Ne sada",
+  "rate_low_title": "Žao nam je zbog toga",
+  "rate_low_hint": "Što je pošlo po zlu?",
+  "rate_send": "Pošalji",
+  "rate_sends_notice": "Ovo šalje vašu poruku razvijatelju zajedno s verzijom aplikacije, modelom uređaja i verzijom Androida. Vaša postavka izvješća o pogreškama ostaje isključena.",
+  "rate_thanks": "Hvala — ovo pomaže.",
+  "rate_failed": "Slanje nije uspjelo. Pokušajte ponovno kasnije."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hr-HR.json
+++ b/SlimSocial_for_Facebook/assets/lang/hr-HR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hr-HR.json
+++ b/SlimSocial_for_Facebook/assets/lang/hr-HR.json
@@ -80,5 +80,14 @@
   "retry": "Pokušaj ponovno",
   "ads_blocked_count": "Dosad skriveno: {}",
   "telemetry_reports": "Šalji anonimne izvještaje",
-  "telemetry_reports_desc": "Anonimni izvještaji o rušenjima i kvarovima pomažu uočiti kada promjena na Facebooku pokvari aplikaciju. Ne šalju se nikakvi osobni podaci ni sadržaj stranica. To možete isključiti u bilo kojem trenutku."
+  "telemetry_reports_desc": "Anonimni izvještaji o rušenjima i kvarovima pomažu uočiti kada promjena na Facebooku pokvari aplikaciju. Ne šalju se nikakvi osobni podaci ni sadržaj stranica. To možete isključiti u bilo kojem trenutku.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hu-HU.json
+++ b/SlimSocial_for_Facebook/assets/lang/hu-HU.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hu-HU.json
+++ b/SlimSocial_for_Facebook/assets/lang/hu-HU.json
@@ -80,5 +80,14 @@
   "retry": "Újrapróbálkozás",
   "ads_blocked_count": "Eddig {} elrejtve",
   "telemetry_reports": "Névtelen jelentések küldése",
-  "telemetry_reports_desc": "A névtelen összeomlás- és hibajelentések segítenek észrevenni, ha a Facebook egy változtatása elrontja az alkalmazást. Semmilyen személyes adat és oldaltartalom nem kerül elküldésre. Bármikor kikapcsolhatod."
+  "telemetry_reports_desc": "A névtelen összeomlás- és hibajelentések segítenek észrevenni, ha a Facebook egy változtatása elrontja az alkalmazást. Semmilyen személyes adat és oldaltartalom nem kerül elküldésre. Bármikor kikapcsolhatod.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/hu-HU.json
+++ b/SlimSocial_for_Facebook/assets/lang/hu-HU.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Eddig {} elrejtve",
   "telemetry_reports": "Névtelen jelentések küldése",
   "telemetry_reports_desc": "A névtelen összeomlás- és hibajelentések segítenek észrevenni, ha a Facebook egy változtatása elrontja az alkalmazást. Semmilyen személyes adat és oldaltartalom nem kerül elküldésre. Bármikor kikapcsolhatod.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Tetszik a SlimSocial?",
+  "rate_subtitle": "Koppints egy csillagra az értékeléshez",
+  "rate_later": "Most nem",
+  "rate_low_title": "Sajnáljuk",
+  "rate_low_hint": "Mi nem működött?",
+  "rate_send": "Küldés",
+  "rate_sends_notice": "Ez elküldi az üzenetedet a fejlesztőnek az alkalmazás verziójával, az eszköz modelljével és az Android verziójával együtt. A hibajelentések beállítása kikapcsolva marad.",
+  "rate_thanks": "Köszönjük — ez segít.",
+  "rate_failed": "Nem sikerült elküldeni. Próbáld újra később."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ig-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ig-NG.json
@@ -80,5 +80,14 @@
   "retry": "Nwaa ọzọ",
   "ads_blocked_count": "Ezochiela {} ruo ugbu a",
   "telemetry_reports": "Send anonymous reports",
-  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time."
+  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ig-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ig-NG.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ig-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ig-NG.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Ezochiela {} ruo ugbu a",
   "telemetry_reports": "Send anonymous reports",
   "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial ọ na-amasị gị?",
+  "rate_subtitle": "Pịa kpakpando iji nye ọkwa",
+  "rate_later": "Ọ bụghị ugbu a",
+  "rate_low_title": "Ọ dị nwute ịnụ nke ahụ",
+  "rate_low_hint": "Gịnị mere?",
+  "rate_send": "Zipu",
+  "rate_sends_notice": "Nke a na-ezigara onye mmepe ozi gị, tinyere ụdị ngwa, ụdị ngwaọrụ na ụdị Android. Ntọala mkpesa nkwubi gị ga-anọgide na-agbanyụ.",
+  "rate_thanks": "Daalụ — nke a na-enyere aka.",
+  "rate_failed": "Enweghị ike izipu. Biko nwaa ọzọ ma emesịa."
 }

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -80,5 +80,14 @@
   "retry": "Riprova",
   "ads_blocked_count": "{} nascosti finora",
   "telemetry_reports": "Invia segnalazioni anonime",
-  "telemetry_reports_desc": "Le segnalazioni anonime di crash e malfunzionamenti aiutano a capire quando una modifica di Facebook rompe l'app. Non vengono inviati dati personali né il contenuto delle pagine. Puoi disattivarle quando vuoi."
+  "telemetry_reports_desc": "Le segnalazioni anonime di crash e malfunzionamenti aiutano a capire quando una modifica di Facebook rompe l'app. Non vengono inviati dati personali né il contenuto delle pagine. Puoi disattivarle quando vuoi.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} nascosti finora",
   "telemetry_reports": "Invia segnalazioni anonime",
   "telemetry_reports_desc": "Le segnalazioni anonime di crash e malfunzionamenti aiutano a capire quando una modifica di Facebook rompe l'app. Non vengono inviati dati personali né il contenuto delle pagine. Puoi disattivarle quando vuoi.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Ti piace SlimSocial?",
+  "rate_subtitle": "Tocca una stella per votare",
+  "rate_later": "Non ora",
+  "rate_low_title": "Ci dispiace",
+  "rate_low_hint": "Cosa non ha funzionato?",
+  "rate_send": "Invia",
+  "rate_sends_notice": "Questo invia il tuo messaggio allo sviluppatore, insieme alla versione dell'app, al modello del dispositivo e alla versione di Android. L'impostazione sulle segnalazioni di errori resta disattivata.",
+  "rate_thanks": "Grazie — è utile.",
+  "rate_failed": "Invio non riuscito. Riprova più tardi."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ja-JP.json
+++ b/SlimSocial_for_Facebook/assets/lang/ja-JP.json
@@ -80,5 +80,14 @@
   "retry": "再試行",
   "ads_blocked_count": "これまでに{}件を非表示にしました",
   "telemetry_reports": "匿名レポートを送信",
-  "telemetry_reports_desc": "匿名のクラッシュ・不具合レポートは、Facebook側の変更でアプリが壊れたことに気づく助けになります。個人情報やページの内容は送信されません。いつでもオフにできます。"
+  "telemetry_reports_desc": "匿名のクラッシュ・不具合レポートは、Facebook側の変更でアプリが壊れたことに気づく助けになります。個人情報やページの内容は送信されません。いつでもオフにできます。",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ja-JP.json
+++ b/SlimSocial_for_Facebook/assets/lang/ja-JP.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ja-JP.json
+++ b/SlimSocial_for_Facebook/assets/lang/ja-JP.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "これまでに{}件を非表示にしました",
   "telemetry_reports": "匿名レポートを送信",
   "telemetry_reports_desc": "匿名のクラッシュ・不具合レポートは、Facebook側の変更でアプリが壊れたことに気づく助けになります。個人情報やページの内容は送信されません。いつでもオフにできます。",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial はいかがですか？",
+  "rate_subtitle": "星をタップして評価してください",
+  "rate_later": "後で",
+  "rate_low_title": "ご不便をおかけしました",
+  "rate_low_hint": "何が問題でしたか？",
+  "rate_send": "送信",
+  "rate_sends_notice": "メッセージが、アプリのバージョン、端末のモデル、Android のバージョンとともに開発者に送信されます。クラッシュレポートの設定はオフのままです。",
+  "rate_thanks": "ありがとうございます — 助かります。",
+  "rate_failed": "送信できませんでした。後でもう一度お試しください。"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ko-KR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ko-KR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ko-KR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ko-KR.json
@@ -80,5 +80,14 @@
   "retry": "다시 시도",
   "ads_blocked_count": "지금까지 {}개 숨김",
   "telemetry_reports": "익명 보고서 보내기",
-  "telemetry_reports_desc": "익명 오류 및 고장 보고서는 Facebook의 변경으로 앱이 망가진 시점을 파악하는 데 도움이 됩니다. 개인 정보나 페이지 내용은 전송되지 않습니다. 언제든지 끌 수 있습니다."
+  "telemetry_reports_desc": "익명 오류 및 고장 보고서는 Facebook의 변경으로 앱이 망가진 시점을 파악하는 데 도움이 됩니다. 개인 정보나 페이지 내용은 전송되지 않습니다. 언제든지 끌 수 있습니다.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ko-KR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ko-KR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "지금까지 {}개 숨김",
   "telemetry_reports": "익명 보고서 보내기",
   "telemetry_reports_desc": "익명 오류 및 고장 보고서는 Facebook의 변경으로 앱이 망가진 시점을 파악하는 데 도움이 됩니다. 개인 정보나 페이지 내용은 전송되지 않습니다. 언제든지 끌 수 있습니다.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial이 마음에 드시나요?",
+  "rate_subtitle": "별을 탭하여 평가해 주세요",
+  "rate_later": "나중에",
+  "rate_low_title": "불편을 드려 죄송합니다",
+  "rate_low_hint": "무엇이 문제였나요?",
+  "rate_send": "보내기",
+  "rate_sends_notice": "메시지가 앱 버전, 기기 모델, Android 버전과 함께 개발자에게 전송됩니다. 오류 보고 설정은 계속 꺼져 있습니다.",
+  "rate_thanks": "감사합니다 — 큰 도움이 됩니다.",
+  "rate_failed": "보내지 못했습니다. 나중에 다시 시도해 주세요."
 }

--- a/SlimSocial_for_Facebook/assets/lang/lt-LT.json
+++ b/SlimSocial_for_Facebook/assets/lang/lt-LT.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Iki šiol paslėpta: {}",
   "telemetry_reports": "Siųsti anoniminius pranešimus",
   "telemetry_reports_desc": "Anoniminiai strigčių ir gedimų pranešimai padeda pastebėti, kai „Facebook“ pakeitimas sugadina programėlę. Jokie asmens duomenys ir puslapių turinys nesiunčiami. Tai galite išjungti bet kada.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Ar patinka „SlimSocial“?",
+  "rate_subtitle": "Palieskite žvaigždutę, kad įvertintumėte",
+  "rate_later": "Ne dabar",
+  "rate_low_title": "Gaila tai girdėti",
+  "rate_low_hint": "Kas nutiko?",
+  "rate_send": "Siųsti",
+  "rate_sends_notice": "Taip kūrėjui bus išsiųsta jūsų žinutė kartu su programėlės versija, įrenginio modeliu ir „Android“ versija. Jūsų klaidų ataskaitų nustatymas lieka išjungtas.",
+  "rate_thanks": "Ačiū — tai padeda.",
+  "rate_failed": "Nepavyko išsiųsti. Bandykite vėliau."
 }

--- a/SlimSocial_for_Facebook/assets/lang/lt-LT.json
+++ b/SlimSocial_for_Facebook/assets/lang/lt-LT.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/lt-LT.json
+++ b/SlimSocial_for_Facebook/assets/lang/lt-LT.json
@@ -80,5 +80,14 @@
   "retry": "Bandyti dar kartą",
   "ads_blocked_count": "Iki šiol paslėpta: {}",
   "telemetry_reports": "Siųsti anoniminius pranešimus",
-  "telemetry_reports_desc": "Anoniminiai strigčių ir gedimų pranešimai padeda pastebėti, kai „Facebook“ pakeitimas sugadina programėlę. Jokie asmens duomenys ir puslapių turinys nesiunčiami. Tai galite išjungti bet kada."
+  "telemetry_reports_desc": "Anoniminiai strigčių ir gedimų pranešimai padeda pastebėti, kai „Facebook“ pakeitimas sugadina programėlę. Jokie asmens duomenys ir puslapių turinys nesiunčiami. Tai galite išjungti bet kada.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/lv-LV.json
+++ b/SlimSocial_for_Facebook/assets/lang/lv-LV.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/lv-LV.json
+++ b/SlimSocial_for_Facebook/assets/lang/lv-LV.json
@@ -80,5 +80,14 @@
   "retry": "Mēģināt vēlreiz",
   "ads_blocked_count": "Līdz šim paslēpti: {}",
   "telemetry_reports": "Sūtīt anonīmus ziņojumus",
-  "telemetry_reports_desc": "Anonīmi avāriju un kļūmju ziņojumi palīdz pamanīt, kad Facebook izmaiņas salauž lietotni. Netiek sūtīti nekādi personas dati un lapu saturs. To var izslēgt jebkurā brīdī."
+  "telemetry_reports_desc": "Anonīmi avāriju un kļūmju ziņojumi palīdz pamanīt, kad Facebook izmaiņas salauž lietotni. Netiek sūtīti nekādi personas dati un lapu saturs. To var izslēgt jebkurā brīdī.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/lv-LV.json
+++ b/SlimSocial_for_Facebook/assets/lang/lv-LV.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Līdz šim paslēpti: {}",
   "telemetry_reports": "Sūtīt anonīmus ziņojumus",
   "telemetry_reports_desc": "Anonīmi avāriju un kļūmju ziņojumi palīdz pamanīt, kad Facebook izmaiņas salauž lietotni. Netiek sūtīti nekādi personas dati un lapu saturs. To var izslēgt jebkurā brīdī.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Vai SlimSocial patīk?",
+  "rate_subtitle": "Pieskarieties zvaigznei, lai novērtētu",
+  "rate_later": "Ne tagad",
+  "rate_low_title": "Žēl to dzirdēt",
+  "rate_low_hint": "Kas nogāja greizi?",
+  "rate_send": "Sūtīt",
+  "rate_sends_notice": "Tas nosūta izstrādātājam jūsu ziņojumu kopā ar lietotnes versiju, ierīces modeli un Android versiju. Jūsu kļūdu ziņojumu iestatījums paliek izslēgts.",
+  "rate_thanks": "Paldies — tas palīdz.",
+  "rate_failed": "Neizdevās nosūtīt. Mēģiniet vēlreiz vēlāk."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ml-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ml-IN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ml-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ml-IN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "ഇതുവരെ {} എണ്ണം മറച്ചു",
   "telemetry_reports": "അജ്ഞാത റിപ്പോർട്ടുകൾ അയയ്ക്കുക",
   "telemetry_reports_desc": "അജ്ഞാതമായ ക്രാഷ്, തകരാർ റിപ്പോർട്ടുകൾ Facebook-ലെ ഒരു മാറ്റം ആപ്പ് തകർക്കുമ്പോൾ അത് തിരിച്ചറിയാൻ സഹായിക്കുന്നു. വ്യക്തിഗത വിവരങ്ങളോ പേജിലെ ഉള്ളടക്കമോ അയയ്ക്കുന്നില്ല. എപ്പോൾ വേണമെങ്കിലും ഇത് ഓഫ് ചെയ്യാം.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial ഇഷ്ടപ്പെടുന്നുണ്ടോ?",
+  "rate_subtitle": "റേറ്റ് ചെയ്യാൻ ഒരു നക്ഷത്രത്തിൽ ടാപ്പ് ചെയ്യുക",
+  "rate_later": "ഇപ്പോൾ വേണ്ട",
+  "rate_low_title": "അത് കേട്ടതിൽ ഖേദമുണ്ട്",
+  "rate_low_hint": "എന്താണ് പ്രശ്നം?",
+  "rate_send": "അയയ്ക്കുക",
+  "rate_sends_notice": "ഇത് നിങ്ങളുടെ സന്ദേശം ആപ്പ് പതിപ്പ്, ഉപകരണ മോഡൽ, Android പതിപ്പ് എന്നിവയ്‌ക്കൊപ്പം ഡെവലപ്പർക്ക് അയയ്ക്കും. നിങ്ങളുടെ ക്രാഷ് റിപ്പോർട്ട് ക്രമീകരണം ഓഫായി തുടരും.",
+  "rate_thanks": "നന്ദി — ഇത് സഹായകരമാണ്.",
+  "rate_failed": "അയയ്ക്കാനായില്ല. ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ml-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ml-IN.json
@@ -80,5 +80,14 @@
   "retry": "വീണ്ടും ശ്രമിക്കുക",
   "ads_blocked_count": "ഇതുവരെ {} എണ്ണം മറച്ചു",
   "telemetry_reports": "അജ്ഞാത റിപ്പോർട്ടുകൾ അയയ്ക്കുക",
-  "telemetry_reports_desc": "അജ്ഞാതമായ ക്രാഷ്, തകരാർ റിപ്പോർട്ടുകൾ Facebook-ലെ ഒരു മാറ്റം ആപ്പ് തകർക്കുമ്പോൾ അത് തിരിച്ചറിയാൻ സഹായിക്കുന്നു. വ്യക്തിഗത വിവരങ്ങളോ പേജിലെ ഉള്ളടക്കമോ അയയ്ക്കുന്നില്ല. എപ്പോൾ വേണമെങ്കിലും ഇത് ഓഫ് ചെയ്യാം."
+  "telemetry_reports_desc": "അജ്ഞാതമായ ക്രാഷ്, തകരാർ റിപ്പോർട്ടുകൾ Facebook-ലെ ഒരു മാറ്റം ആപ്പ് തകർക്കുമ്പോൾ അത് തിരിച്ചറിയാൻ സഹായിക്കുന്നു. വ്യക്തിഗത വിവരങ്ങളോ പേജിലെ ഉള്ളടക്കമോ അയയ്ക്കുന്നില്ല. എപ്പോൾ വേണമെങ്കിലും ഇത് ഓഫ് ചെയ്യാം.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/mr-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/mr-IN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "आतापर्यंत {} लपवले",
   "telemetry_reports": "निनावी अहवाल पाठवा",
   "telemetry_reports_desc": "निनावी क्रॅश आणि बिघाडाचे अहवाल Facebook मधील बदलामुळे अ‍ॅप कधी बिघडते हे ओळखण्यास मदत करतात. कोणतीही वैयक्तिक माहिती किंवा पानावरील मजकूर पाठवला जात नाही. तुम्ही हे कधीही बंद करू शकता.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial आवडत आहे?",
+  "rate_subtitle": "रेटिंग देण्यासाठी ताऱ्यावर टॅप करा",
+  "rate_later": "आत्ता नाही",
+  "rate_low_title": "हे ऐकून वाईट वाटले",
+  "rate_low_hint": "काय चूक झाली?",
+  "rate_send": "पाठवा",
+  "rate_sends_notice": "यामुळे तुमचा संदेश अ‍ॅप आवृत्ती, डिव्हाइस मॉडेल आणि Android आवृत्तीसह विकसकाला पाठवला जाईल. तुमची क्रॅश अहवाल सेटिंग बंदच राहील.",
+  "rate_thanks": "धन्यवाद — याची मदत होते.",
+  "rate_failed": "पाठवता आले नाही. कृपया नंतर पुन्हा प्रयत्न करा."
 }

--- a/SlimSocial_for_Facebook/assets/lang/mr-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/mr-IN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/mr-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/mr-IN.json
@@ -80,5 +80,14 @@
   "retry": "पुन्हा प्रयत्न करा",
   "ads_blocked_count": "आतापर्यंत {} लपवले",
   "telemetry_reports": "निनावी अहवाल पाठवा",
-  "telemetry_reports_desc": "निनावी क्रॅश आणि बिघाडाचे अहवाल Facebook मधील बदलामुळे अ‍ॅप कधी बिघडते हे ओळखण्यास मदत करतात. कोणतीही वैयक्तिक माहिती किंवा पानावरील मजकूर पाठवला जात नाही. तुम्ही हे कधीही बंद करू शकता."
+  "telemetry_reports_desc": "निनावी क्रॅश आणि बिघाडाचे अहवाल Facebook मधील बदलामुळे अ‍ॅप कधी बिघडते हे ओळखण्यास मदत करतात. कोणतीही वैयक्तिक माहिती किंवा पानावरील मजकूर पाठवला जात नाही. तुम्ही हे कधीही बंद करू शकता.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/nl-NL.json
+++ b/SlimSocial_for_Facebook/assets/lang/nl-NL.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} tot nu toe verborgen",
   "telemetry_reports": "Anonieme rapporten versturen",
   "telemetry_reports_desc": "Anonieme crash- en storingsrapporten helpen te zien wanneer een wijziging bij Facebook de app kapotmaakt. Er worden geen persoonlijke gegevens en geen pagina-inhoud verstuurd. Je kunt dit altijd uitschakelen.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Bevalt SlimSocial?",
+  "rate_subtitle": "Tik op een ster om te beoordelen",
+  "rate_later": "Niet nu",
+  "rate_low_title": "Wat vervelend om te horen",
+  "rate_low_hint": "Wat ging er mis?",
+  "rate_send": "Verzenden",
+  "rate_sends_notice": "Hiermee stuur je je bericht naar de ontwikkelaar, samen met de app-versie, het apparaatmodel en de Android-versie. Je instelling voor foutrapporten blijft uitgeschakeld.",
+  "rate_thanks": "Bedankt — hier hebben we wat aan.",
+  "rate_failed": "Verzenden mislukt. Probeer het later opnieuw."
 }

--- a/SlimSocial_for_Facebook/assets/lang/nl-NL.json
+++ b/SlimSocial_for_Facebook/assets/lang/nl-NL.json
@@ -80,5 +80,14 @@
   "retry": "Opnieuw proberen",
   "ads_blocked_count": "{} tot nu toe verborgen",
   "telemetry_reports": "Anonieme rapporten versturen",
-  "telemetry_reports_desc": "Anonieme crash- en storingsrapporten helpen te zien wanneer een wijziging bij Facebook de app kapotmaakt. Er worden geen persoonlijke gegevens en geen pagina-inhoud verstuurd. Je kunt dit altijd uitschakelen."
+  "telemetry_reports_desc": "Anonieme crash- en storingsrapporten helpen te zien wanneer een wijziging bij Facebook de app kapotmaakt. Er worden geen persoonlijke gegevens en geen pagina-inhoud verstuurd. Je kunt dit altijd uitschakelen.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/nl-NL.json
+++ b/SlimSocial_for_Facebook/assets/lang/nl-NL.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/no-NO.json
+++ b/SlimSocial_for_Facebook/assets/lang/no-NO.json
@@ -80,5 +80,14 @@
   "retry": "Prøv igjen",
   "ads_blocked_count": "{} skjult så langt",
   "telemetry_reports": "Send anonyme rapporter",
-  "telemetry_reports_desc": "Anonyme krasj- og feilrapporter hjelper med å oppdage når en endring på Facebook ødelegger appen. Ingen personopplysninger og ikke noe sideinnhold sendes. Du kan slå det av når som helst."
+  "telemetry_reports_desc": "Anonyme krasj- og feilrapporter hjelper med å oppdage når en endring på Facebook ødelegger appen. Ingen personopplysninger og ikke noe sideinnhold sendes. Du kan slå det av når som helst.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/no-NO.json
+++ b/SlimSocial_for_Facebook/assets/lang/no-NO.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/no-NO.json
+++ b/SlimSocial_for_Facebook/assets/lang/no-NO.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} skjult så langt",
   "telemetry_reports": "Send anonyme rapporter",
   "telemetry_reports_desc": "Anonyme krasj- og feilrapporter hjelper med å oppdage når en endring på Facebook ødelegger appen. Ingen personopplysninger og ikke noe sideinnhold sendes. Du kan slå det av når som helst.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
+  "rate_title": "Liker du SlimSocial?",
+  "rate_subtitle": "Trykk på en stjerne for å vurdere",
+  "rate_later": "Ikke nå",
+  "rate_low_title": "Det var leit å høre",
+  "rate_low_hint": "Hva gikk galt?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_sends_notice": "Dette sender meldingen din til utvikleren, sammen med appversjonen, enhetsmodellen og Android-versjonen. Innstillingen din for feilrapporter forblir av.",
+  "rate_thanks": "Takk — dette hjelper.",
+  "rate_failed": "Kunne ikke sende. Prøv igjen senere."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} don hide so far",
   "telemetry_reports": "Send anonymous reports",
   "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
+  "rate_title": "You dey enjoy SlimSocial?",
+  "rate_subtitle": "Tap star make you rate am",
   "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
+  "rate_low_title": "Sorry to hear am",
+  "rate_low_hint": "Wetin happen?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_sends_notice": "Dis one go send your message give di developer, plus your app version, device model and Android version. Your crash report setting go still dey off.",
+  "rate_thanks": "Thank you — e dey help.",
+  "rate_failed": "E no fit send. Abeg try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
@@ -80,5 +80,14 @@
   "retry": "Try again",
   "ads_blocked_count": "{} don hide so far",
   "telemetry_reports": "Send anonymous reports",
-  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time."
+  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pl-PL.json
+++ b/SlimSocial_for_Facebook/assets/lang/pl-PL.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Do tej pory ukryto: {}",
   "telemetry_reports": "Wysyłaj anonimowe raporty",
   "telemetry_reports_desc": "Anonimowe raporty o awariach i usterkach pomagają zauważyć, kiedy zmiana na Facebooku psuje aplikację. Nie są wysyłane żadne dane osobowe ani treść stron. Możesz to wyłączyć w każdej chwili.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Podoba Ci się SlimSocial?",
+  "rate_subtitle": "Dotknij gwiazdki, aby ocenić",
+  "rate_later": "Nie teraz",
+  "rate_low_title": "Przykro nam to słyszeć",
+  "rate_low_hint": "Co poszło nie tak?",
+  "rate_send": "Wyślij",
+  "rate_sends_notice": "Spowoduje to wysłanie Twojej wiadomości do dewelopera wraz z wersją aplikacji, modelem urządzenia i wersją Androida. Twoje ustawienie raportów o błędach pozostaje wyłączone.",
+  "rate_thanks": "Dziękujemy — to pomaga.",
+  "rate_failed": "Nie udało się wysłać. Spróbuj ponownie później."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pl-PL.json
+++ b/SlimSocial_for_Facebook/assets/lang/pl-PL.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pl-PL.json
+++ b/SlimSocial_for_Facebook/assets/lang/pl-PL.json
@@ -80,5 +80,14 @@
   "retry": "Spróbuj ponownie",
   "ads_blocked_count": "Do tej pory ukryto: {}",
   "telemetry_reports": "Wysyłaj anonimowe raporty",
-  "telemetry_reports_desc": "Anonimowe raporty o awariach i usterkach pomagają zauważyć, kiedy zmiana na Facebooku psuje aplikację. Nie są wysyłane żadne dane osobowe ani treść stron. Możesz to wyłączyć w każdej chwili."
+  "telemetry_reports_desc": "Anonimowe raporty o awariach i usterkach pomagają zauważyć, kiedy zmiana na Facebooku psuje aplikację. Nie są wysyłane żadne dane osobowe ani treść stron. Możesz to wyłączyć w każdej chwili.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-BR.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-BR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} ocultados até agora",
   "telemetry_reports": "Enviar relatórios anônimos",
   "telemetry_reports_desc": "Relatórios anônimos de falhas e erros ajudam a perceber quando uma mudança do Facebook quebra o app. Nenhum dado pessoal e nenhum conteúdo das páginas é enviado. Você pode desativar isso quando quiser.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Está gostando do SlimSocial?",
+  "rate_subtitle": "Toque em uma estrela para avaliar",
+  "rate_later": "Agora não",
+  "rate_low_title": "Sentimos muito por isso",
+  "rate_low_hint": "O que deu errado?",
+  "rate_send": "Enviar",
+  "rate_sends_notice": "Isso envia sua mensagem ao desenvolvedor, junto com a versão do aplicativo, o modelo do aparelho e a versão do Android. Sua configuração de relatórios de erro continua desativada.",
+  "rate_thanks": "Obrigado — isso ajuda.",
+  "rate_failed": "Não foi possível enviar. Tente novamente mais tarde."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-BR.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-BR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-BR.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-BR.json
@@ -80,5 +80,14 @@
   "retry": "Tentar novamente",
   "ads_blocked_count": "{} ocultados até agora",
   "telemetry_reports": "Enviar relatórios anônimos",
-  "telemetry_reports_desc": "Relatórios anônimos de falhas e erros ajudam a perceber quando uma mudança do Facebook quebra o app. Nenhum dado pessoal e nenhum conteúdo das páginas é enviado. Você pode desativar isso quando quiser."
+  "telemetry_reports_desc": "Relatórios anônimos de falhas e erros ajudam a perceber quando uma mudança do Facebook quebra o app. Nenhum dado pessoal e nenhum conteúdo das páginas é enviado. Você pode desativar isso quando quiser.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-PT.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-PT.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-PT.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-PT.json
@@ -80,5 +80,14 @@
   "retry": "Tentar novamente",
   "ads_blocked_count": "{} ocultados até agora",
   "telemetry_reports": "Enviar relatórios anónimos",
-  "telemetry_reports_desc": "Os relatórios anónimos de falhas e erros ajudam a perceber quando uma alteração do Facebook estraga a aplicação. Não são enviados dados pessoais nem o conteúdo das páginas. Pode desativar isto a qualquer momento."
+  "telemetry_reports_desc": "Os relatórios anónimos de falhas e erros ajudam a perceber quando uma alteração do Facebook estraga a aplicação. Não são enviados dados pessoais nem o conteúdo das páginas. Pode desativar isto a qualquer momento.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-PT.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-PT.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} ocultados até agora",
   "telemetry_reports": "Enviar relatórios anónimos",
   "telemetry_reports_desc": "Os relatórios anónimos de falhas e erros ajudam a perceber quando uma alteração do Facebook estraga a aplicação. Não são enviados dados pessoais nem o conteúdo das páginas. Pode desativar isto a qualquer momento.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Está a gostar do SlimSocial?",
+  "rate_subtitle": "Toque numa estrela para avaliar",
+  "rate_later": "Agora não",
+  "rate_low_title": "Lamentamos saber isso",
+  "rate_low_hint": "O que correu mal?",
+  "rate_send": "Enviar",
+  "rate_sends_notice": "Isto envia a sua mensagem ao programador, juntamente com a versão da aplicação, o modelo do dispositivo e a versão do Android. A sua definição de relatórios de erros permanece desativada.",
+  "rate_thanks": "Obrigado — isto ajuda.",
+  "rate_failed": "Não foi possível enviar. Tente novamente mais tarde."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ro-RO.json
+++ b/SlimSocial_for_Facebook/assets/lang/ro-RO.json
@@ -80,5 +80,14 @@
   "retry": "Reîncercați",
   "ads_blocked_count": "{} ascunse până acum",
   "telemetry_reports": "Trimite rapoarte anonime",
-  "telemetry_reports_desc": "Rapoartele anonime despre blocări și defecțiuni ajută la observarea momentului în care o modificare Facebook strică aplicația. Nu sunt trimise date personale și nici conținutul paginilor. Poți dezactiva oricând."
+  "telemetry_reports_desc": "Rapoartele anonime despre blocări și defecțiuni ajută la observarea momentului în care o modificare Facebook strică aplicația. Nu sunt trimise date personale și nici conținutul paginilor. Poți dezactiva oricând.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ro-RO.json
+++ b/SlimSocial_for_Facebook/assets/lang/ro-RO.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ro-RO.json
+++ b/SlimSocial_for_Facebook/assets/lang/ro-RO.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} ascunse până acum",
   "telemetry_reports": "Trimite rapoarte anonime",
   "telemetry_reports_desc": "Rapoartele anonime despre blocări și defecțiuni ajută la observarea momentului în care o modificare Facebook strică aplicația. Nu sunt trimise date personale și nici conținutul paginilor. Poți dezactiva oricând.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Îți place SlimSocial?",
+  "rate_subtitle": "Atinge o stea pentru a evalua",
+  "rate_later": "Nu acum",
+  "rate_low_title": "Ne pare rău să auzim asta",
+  "rate_low_hint": "Ce nu a funcționat?",
+  "rate_send": "Trimite",
+  "rate_sends_notice": "Aceasta trimite mesajul tău către dezvoltator, împreună cu versiunea aplicației, modelul dispozitivului și versiunea Android. Setarea ta pentru rapoartele de eroare rămâne dezactivată.",
+  "rate_thanks": "Mulțumim — asta ajută.",
+  "rate_failed": "Trimiterea a eșuat. Încearcă din nou mai târziu."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ru-RU.json
+++ b/SlimSocial_for_Facebook/assets/lang/ru-RU.json
@@ -80,5 +80,14 @@
   "retry": "Повторить",
   "ads_blocked_count": "Скрыто: {}",
   "telemetry_reports": "Отправлять анонимные отчёты",
-  "telemetry_reports_desc": "Анонимные отчёты о сбоях и поломках помогают заметить, когда изменение в Facebook ломает приложение. Личные данные и содержимое страниц не отправляются. Это можно отключить в любой момент."
+  "telemetry_reports_desc": "Анонимные отчёты о сбоях и поломках помогают заметить, когда изменение в Facebook ломает приложение. Личные данные и содержимое страниц не отправляются. Это можно отключить в любой момент.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ru-RU.json
+++ b/SlimSocial_for_Facebook/assets/lang/ru-RU.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ru-RU.json
+++ b/SlimSocial_for_Facebook/assets/lang/ru-RU.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Скрыто: {}",
   "telemetry_reports": "Отправлять анонимные отчёты",
   "telemetry_reports_desc": "Анонимные отчёты о сбоях и поломках помогают заметить, когда изменение в Facebook ломает приложение. Личные данные и содержимое страниц не отправляются. Это можно отключить в любой момент.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Нравится SlimSocial?",
+  "rate_subtitle": "Коснитесь звезды, чтобы оценить",
+  "rate_later": "Не сейчас",
+  "rate_low_title": "Жаль это слышать",
+  "rate_low_hint": "Что пошло не так?",
+  "rate_send": "Отправить",
+  "rate_sends_notice": "Это отправит разработчику ваше сообщение вместе с версией приложения, моделью устройства и версией Android. Настройка отчётов об ошибках останется выключенной.",
+  "rate_thanks": "Спасибо — это помогает.",
+  "rate_failed": "Не удалось отправить. Повторите попытку позже."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sk-SK.json
+++ b/SlimSocial_for_Facebook/assets/lang/sk-SK.json
@@ -80,5 +80,14 @@
   "retry": "Skúsiť znova",
   "ads_blocked_count": "Zatiaľ skrytých: {}",
   "telemetry_reports": "Odosielať anonymné hlásenia",
-  "telemetry_reports_desc": "Anonymné hlásenia o pádoch a poruchách pomáhajú odhaliť, kedy zmena na Facebooku pokazí aplikáciu. Neodosielajú sa žiadne osobné údaje ani obsah stránok. Môžete to kedykoľvek vypnúť."
+  "telemetry_reports_desc": "Anonymné hlásenia o pádoch a poruchách pomáhajú odhaliť, kedy zmena na Facebooku pokazí aplikáciu. Neodosielajú sa žiadne osobné údaje ani obsah stránok. Môžete to kedykoľvek vypnúť.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sk-SK.json
+++ b/SlimSocial_for_Facebook/assets/lang/sk-SK.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Zatiaľ skrytých: {}",
   "telemetry_reports": "Odosielať anonymné hlásenia",
   "telemetry_reports_desc": "Anonymné hlásenia o pádoch a poruchách pomáhajú odhaliť, kedy zmena na Facebooku pokazí aplikáciu. Neodosielajú sa žiadne osobné údaje ani obsah stránok. Môžete to kedykoľvek vypnúť.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Páči sa vám SlimSocial?",
+  "rate_subtitle": "Klepnutím na hviezdičku aplikáciu ohodnotíte",
+  "rate_later": "Teraz nie",
+  "rate_low_title": "To nás mrzí",
+  "rate_low_hint": "Čo sa pokazilo?",
+  "rate_send": "Odoslať",
+  "rate_sends_notice": "Týmto odošlete vývojárovi svoju správu spolu s verziou aplikácie, modelom zariadenia a verziou Androidu. Vaše nastavenie hlásení chýb zostáva vypnuté.",
+  "rate_thanks": "Ďakujeme — to pomáha.",
+  "rate_failed": "Odoslanie zlyhalo. Skúste to znova neskôr."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sk-SK.json
+++ b/SlimSocial_for_Facebook/assets/lang/sk-SK.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sl-SI.json
+++ b/SlimSocial_for_Facebook/assets/lang/sl-SI.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sl-SI.json
+++ b/SlimSocial_for_Facebook/assets/lang/sl-SI.json
@@ -80,5 +80,14 @@
   "retry": "Poskusi znova",
   "ads_blocked_count": "Doslej skritih: {}",
   "telemetry_reports": "Pošiljaj anonimna poročila",
-  "telemetry_reports_desc": "Anonimna poročila o sesutjih in okvarah pomagajo opaziti, kdaj sprememba na Facebooku pokvari aplikacijo. Osebni podatki in vsebina strani se ne pošiljajo. To lahko kadar koli izklopite."
+  "telemetry_reports_desc": "Anonimna poročila o sesutjih in okvarah pomagajo opaziti, kdaj sprememba na Facebooku pokvari aplikacijo. Osebni podatki in vsebina strani se ne pošiljajo. To lahko kadar koli izklopite.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sl-SI.json
+++ b/SlimSocial_for_Facebook/assets/lang/sl-SI.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Doslej skritih: {}",
   "telemetry_reports": "Pošiljaj anonimna poročila",
   "telemetry_reports_desc": "Anonimna poročila o sesutjih in okvarah pomagajo opaziti, kdaj sprememba na Facebooku pokvari aplikacijo. Osebni podatki in vsebina strani se ne pošiljajo. To lahko kadar koli izklopite.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Vam je SlimSocial všeč?",
+  "rate_subtitle": "Dotaknite se zvezdice za oceno",
+  "rate_later": "Ne zdaj",
+  "rate_low_title": "Žal nam je za to",
+  "rate_low_hint": "Kaj je šlo narobe?",
+  "rate_send": "Pošlji",
+  "rate_sends_notice": "S tem boste razvijalcu poslali svoje sporočilo skupaj z različico aplikacije, modelom naprave in različico Androida. Vaša nastavitev poročil o napakah ostane izklopljena.",
+  "rate_thanks": "Hvala — to pomaga.",
+  "rate_failed": "Pošiljanje ni uspelo. Poskusite znova pozneje."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sr-SP.json
+++ b/SlimSocial_for_Facebook/assets/lang/sr-SP.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sr-SP.json
+++ b/SlimSocial_for_Facebook/assets/lang/sr-SP.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Dosad sakriveno: {}",
   "telemetry_reports": "Šalji anonimne izveštaje",
   "telemetry_reports_desc": "Anonimni izveštaji o padovima i kvarovima pomažu da se primeti kada promena na Facebooku pokvari aplikaciju. Ne šalju se lični podaci ni sadržaj stranica. Ovo možete isključiti u bilo kom trenutku.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Sviđa li vam se SlimSocial?",
+  "rate_subtitle": "Dodirnite zvezdicu da biste ocenili",
+  "rate_later": "Ne sada",
+  "rate_low_title": "Žao nam je zbog toga",
+  "rate_low_hint": "Šta je pošlo naopako?",
+  "rate_send": "Pošalji",
+  "rate_sends_notice": "Ovo šalje vašu poruku programeru zajedno sa verzijom aplikacije, modelom uređaja i verzijom Androida. Vaše podešavanje izveštaja o greškama ostaje isključeno.",
+  "rate_thanks": "Hvala — ovo pomaže.",
+  "rate_failed": "Slanje nije uspelo. Pokušajte ponovo kasnije."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sr-SP.json
+++ b/SlimSocial_for_Facebook/assets/lang/sr-SP.json
@@ -80,5 +80,14 @@
   "retry": "Pokušaj ponovo",
   "ads_blocked_count": "Dosad sakriveno: {}",
   "telemetry_reports": "Šalji anonimne izveštaje",
-  "telemetry_reports_desc": "Anonimni izveštaji o padovima i kvarovima pomažu da se primeti kada promena na Facebooku pokvari aplikaciju. Ne šalju se lični podaci ni sadržaj stranica. Ovo možete isključiti u bilo kom trenutku."
+  "telemetry_reports_desc": "Anonimni izveštaji o padovima i kvarovima pomažu da se primeti kada promena na Facebooku pokvari aplikaciju. Ne šalju se lični podaci ni sadržaj stranica. Ovo možete isključiti u bilo kom trenutku.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sv-SE.json
+++ b/SlimSocial_for_Facebook/assets/lang/sv-SE.json
@@ -80,5 +80,14 @@
   "retry": "Försök igen",
   "ads_blocked_count": "{} dolda hittills",
   "telemetry_reports": "Skicka anonyma rapporter",
-  "telemetry_reports_desc": "Anonyma krasch- och felrapporter hjälper till att upptäcka när en ändring hos Facebook gör att appen slutar fungera. Inga personuppgifter och inget sidinnehåll skickas. Du kan stänga av det när som helst."
+  "telemetry_reports_desc": "Anonyma krasch- och felrapporter hjälper till att upptäcka när en ändring hos Facebook gör att appen slutar fungera. Inga personuppgifter och inget sidinnehåll skickas. Du kan stänga av det när som helst.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sv-SE.json
+++ b/SlimSocial_for_Facebook/assets/lang/sv-SE.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/sv-SE.json
+++ b/SlimSocial_for_Facebook/assets/lang/sv-SE.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "{} dolda hittills",
   "telemetry_reports": "Skicka anonyma rapporter",
   "telemetry_reports_desc": "Anonyma krasch- och felrapporter hjälper till att upptäcka när en ändring hos Facebook gör att appen slutar fungera. Inga personuppgifter och inget sidinnehåll skickas. Du kan stänga av det när som helst.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Gillar du SlimSocial?",
+  "rate_subtitle": "Tryck på en stjärna för att betygsätta",
+  "rate_later": "Inte nu",
+  "rate_low_title": "Tråkigt att höra",
+  "rate_low_hint": "Vad gick fel?",
+  "rate_send": "Skicka",
+  "rate_sends_notice": "Detta skickar ditt meddelande till utvecklaren, tillsammans med appversionen, enhetsmodellen och Android-versionen. Din inställning för felrapporter förblir avstängd.",
+  "rate_thanks": "Tack — det hjälper.",
+  "rate_failed": "Kunde inte skicka. Försök igen senare."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ta-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ta-IN.json
@@ -80,5 +80,14 @@
   "retry": "மீண்டும் முயலவும்",
   "ads_blocked_count": "இதுவரை {} மறைக்கப்பட்டன",
   "telemetry_reports": "அநாமதேய அறிக்கைகளை அனுப்பு",
-  "telemetry_reports_desc": "அநாமதேய செயலிழப்பு மற்றும் கோளாறு அறிக்கைகள், Facebook-இல் ஏற்படும் மாற்றம் செயலியைப் பழுதாக்கும்போது அதைக் கண்டறிய உதவுகின்றன. தனிப்பட்ட தகவல்களோ பக்க உள்ளடக்கமோ அனுப்பப்படுவதில்லை. இதை எப்போது வேண்டுமானாலும் நிறுத்தலாம்."
+  "telemetry_reports_desc": "அநாமதேய செயலிழப்பு மற்றும் கோளாறு அறிக்கைகள், Facebook-இல் ஏற்படும் மாற்றம் செயலியைப் பழுதாக்கும்போது அதைக் கண்டறிய உதவுகின்றன. தனிப்பட்ட தகவல்களோ பக்க உள்ளடக்கமோ அனுப்பப்படுவதில்லை. இதை எப்போது வேண்டுமானாலும் நிறுத்தலாம்.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ta-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ta-IN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ta-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ta-IN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "இதுவரை {} மறைக்கப்பட்டன",
   "telemetry_reports": "அநாமதேய அறிக்கைகளை அனுப்பு",
   "telemetry_reports_desc": "அநாமதேய செயலிழப்பு மற்றும் கோளாறு அறிக்கைகள், Facebook-இல் ஏற்படும் மாற்றம் செயலியைப் பழுதாக்கும்போது அதைக் கண்டறிய உதவுகின்றன. தனிப்பட்ட தகவல்களோ பக்க உள்ளடக்கமோ அனுப்பப்படுவதில்லை. இதை எப்போது வேண்டுமானாலும் நிறுத்தலாம்.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial பிடித்திருக்கிறதா?",
+  "rate_subtitle": "மதிப்பிட ஒரு நட்சத்திரத்தைத் தட்டவும்",
+  "rate_later": "இப்போது வேண்டாம்",
+  "rate_low_title": "அதைக் கேட்க வருந்துகிறோம்",
+  "rate_low_hint": "என்ன தவறு நடந்தது?",
+  "rate_send": "அனுப்பு",
+  "rate_sends_notice": "இது உங்கள் செய்தியை ஆப் பதிப்பு, சாதன மாடல் மற்றும் Android பதிப்புடன் உருவாக்குநருக்கு அனுப்பும். உங்கள் செயலிழப்பு அறிக்கை அமைப்பு அணைக்கப்பட்டே இருக்கும்.",
+  "rate_thanks": "நன்றி — இது உதவுகிறது.",
+  "rate_failed": "அனுப்ப முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்."
 }

--- a/SlimSocial_for_Facebook/assets/lang/te-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/te-IN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/te-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/te-IN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "ఇప్పటివరకు {} దాచబడ్డాయి",
   "telemetry_reports": "అనామక నివేదికలను పంపండి",
   "telemetry_reports_desc": "అనామక క్రాష్ మరియు లోపాల నివేదికలు Facebook లో వచ్చిన మార్పు యాప్‌ను ఎప్పుడు పాడు చేసిందో గుర్తించడంలో సహాయపడతాయి. వ్యక్తిగత సమాచారం గానీ పేజీ కంటెంట్ గానీ పంపబడదు. దీన్ని మీరు ఎప్పుడైనా ఆఫ్ చేయవచ్చు.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial నచ్చిందా?",
+  "rate_subtitle": "రేటింగ్ ఇవ్వడానికి ఒక నక్షత్రాన్ని నొక్కండి",
+  "rate_later": "ఇప్పుడు కాదు",
+  "rate_low_title": "అది వినడం బాధగా ఉంది",
+  "rate_low_hint": "ఏమి తప్పు జరిగింది?",
+  "rate_send": "పంపు",
+  "rate_sends_notice": "ఇది మీ సందేశాన్ని యాప్ వెర్షన్, పరికర మోడల్ మరియు Android వెర్షన్‌తో పాటు డెవలపర్‌కు పంపుతుంది. మీ క్రాష్ రిపోర్ట్ సెట్టింగ్ ఆఫ్‌లోనే ఉంటుంది.",
+  "rate_thanks": "ధన్యవాదాలు — ఇది సహాయపడుతుంది.",
+  "rate_failed": "పంపడం సాధ్యం కాలేదు. దయచేసి తర్వాత మళ్లీ ప్రయత్నించండి."
 }

--- a/SlimSocial_for_Facebook/assets/lang/te-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/te-IN.json
@@ -80,5 +80,14 @@
   "retry": "మళ్లీ ప్రయత్నించండి",
   "ads_blocked_count": "ఇప్పటివరకు {} దాచబడ్డాయి",
   "telemetry_reports": "అనామక నివేదికలను పంపండి",
-  "telemetry_reports_desc": "అనామక క్రాష్ మరియు లోపాల నివేదికలు Facebook లో వచ్చిన మార్పు యాప్‌ను ఎప్పుడు పాడు చేసిందో గుర్తించడంలో సహాయపడతాయి. వ్యక్తిగత సమాచారం గానీ పేజీ కంటెంట్ గానీ పంపబడదు. దీన్ని మీరు ఎప్పుడైనా ఆఫ్ చేయవచ్చు."
+  "telemetry_reports_desc": "అనామక క్రాష్ మరియు లోపాల నివేదికలు Facebook లో వచ్చిన మార్పు యాప్‌ను ఎప్పుడు పాడు చేసిందో గుర్తించడంలో సహాయపడతాయి. వ్యక్తిగత సమాచారం గానీ పేజీ కంటెంట్ గానీ పంపబడదు. దీన్ని మీరు ఎప్పుడైనా ఆఫ్ చేయవచ్చు.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/th-TH.json
+++ b/SlimSocial_for_Facebook/assets/lang/th-TH.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "ซ่อนไปแล้ว {} รายการ",
   "telemetry_reports": "ส่งรายงานแบบไม่ระบุตัวตน",
   "telemetry_reports_desc": "รายงานข้อขัดข้องและความเสียหายแบบไม่ระบุตัวตนช่วยให้รู้ว่าการเปลี่ยนแปลงของ Facebook ทำให้แอปใช้งานไม่ได้เมื่อใด ไม่มีการส่งข้อมูลส่วนตัวหรือเนื้อหาของหน้าเว็บ คุณปิดได้ทุกเมื่อ",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "ชอบ SlimSocial ไหม",
+  "rate_subtitle": "แตะที่ดาวเพื่อให้คะแนน",
+  "rate_later": "ไว้ทีหลัง",
+  "rate_low_title": "เสียใจที่ได้ยินเช่นนั้น",
+  "rate_low_hint": "เกิดอะไรขึ้น",
+  "rate_send": "ส่ง",
+  "rate_sends_notice": "การดำเนินการนี้จะส่งข้อความของคุณไปยังผู้พัฒนา พร้อมกับเวอร์ชันแอป รุ่นอุปกรณ์ และเวอร์ชัน Android การตั้งค่ารายงานข้อขัดข้องของคุณจะยังคงปิดอยู่",
+  "rate_thanks": "ขอบคุณ — ช่วยได้มาก",
+  "rate_failed": "ส่งไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง"
 }

--- a/SlimSocial_for_Facebook/assets/lang/th-TH.json
+++ b/SlimSocial_for_Facebook/assets/lang/th-TH.json
@@ -80,5 +80,14 @@
   "retry": "ลองอีกครั้ง",
   "ads_blocked_count": "ซ่อนไปแล้ว {} รายการ",
   "telemetry_reports": "ส่งรายงานแบบไม่ระบุตัวตน",
-  "telemetry_reports_desc": "รายงานข้อขัดข้องและความเสียหายแบบไม่ระบุตัวตนช่วยให้รู้ว่าการเปลี่ยนแปลงของ Facebook ทำให้แอปใช้งานไม่ได้เมื่อใด ไม่มีการส่งข้อมูลส่วนตัวหรือเนื้อหาของหน้าเว็บ คุณปิดได้ทุกเมื่อ"
+  "telemetry_reports_desc": "รายงานข้อขัดข้องและความเสียหายแบบไม่ระบุตัวตนช่วยให้รู้ว่าการเปลี่ยนแปลงของ Facebook ทำให้แอปใช้งานไม่ได้เมื่อใด ไม่มีการส่งข้อมูลส่วนตัวหรือเนื้อหาของหน้าเว็บ คุณปิดได้ทุกเมื่อ",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/th-TH.json
+++ b/SlimSocial_for_Facebook/assets/lang/th-TH.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/tr-TR.json
+++ b/SlimSocial_for_Facebook/assets/lang/tr-TR.json
@@ -80,5 +80,14 @@
   "retry": "Tekrar dene",
   "ads_blocked_count": "Şimdiye kadar {} gizlendi",
   "telemetry_reports": "Anonim rapor gönder",
-  "telemetry_reports_desc": "Anonim çökme ve bozulma raporları, Facebook'taki bir değişikliğin uygulamayı ne zaman bozduğunu fark etmeye yardımcı olur. Hiçbir kişisel veri ve sayfa içeriği gönderilmez. Bunu istediğin zaman kapatabilirsin."
+  "telemetry_reports_desc": "Anonim çökme ve bozulma raporları, Facebook'taki bir değişikliğin uygulamayı ne zaman bozduğunu fark etmeye yardımcı olur. Hiçbir kişisel veri ve sayfa içeriği gönderilmez. Bunu istediğin zaman kapatabilirsin.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/tr-TR.json
+++ b/SlimSocial_for_Facebook/assets/lang/tr-TR.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/tr-TR.json
+++ b/SlimSocial_for_Facebook/assets/lang/tr-TR.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Şimdiye kadar {} gizlendi",
   "telemetry_reports": "Anonim rapor gönder",
   "telemetry_reports_desc": "Anonim çökme ve bozulma raporları, Facebook'taki bir değişikliğin uygulamayı ne zaman bozduğunu fark etmeye yardımcı olur. Hiçbir kişisel veri ve sayfa içeriği gönderilmez. Bunu istediğin zaman kapatabilirsin.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "SlimSocial'ı beğendiniz mi?",
+  "rate_subtitle": "Puan vermek için bir yıldıza dokunun",
+  "rate_later": "Şimdi değil",
+  "rate_low_title": "Bunu duyduğumuza üzüldük",
+  "rate_low_hint": "Ne ters gitti?",
+  "rate_send": "Gönder",
+  "rate_sends_notice": "Bu, mesajınızı uygulama sürümü, cihaz modeli ve Android sürümüyle birlikte geliştiriciye gönderir. Hata raporu ayarınız kapalı kalır.",
+  "rate_thanks": "Teşekkürler — bu yardımcı oluyor.",
+  "rate_failed": "Gönderilemedi. Lütfen daha sonra tekrar deneyin."
 }

--- a/SlimSocial_for_Facebook/assets/lang/uk-UA.json
+++ b/SlimSocial_for_Facebook/assets/lang/uk-UA.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/uk-UA.json
+++ b/SlimSocial_for_Facebook/assets/lang/uk-UA.json
@@ -80,5 +80,14 @@
   "retry": "Повторити",
   "ads_blocked_count": "Приховано: {}",
   "telemetry_reports": "Надсилати анонімні звіти",
-  "telemetry_reports_desc": "Анонімні звіти про збої та поломки допомагають помітити, коли зміна у Facebook ламає застосунок. Особисті дані й вміст сторінок не надсилаються. Це можна вимкнути будь-коли."
+  "telemetry_reports_desc": "Анонімні звіти про збої та поломки допомагають помітити, коли зміна у Facebook ламає застосунок. Особисті дані й вміст сторінок не надсилаються. Це можна вимкнути будь-коли.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/uk-UA.json
+++ b/SlimSocial_for_Facebook/assets/lang/uk-UA.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Приховано: {}",
   "telemetry_reports": "Надсилати анонімні звіти",
   "telemetry_reports_desc": "Анонімні звіти про збої та поломки допомагають помітити, коли зміна у Facebook ламає застосунок. Особисті дані й вміст сторінок не надсилаються. Це можна вимкнути будь-коли.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Подобається SlimSocial?",
+  "rate_subtitle": "Торкніться зірки, щоб оцінити",
+  "rate_later": "Не зараз",
+  "rate_low_title": "Прикро це чути",
+  "rate_low_hint": "Що пішло не так?",
+  "rate_send": "Надіслати",
+  "rate_sends_notice": "Це надішле розробнику ваше повідомлення разом із версією застосунку, моделлю пристрою та версією Android. Ваше налаштування звітів про помилки залишиться вимкненим.",
+  "rate_thanks": "Дякуємо — це допомагає.",
+  "rate_failed": "Не вдалося надіслати. Спробуйте пізніше."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ur-PK.json
+++ b/SlimSocial_for_Facebook/assets/lang/ur-PK.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ur-PK.json
+++ b/SlimSocial_for_Facebook/assets/lang/ur-PK.json
@@ -80,5 +80,14 @@
   "retry": "دوبارہ کوشش کریں",
   "ads_blocked_count": "اب تک {} چھپائے گئے",
   "telemetry_reports": "گمنام رپورٹس بھیجیں",
-  "telemetry_reports_desc": "گمنام کریش اور خرابی کی رپورٹس یہ پہچاننے میں مدد دیتی ہیں کہ فیس بک کی کوئی تبدیلی ایپ کو کب خراب کرتی ہے۔ کوئی ذاتی معلومات یا صفحے کا مواد نہیں بھیجا جاتا۔ آپ اسے کسی بھی وقت بند کر سکتے ہیں۔"
+  "telemetry_reports_desc": "گمنام کریش اور خرابی کی رپورٹس یہ پہچاننے میں مدد دیتی ہیں کہ فیس بک کی کوئی تبدیلی ایپ کو کب خراب کرتی ہے۔ کوئی ذاتی معلومات یا صفحے کا مواد نہیں بھیجا جاتا۔ آپ اسے کسی بھی وقت بند کر سکتے ہیں۔",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/ur-PK.json
+++ b/SlimSocial_for_Facebook/assets/lang/ur-PK.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "اب تک {} چھپائے گئے",
   "telemetry_reports": "گمنام رپورٹس بھیجیں",
   "telemetry_reports_desc": "گمنام کریش اور خرابی کی رپورٹس یہ پہچاننے میں مدد دیتی ہیں کہ فیس بک کی کوئی تبدیلی ایپ کو کب خراب کرتی ہے۔ کوئی ذاتی معلومات یا صفحے کا مواد نہیں بھیجا جاتا۔ آپ اسے کسی بھی وقت بند کر سکتے ہیں۔",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "کیا آپ کو SlimSocial پسند ہے؟",
+  "rate_subtitle": "درجہ بندی کے لیے ستارے پر ٹیپ کریں",
+  "rate_later": "ابھی نہیں",
+  "rate_low_title": "یہ سن کر افسوس ہوا",
+  "rate_low_hint": "کیا مسئلہ ہوا؟",
+  "rate_send": "بھیجیں",
+  "rate_sends_notice": "اس سے آپ کا پیغام ایپ ورژن، ڈیوائس ماڈل اور Android ورژن کے ساتھ ڈویلپر کو بھیجا جائے گا۔ آپ کی کریش رپورٹ کی ترتیب بند رہے گی۔",
+  "rate_thanks": "شکریہ — اس سے مدد ملتی ہے۔",
+  "rate_failed": "بھیجا نہیں جا سکا۔ براہ کرم بعد میں دوبارہ کوشش کریں۔"
 }

--- a/SlimSocial_for_Facebook/assets/lang/vi-VN.json
+++ b/SlimSocial_for_Facebook/assets/lang/vi-VN.json
@@ -80,5 +80,14 @@
   "retry": "Thử lại",
   "ads_blocked_count": "Đã ẩn {} cho đến nay",
   "telemetry_reports": "Gửi báo cáo ẩn danh",
-  "telemetry_reports_desc": "Báo cáo sự cố và lỗi ẩn danh giúp phát hiện khi một thay đổi của Facebook làm hỏng ứng dụng. Không có dữ liệu cá nhân hay nội dung trang nào được gửi đi. Bạn có thể tắt bất cứ lúc nào."
+  "telemetry_reports_desc": "Báo cáo sự cố và lỗi ẩn danh giúp phát hiện khi một thay đổi của Facebook làm hỏng ứng dụng. Không có dữ liệu cá nhân hay nội dung trang nào được gửi đi. Bạn có thể tắt bất cứ lúc nào.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/vi-VN.json
+++ b/SlimSocial_for_Facebook/assets/lang/vi-VN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/vi-VN.json
+++ b/SlimSocial_for_Facebook/assets/lang/vi-VN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "Đã ẩn {} cho đến nay",
   "telemetry_reports": "Gửi báo cáo ẩn danh",
   "telemetry_reports_desc": "Báo cáo sự cố và lỗi ẩn danh giúp phát hiện khi một thay đổi của Facebook làm hỏng ứng dụng. Không có dữ liệu cá nhân hay nội dung trang nào được gửi đi. Bạn có thể tắt bất cứ lúc nào.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Bạn thấy SlimSocial thế nào?",
+  "rate_subtitle": "Chạm vào một ngôi sao để đánh giá",
+  "rate_later": "Để sau",
+  "rate_low_title": "Rất tiếc khi nghe điều đó",
+  "rate_low_hint": "Đã xảy ra chuyện gì?",
+  "rate_send": "Gửi",
+  "rate_sends_notice": "Thao tác này sẽ gửi tin nhắn của bạn đến nhà phát triển, cùng với phiên bản ứng dụng, kiểu thiết bị và phiên bản Android. Cài đặt báo cáo sự cố của bạn vẫn tắt.",
+  "rate_thanks": "Cảm ơn — điều này rất hữu ích.",
+  "rate_failed": "Không thể gửi. Vui lòng thử lại sau."
 }

--- a/SlimSocial_for_Facebook/assets/lang/yo-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/yo-NG.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/yo-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/yo-NG.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "A ti fi {} pamọ́ títí di báyìí",
   "telemetry_reports": "Send anonymous reports",
   "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "Ṣé o nífẹ̀ẹ́ SlimSocial?",
+  "rate_subtitle": "Tẹ ìràwọ̀ kan láti fún ní ìdíwọ̀n",
+  "rate_later": "Kì í ṣe nísinsìnyí",
+  "rate_low_title": "A kábàámọ̀ láti gbọ́ bẹ́ẹ̀",
+  "rate_low_hint": "Kí ni kò ṣiṣẹ́?",
+  "rate_send": "Firánṣẹ́",
+  "rate_sends_notice": "Èyí yóò fi iṣẹ́ rẹ ránṣẹ́ sí olùdàgbàsókè, pẹ̀lú ẹ̀yà app, àwòṣe ẹ̀rọ àti ẹ̀yà Android. Ètò ìròyìn àṣìṣe rẹ yóò wà ní pípa.",
+  "rate_thanks": "O ṣeun — èyí ṣèrànwọ́.",
+  "rate_failed": "Kò lè fi ránṣẹ́. Jọ̀wọ́ gbìyànjú lẹ́ẹ̀kansi nígbà mìíràn."
 }

--- a/SlimSocial_for_Facebook/assets/lang/yo-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/yo-NG.json
@@ -80,5 +80,14 @@
   "retry": "Gbìyànjú lẹ́ẹ̀kansí",
   "ads_blocked_count": "A ti fi {} pamọ́ títí di báyìí",
   "telemetry_reports": "Send anonymous reports",
-  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time."
+  "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-CN.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-CN.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "已隐藏 {} 条",
   "telemetry_reports": "发送匿名报告",
   "telemetry_reports_desc": "匿名的崩溃和故障报告有助于发现 Facebook 的改动何时让应用出问题。不会发送任何个人数据和页面内容。你可以随时关闭。",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "喜欢 SlimSocial 吗？",
+  "rate_subtitle": "点按星星进行评分",
+  "rate_later": "以后再说",
+  "rate_low_title": "很抱歉听到这个",
+  "rate_low_hint": "出了什么问题？",
+  "rate_send": "发送",
+  "rate_sends_notice": "这会将你的留言连同应用版本、设备型号和 Android 版本一起发送给开发者。你的崩溃报告设置仍保持关闭。",
+  "rate_thanks": "谢谢 — 这很有帮助。",
+  "rate_failed": "发送失败。请稍后再试。"
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-CN.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-CN.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-CN.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-CN.json
@@ -80,5 +80,14 @@
   "retry": "重试",
   "ads_blocked_count": "已隐藏 {} 条",
   "telemetry_reports": "发送匿名报告",
-  "telemetry_reports_desc": "匿名的崩溃和故障报告有助于发现 Facebook 的改动何时让应用出问题。不会发送任何个人数据和页面内容。你可以随时关闭。"
+  "telemetry_reports_desc": "匿名的崩溃和故障报告有助于发现 Facebook 的改动何时让应用出问题。不会发送任何个人数据和页面内容。你可以随时关闭。",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-TW.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-TW.json
@@ -80,5 +80,14 @@
   "retry": "重試",
   "ads_blocked_count": "已隱藏 {} 則",
   "telemetry_reports": "傳送匿名報告",
-  "telemetry_reports_desc": "匿名的當機與故障報告有助於發現 Facebook 的變動何時讓應用程式出問題。不會傳送任何個人資料或頁面內容。你可以隨時關閉。"
+  "telemetry_reports_desc": "匿名的當機與故障報告有助於發現 Facebook 的變動何時讓應用程式出問題。不會傳送任何個人資料或頁面內容。你可以隨時關閉。",
+  "rate_title": "Enjoying SlimSocial?",
+  "rate_subtitle": "Tap a star to rate it",
+  "rate_later": "Not now",
+  "rate_low_title": "Sorry to hear that",
+  "rate_low_hint": "What went wrong?",
+  "rate_send": "Send",
+  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_thanks": "Thanks — this helps.",
+  "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-TW.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-TW.json
@@ -87,7 +87,7 @@
   "rate_low_title": "Sorry to hear that",
   "rate_low_hint": "What went wrong?",
   "rate_send": "Send",
-  "rate_sends_notice": "This sends your message and app version to the developer. Your crash reporting setting stays off.",
+  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
   "rate_thanks": "Thanks — this helps.",
   "rate_failed": "Could not send. Please try again later."
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-TW.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-TW.json
@@ -81,13 +81,13 @@
   "ads_blocked_count": "已隱藏 {} 則",
   "telemetry_reports": "傳送匿名報告",
   "telemetry_reports_desc": "匿名的當機與故障報告有助於發現 Facebook 的變動何時讓應用程式出問題。不會傳送任何個人資料或頁面內容。你可以隨時關閉。",
-  "rate_title": "Enjoying SlimSocial?",
-  "rate_subtitle": "Tap a star to rate it",
-  "rate_later": "Not now",
-  "rate_low_title": "Sorry to hear that",
-  "rate_low_hint": "What went wrong?",
-  "rate_send": "Send",
-  "rate_sends_notice": "This sends your message, along with your app version, device model and Android version, to the developer. Your crash reporting setting stays off.",
-  "rate_thanks": "Thanks — this helps.",
-  "rate_failed": "Could not send. Please try again later."
+  "rate_title": "喜歡 SlimSocial 嗎？",
+  "rate_subtitle": "點按星星進行評分",
+  "rate_later": "稍後再說",
+  "rate_low_title": "很抱歉聽到這個",
+  "rate_low_hint": "出了什麼問題？",
+  "rate_send": "傳送",
+  "rate_sends_notice": "這會將你的訊息連同應用程式版本、裝置型號和 Android 版本一併傳送給開發者。你的當機報告設定仍維持關閉。",
+  "rate_thanks": "謝謝 — 這很有幫助。",
+  "rate_failed": "傳送失敗。請稍後再試。"
 }

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -113,6 +113,19 @@ class SpKeys {
   /// Whether crash and health reporting may send anything. Unset means on.
   static const String telemetryEnabled = "telemetry_enabled";
 
+  /// Cold starts counted since install, from 1. Drives the rating prompt.
+  static const String ratingOpens = "rating_opens";
+
+  /// How many times the rating prompt has been shown, ever.
+  static const String ratingAsks = "rating_asks";
+
+  /// Set once the user picks a star rating. Unset means never answered.
+  static const String ratingAnswered = "rating_answered";
+
+  /// The open number the prompt last appeared on, so a feed that reloads
+  /// cannot produce a second prompt in one launch.
+  static const String ratingLastAskedOpen = "rating_last_asked_open";
+
   static const String customUserAgent = "custom_useragent";
   static const String customCss = "custom_css";
   static const String customJs = "custom_js";

--- a/SlimSocial_for_Facebook/lib/main.dart
+++ b/SlimSocial_for_Facebook/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:native_flutter_proxy/native_flutter_proxy.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:slimsocial_for_facebook/consts.dart';
 import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
 import 'package:slimsocial_for_facebook/screens/home_page.dart';
 import 'package:slimsocial_for_facebook/screens/settings_page.dart';
@@ -36,6 +37,9 @@ Future<void> _startApp() async {
   await EasyLocalization.ensureInitialized();
   packageInfo = await PackageInfo.fromPlatform();
   sp = await SharedPreferences.getInstance();
+  //counted here rather than in the home screen: this runs exactly once per
+  //cold start, while the screen can be rebuilt without the app restarting
+  await sp.setInt(SpKeys.ratingOpens, (sp.getInt(SpKeys.ratingOpens) ?? 0) + 1);
   final container = ProviderContainer();
 
   if (sp.getBool("custom_proxy_enabled") ?? false) _setupProxy();

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -21,10 +21,12 @@ import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/dark_theme.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/load_retry_policy.dart';
+import 'package:slimsocial_for_facebook/utils/rating_prompt.dart';
 import 'package:slimsocial_for_facebook/utils/telemetry.dart';
 import 'package:slimsocial_for_facebook/utils/url_cleaner.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
+import 'package:slimsocial_for_facebook/widgets/rating_dialog.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 
@@ -47,6 +49,12 @@ class _HomePageState extends ConsumerState<HomePage> {
   /// left, how long to wait before each, and whether the app should be showing
   /// its own error state instead of the browser's.
   late final LoadRetryPolicy _retryPolicy;
+
+  /// Feed loads completed since this screen was built.
+  ///
+  /// Deliberately a field and not a preference: "this session" is the whole
+  /// point of it, and a field dies with the screen for free.
+  int _loadsThisSession = 0;
 
   @override
   void initState() {
@@ -132,6 +140,9 @@ class _HomePageState extends ConsumerState<HomePage> {
             _retryPolicy.onNavigationFinished();
             await runJs();
             if (kDebugMode) debugPrint(url);
+
+            _loadsThisSession++;
+            unawaited(_maybeAskForRating());
           },
           onProgress: (int progress) {
             if (!mounted) return;
@@ -717,6 +728,40 @@ class _HomePageState extends ConsumerState<HomePage> {
         reportDetail: false,
       );
     }
+  }
+
+  /// Shows the rating prompt if this is one of the launches it is due on.
+  ///
+  /// Every hop here is guarded: the controller outlives this State, so a load
+  /// still in flight keeps calling back after the widget has gone.
+  Future<void> _maybeAskForRating() async {
+    if (!mounted) return;
+    //asking over a feed that is still retrying is asking about a broken app
+    if (_retryPolicy.loadFailed) return;
+
+    final opens = sp.getInt(SpKeys.ratingOpens) ?? 0;
+    final asks = sp.getInt(SpKeys.ratingAsks) ?? 0;
+
+    if (!RatingPrompt.shouldAsk(
+      opens: opens,
+      asks: asks,
+      answered: sp.getBool(SpKeys.ratingAnswered) ?? false,
+      lastAskedOpen: sp.getInt(SpKeys.ratingLastAskedOpen) ?? 0,
+      loadsThisSession: _loadsThisSession,
+    )) {
+      return;
+    }
+
+    //written before the dialog opens, so a crash or a force-quit mid-prompt
+    //still costs this launch's single ask rather than looping on it
+    await sp.setInt(SpKeys.ratingAsks, asks + 1);
+    await sp.setInt(SpKeys.ratingLastAskedOpen, opens);
+    if (!mounted) return;
+
+    await showRatingDialog(
+      context: context,
+      onRated: (stars) => sp.setBool(SpKeys.ratingAnswered, true),
+    );
   }
 
 /*  JavascriptChannel _setupJavascriptChannel(BuildContext context) {

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -54,7 +54,18 @@ class _HomePageState extends ConsumerState<HomePage> {
   ///
   /// Deliberately a field and not a preference: "this session" is the whole
   /// point of it, and a field dies with the screen for free.
-  int _loadsThisSession = 0;
+  final SessionLoadCounter _loadsThisSession = SessionLoadCounter();
+
+  /// Set while the rating prompt is being written down or shown.
+  ///
+  /// [_maybeAskForRating] is started with `unawaited`, so the callback that
+  /// starts it can fire again while it is suspended on its first `await` — and
+  /// at that point the ask has been counted but the launch it was asked on has
+  /// not been recorded yet, so the second caller passes every gate and opens a
+  /// second dialog on top of the first. That spends two of the three lifetime
+  /// asks on one launch. A plain synchronous bool closes the window without
+  /// depending on `shared_preferences` answering a write from its own cache.
+  bool _askingForRating = false;
 
   @override
   void initState() {
@@ -107,6 +118,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             //while one is outstanding.
             if (!mounted) return;
             _retryPolicy.onNavigationStarted();
+            _loadsThisSession.onNavigationStarted();
             setState(() {
               isScontentUrl = Uri.parse(url).host.contains("scontent");
             });
@@ -137,12 +149,19 @@ class _HomePageState extends ConsumerState<HomePage> {
           },
           onPageFinished: (String url) async {
             if (!mounted) return;
+            //asked before anything is awaited: a navigation starting while
+            //runJs is outstanding belongs to the next page, and it would clear
+            //the very failure this finish is reporting
+            final loadCompleted = _loadsThisSession.onNavigationFinished();
             _retryPolicy.onNavigationFinished();
             await runJs();
+            if (!mounted) return;
             if (kDebugMode) debugPrint(url);
 
-            _loadsThisSession++;
-            unawaited(_maybeAskForRating());
+            //a failed main-frame load finishes like any other document on
+            //Android, and asking for a rating over the error page is the
+            //one-star review this gate exists to avoid
+            if (loadCompleted) unawaited(_maybeAskForRating());
           },
           onProgress: (int progress) {
             if (!mounted) return;
@@ -295,6 +314,9 @@ class _HomePageState extends ConsumerState<HomePage> {
     }
 
     _retryPolicy.onLoadError(url: error.url, isForMainFrame: isForMainFrame);
+    //fires before the error page's own onPageFinished, which is what keeps
+    //that finish from being counted as a load that worked
+    _loadsThisSession.onLoadError(isForMainFrame: isForMainFrame);
   }
 
   Future<NavigationDecision> onNavigationRequest(
@@ -736,6 +758,9 @@ class _HomePageState extends ConsumerState<HomePage> {
   /// still in flight keeps calling back after the widget has gone.
   Future<void> _maybeAskForRating() async {
     if (!mounted) return;
+    //one prompt at a time: the gates below are read from storage that the
+    //first call has not finished writing yet
+    if (_askingForRating) return;
     //asking over a feed that is still retrying is asking about a broken app
     if (_retryPolicy.loadFailed) return;
 
@@ -747,21 +772,28 @@ class _HomePageState extends ConsumerState<HomePage> {
       asks: asks,
       answered: sp.getBool(SpKeys.ratingAnswered) ?? false,
       lastAskedOpen: sp.getInt(SpKeys.ratingLastAskedOpen) ?? 0,
-      loadsThisSession: _loadsThisSession,
+      loadsThisSession: _loadsThisSession.completed,
     )) {
       return;
     }
 
-    //written before the dialog opens, so a crash or a force-quit mid-prompt
-    //still costs this launch's single ask rather than looping on it
-    await sp.setInt(SpKeys.ratingAsks, asks + 1);
-    await sp.setInt(SpKeys.ratingLastAskedOpen, opens);
-    if (!mounted) return;
+    //set before the first await and cleared however this ends, including a
+    //dialog that throws
+    _askingForRating = true;
+    try {
+      //written before the dialog opens, so a crash or a force-quit mid-prompt
+      //still costs this launch's single ask rather than looping on it
+      await sp.setInt(SpKeys.ratingAsks, asks + 1);
+      await sp.setInt(SpKeys.ratingLastAskedOpen, opens);
+      if (!mounted) return;
 
-    await showRatingDialog(
-      context: context,
-      onRated: (stars) => sp.setBool(SpKeys.ratingAnswered, true),
-    );
+      await showRatingDialog(
+        context: context,
+        onRated: (stars) => sp.setBool(SpKeys.ratingAnswered, true),
+      );
+    } finally {
+      _askingForRating = false;
+    }
   }
 
 /*  JavascriptChannel _setupJavascriptChannel(BuildContext context) {

--- a/SlimSocial_for_Facebook/lib/utils/rating_prompt.dart
+++ b/SlimSocial_for_Facebook/lib/utils/rating_prompt.dart
@@ -1,0 +1,58 @@
+/// Decides when to ask the user to rate the app.
+///
+/// Plain Dart on purpose. The schedule is the part worth testing and every
+/// input is a number the caller already holds, so nothing here reads a
+/// preference or touches a widget and the whole policy is covered by a table
+/// of integers. Where the numbers are stored, and what is done with the
+/// answer, is the caller's business.
+abstract final class RatingPrompt {
+  /// Cold starts on which the prompt may appear.
+  ///
+  /// Three points across the life of the install: once the app has been used
+  /// enough to have an opinion, once it is a habit, and once it has survived
+  /// a few of Facebook's redesigns.
+  static const List<int> kAskOnOpens = <int>[1, 3, 10];
+
+  /// Completed feed loads required before the very first ask.
+  ///
+  /// The concrete reading of "after a few interactions": enough navigation
+  /// that the person has seen the app work rather than merely started it.
+  static const int kFirstAskInteractions = 5;
+
+  /// Completed feed loads required before any later ask.
+  ///
+  /// One is not a formality. `injection.no_posts_matched` fires in production
+  /// and the oldest complaint in the tracker is a feed that never renders;
+  /// prompting over a blank screen collects a one-star rating and nothing
+  /// that was not already known.
+  static const int kLaterAskInteractions = 1;
+
+  /// How many times the prompt may ever appear.
+  ///
+  /// Deliberately independent of [kAskOnOpens]: lengthening that list should
+  /// change *when* the app asks, never turn the prompt into a recurring nag.
+  static const int kMaxAsks = 3;
+
+  /// How many completed loads this session must have before asking on [opens].
+  static int requiredLoads(int opens) => opens == kAskOnOpens.first
+      ? kFirstAskInteractions
+      : kLaterAskInteractions;
+
+  /// Whether the prompt should be shown right now.
+  static bool shouldAsk({
+    required int opens,
+    required int asks,
+    required bool answered,
+    required int lastAskedOpen,
+    required int loadsThisSession,
+  }) {
+    //a star was already given: they told us, and asking again is nagging
+    if (answered) return false;
+    if (asks >= kMaxAsks) return false;
+    if (!kAskOnOpens.contains(opens)) return false;
+    //one ask per launch, however many times the feed reloads
+    if (lastAskedOpen == opens) return false;
+
+    return loadsThisSession >= requiredLoads(opens);
+  }
+}

--- a/SlimSocial_for_Facebook/lib/utils/rating_prompt.dart
+++ b/SlimSocial_for_Facebook/lib/utils/rating_prompt.dart
@@ -56,3 +56,47 @@ abstract final class RatingPrompt {
     return loadsThisSession >= requiredLoads(opens);
   }
 }
+
+/// Counts the feed loads that actually worked, for one run of the screen.
+///
+/// `onPageFinished` on its own cannot be that count. Android commits and
+/// finishes an error page like any other document, so a main-frame failure
+/// arrives as an ordinary finish — and since the retry policy only admits to a
+/// failure once its retries are spent, every attempt in a retry sequence would
+/// read as a completed load. A phone opened while it is still attaching to the
+/// network is enough to reach [RatingPrompt.kLaterAskInteractions] that way,
+/// and the prompt then opens on top of the error screen: exactly the one-star
+/// outcome the engagement gate exists to prevent.
+///
+/// So the failure is remembered per navigation, which is all the webview's
+/// callbacks can tell us: set when the main frame errors, cleared only when the
+/// next navigation starts.
+class SessionLoadCounter {
+  int _completed = 0;
+  bool _navigationFailed = false;
+
+  /// Loads that finished with no main-frame error reported against them.
+  int get completed => _completed;
+
+  /// A new navigation began, so the last one's failure is no longer ours.
+  void onNavigationStarted() => _navigationFailed = false;
+
+  /// Only main-frame failures count: Facebook drops individual images and
+  /// beacons on every page, and a feed that rendered is a feed that worked.
+  void onLoadError({required bool isForMainFrame}) {
+    if (!isForMainFrame) return;
+    _navigationFailed = true;
+  }
+
+  /// Records a finished load, and reports whether it was a real one.
+  ///
+  /// The failure is deliberately not cleared here. A navigation can report
+  /// finished more than once, and a second finish arriving after an error is
+  /// still that same broken page — counting it would put the prompt back over
+  /// the error screen by another route.
+  bool onNavigationFinished() {
+    if (_navigationFailed) return false;
+    _completed++;
+    return true;
+  }
+}

--- a/SlimSocial_for_Facebook/lib/utils/telemetry.dart
+++ b/SlimSocial_for_Facebook/lib/utils/telemetry.dart
@@ -188,8 +188,32 @@ abstract final class Telemetry {
       return;
     }
 
-    if (_sdkRunning) {
+    await _closeClient();
+  }
+
+  /// Shuts the client down, and neither throws nor leaves one running.
+  ///
+  /// [Sentry.isEnabled] is consulted alongside [_sdkRunning] because [_start]
+  /// only assigns that flag once `SentryFlutter.init` has returned: an init
+  /// that brings the client up and then throws leaves the flag false with a
+  /// live client behind it. Someone who has reporting off must end up with no
+  /// client whatever happened on the way here, so the sdk's own view of
+  /// itself gets a say too.
+  static Future<void> _closeClient() async {
+    if (!_sdkRunning && !Sentry.isEnabled) return;
+
+    try {
       await Sentry.close();
+    }
+    //deliberately everything: a close that fails is nothing the caller can
+    //act on, and letting it out would replace the dialog's own result with it
+    // ignore: avoid_catches_without_on_clauses
+    catch (_) {
+      //left to the `finally` below: the flag has to be cleared either way
+    } finally {
+      //a failed close may well have left the native layer running, which is
+      //why the guard above asks [Sentry.isEnabled] rather than this flag
+      //alone — the next call through here tries again
       _sdkRunning = false;
     }
   }
@@ -278,14 +302,18 @@ abstract final class Telemetry {
     catch (_) {
       return false;
     } finally {
+      //cleared first, and before anything here that could fail: this flag is
+      //the only thing letting an opted-out user's events past
+      //[scrubFeedbackEvent], and the `catch` above belongs to the `try`, not
+      //to this block. A close that threw with the clear still queued behind
+      //it would leave the flag set for the rest of the process, and every
+      //later event of theirs would go out
+      _feedbackConsented = false;
+
       //keyed on the stored preference rather than on whether the client was
       //already running: an enabled user whose client had simply not started
       //yet must keep the one this call started
-      if (!isEnabled && _sdkRunning) {
-        await Sentry.close();
-        _sdkRunning = false;
-      }
-      _feedbackConsented = false;
+      if (!isEnabled) await _closeClient();
     }
   }
 
@@ -401,17 +429,10 @@ abstract final class Telemetry {
       //just typed and pressed send on
       if (!isEnabled && !_feedbackConsented) return null;
 
-      final feedback = event.contexts.feedback;
-      if (feedback != null) {
-        event.contexts.feedback = SentryFeedback(
-          message: scrubText(feedback.message),
-          //never collected by this app, and pinned to null so that a future
-          //sdk default cannot start filling them in
-          associatedEventId: feedback.associatedEventId,
-        );
-      }
-
-      return _rebuildScrubbed(event);
+      return _rebuildScrubbed(
+        event,
+        contexts: _feedbackContexts(event.contexts),
+      );
     }
     //deliberately everything: see the doc comment
     // ignore: avoid_catches_without_on_clauses
@@ -420,11 +441,49 @@ abstract final class Telemetry {
     }
   }
 
+  /// The context blocks a feedback event is allowed to carry, rebuilt from
+  /// scratch for the same reason [_rebuildScrubbed] rebuilds the event.
+  ///
+  /// `contexts` reaches a `beforeSend` callback already filled in: sentry runs
+  /// its event processors first, and `LoadContextsIntegration` and the flutter
+  /// enricher are two of them. Passing it through untouched would send a
+  /// device fingerprint under a notice that promises a message, so only the
+  /// three blocks that notice names survive. `culture` is the one worth
+  /// naming: locale and timezone identify a person and tell a bug report
+  /// nothing.
+  static Contexts _feedbackContexts(Contexts contexts) {
+    final feedback = contexts.feedback;
+
+    final allowed = Contexts(
+      //"your device model"
+      device: contexts.device,
+      //"your Android version"
+      operatingSystem: contexts.operatingSystem,
+      //"your app version"
+      app: contexts.app,
+      feedback: feedback == null
+          ? null
+          : SentryFeedback(
+              message: scrubText(feedback.message),
+              //never collected by this app, and pinned to null so that a
+              //future sdk default cannot start filling them in
+              associatedEventId: feedback.associatedEventId,
+            ),
+    );
+
+    //the app's own block, which on this path is the star rating the user just
+    //picked — part of what they pressed send on, not something sentry added
+    final own = contexts[_contextKey];
+    if (own != null) allowed[_contextKey] = _scrubValue(own);
+
+    return allowed;
+  }
+
   /// Rebuilds [event] field by field instead of copying and patching it: a
   /// field this list does not name is dropped, so a future sdk version cannot
   /// start attaching something new that silently rides along. `user`,
   /// `serverName` and the unstructured `extra` bag are intentionally missing.
-  static SentryEvent _rebuildScrubbed(SentryEvent event) {
+  static SentryEvent _rebuildScrubbed(SentryEvent event, {Contexts? contexts}) {
     final message = event.message;
     final request = event.request;
 
@@ -440,7 +499,7 @@ abstract final class Telemetry {
       sdk: event.sdk,
       level: event.level,
       type: event.type,
-      contexts: event.contexts,
+      contexts: contexts ?? event.contexts,
       debugMeta: event.debugMeta,
       threads: event.threads,
       fingerprint: event.fingerprint,

--- a/SlimSocial_for_Facebook/lib/utils/telemetry.dart
+++ b/SlimSocial_for_Facebook/lib/utils/telemetry.dart
@@ -35,6 +35,17 @@ abstract final class Telemetry {
   @visibleForTesting
   static bool get sdkRunning => _sdkRunning;
 
+  /// True only while a feedback send the user explicitly asked for is in
+  /// flight. Read by [scrubFeedbackEvent], which otherwise drops everything
+  /// coming from someone who turned reporting off.
+  static bool _feedbackConsented = false;
+
+  @visibleForTesting
+  //write-only on purpose: the flag exists to widen what leaves the device,
+  //so exposing a reader would only invite code that branches on it
+  // ignore: avoid_setters_without_getters
+  static set feedbackConsented(bool value) => _feedbackConsented = value;
+
   /// Initialises reporting (if a DSN was compiled in and the user allows it)
   /// and runs the app inside a guarded zone so uncaught errors are captured.
   static Future<void> init(Future<void> Function() appRunner) async {
@@ -127,6 +138,12 @@ abstract final class Telemetry {
     options.beforeBreadcrumb = (crumb, hint) => scrubCrumb(crumb);
 
     options.beforeSend = (event, hint) => scrubEvent(event);
+
+    //feedback is the one event whose body a person types. It arrives as
+    //contexts.feedback, and _rebuildScrubbed passes contexts straight
+    //through, so without this the raw sentence would leave the device.
+    //Sentry prefers this callback over beforeSend for type 'feedback'.
+    options.beforeSendFeedback = (event, hint) => scrubFeedbackEvent(event);
   }
 
   /// Whether the user currently allows reporting.
@@ -304,6 +321,36 @@ abstract final class Telemetry {
     try {
       //an opted-out user sends nothing at all, not even a scrubbed skeleton
       if (!isEnabled) return null;
+
+      return _rebuildScrubbed(event);
+    }
+    //deliberately everything: see the doc comment
+    // ignore: avoid_catches_without_on_clauses
+    catch (_) {
+      return null;
+    }
+  }
+
+  /// Last gate before a user's written feedback leaves the device.
+  ///
+  /// Fails closed for the same reason [scrubEvent] does: sentry keeps the
+  /// *unscrubbed* event when a callback throws.
+  @visibleForTesting
+  static SentryEvent? scrubFeedbackEvent(SentryEvent event) {
+    try {
+      //someone who opted out sends nothing, unless this is the message they
+      //just typed and pressed send on
+      if (!isEnabled && !_feedbackConsented) return null;
+
+      final feedback = event.contexts.feedback;
+      if (feedback != null) {
+        event.contexts.feedback = SentryFeedback(
+          message: scrubText(feedback.message),
+          //never collected by this app, and pinned to null so that a future
+          //sdk default cannot start filling them in
+          associatedEventId: feedback.associatedEventId,
+        );
+      }
 
       return _rebuildScrubbed(event);
     }

--- a/SlimSocial_for_Facebook/lib/utils/telemetry.dart
+++ b/SlimSocial_for_Facebook/lib/utils/telemetry.dart
@@ -230,6 +230,65 @@ abstract final class Telemetry {
     );
   }
 
+  /// Whether a feedback box can do anything at all.
+  ///
+  /// False in a build compiled without a dsn, where there is nowhere for the
+  /// text to go. The dialog asks this before offering a box, because a Send
+  /// button that cannot send is worse than no box.
+  static bool get canCollectFeedback => _canReport;
+
+  /// Sends one report the user wrote, with the rating they gave.
+  ///
+  /// Returns whether it was handed to the sdk, so the caller can tell the
+  /// user the truth either way.
+  ///
+  /// Unlike [captureIssue] this is not throttled: the throttle there exists
+  /// because a stale selector fires on every scroll, which has no analogue in
+  /// a person pressing a button. The prompt's own ceiling bounds this.
+  static Future<bool> captureFeedback({
+    required int stars,
+    required String text,
+  }) async {
+    if (!_canReport) return false;
+
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return false;
+
+    //someone who turned reporting off still gets to send the message they
+    //just typed — pressing send is the consent — but their stored choice is
+    //not touched, and the client started for it does not outlive the send
+    _feedbackConsented = true;
+    try {
+      if (!_sdkRunning) await _start();
+
+      await Sentry.captureFeedback(
+        SentryFeedback(message: trimmed),
+        withScope: (scope) async {
+          //a number in the app's own context block stays filterable in
+          //sentry, where the same value inside the message would not
+          await scope.setContexts(_contextKey, <String, dynamic>{
+            'stars': stars,
+          });
+        },
+      );
+      return true;
+    }
+    //a failed send must not take the dialog down with it
+    // ignore: avoid_catches_without_on_clauses
+    catch (_) {
+      return false;
+    } finally {
+      //keyed on the stored preference rather than on whether the client was
+      //already running: an enabled user whose client had simply not started
+      //yet must keep the one this call started
+      if (!isEnabled && _sdkRunning) {
+        await Sentry.close();
+        _sdkRunning = false;
+      }
+      _feedbackConsented = false;
+    }
+  }
+
   /// Claims this session's single slot for [kind], returning false once it is
   /// taken.
   ///

--- a/SlimSocial_for_Facebook/lib/widgets/rating_dialog.dart
+++ b/SlimSocial_for_Facebook/lib/widgets/rating_dialog.dart
@@ -1,0 +1,162 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:slimsocial_for_facebook/utils/telemetry.dart';
+import 'package:slimsocial_for_facebook/utils/utils.dart';
+
+/// Shows the rating prompt. Returns once the user is done with it.
+///
+/// [onRated] is called with the star count the moment a star is tapped, before
+/// either branch runs, so the caller can record that the question was answered
+/// even if what follows fails or is abandoned.
+Future<void> showRatingDialog({
+  required BuildContext context,
+  required Future<void> Function(int stars) onRated,
+}) =>
+    showDialog<void>(
+      context: context,
+      builder: (context) => RatingDialog(onRated: onRated),
+    );
+
+/// The prompt itself. Two steps: the stars, then — for a low rating — a box.
+class RatingDialog extends StatefulWidget {
+  const RatingDialog({required this.onRated, super.key});
+
+  final Future<void> Function(int stars) onRated;
+
+  /// At or above this, the user is sent to the store instead of being asked
+  /// what is wrong.
+  static const int kPositiveStars = 4;
+
+  @override
+  State<RatingDialog> createState() => _RatingDialogState();
+}
+
+class _RatingDialogState extends State<RatingDialog> {
+  final TextEditingController _controller = TextEditingController();
+  int? _stars;
+  bool _sending = false;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onStar(int stars) async {
+    //recorded first: a person who rates two stars and then closes the box has
+    //still answered, and asking them again would be the nagging the schedule
+    //exists to avoid
+    await widget.onRated(stars);
+    if (!mounted) return;
+
+    if (stars >= RatingDialog.kPositiveStars) {
+      Navigator.of(context).pop();
+      final review = InAppReview.instance;
+      if (await review.isAvailable()) {
+        await review.requestReview();
+      }
+      return;
+    }
+
+    setState(() => _stars = stars);
+  }
+
+  Future<void> _send() async {
+    setState(() => _sending = true);
+
+    final sent = await Telemetry.captureFeedback(
+      stars: _stars!,
+      text: _controller.text,
+    );
+
+    if (!mounted) return;
+    Navigator.of(context).pop();
+    showToast(sent ? 'rate_thanks'.tr() : 'rate_failed'.tr());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_stars == null) return _stepStars(context);
+    return _stepFeedback(context);
+  }
+
+  Widget _stepStars(BuildContext context) => AlertDialog(
+        title: Text('rate_title'.tr()),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('rate_subtitle'.tr()),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(5, (i) {
+                final stars = i + 1;
+                return IconButton(
+                  key: ValueKey('rating_star_$stars'),
+                  icon: const Icon(Icons.star_border),
+                  onPressed: () => _onStar(stars),
+                );
+              }),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text('rate_later'.tr()),
+          ),
+        ],
+      );
+
+  Widget _stepFeedback(BuildContext context) {
+    //nothing to send it to, so no box: a Send button that cannot send is
+    //worse than not offering one
+    if (!Telemetry.canCollectFeedback) {
+      return AlertDialog(
+        title: Text('rate_low_title'.tr()),
+        content: Text('rate_thanks'.tr()),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text('rate_later'.tr()),
+          ),
+        ],
+      );
+    }
+
+    return AlertDialog(
+      title: Text('rate_low_title'.tr()),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _controller,
+            maxLines: 4,
+            autofocus: true,
+            decoration: InputDecoration(hintText: 'rate_low_hint'.tr()),
+          ),
+          //shown only to someone who turned reporting off, because for them
+          //pressing send is the whole of the consent
+          if (!Telemetry.isEnabled) ...[
+            const SizedBox(height: 12),
+            Text(
+              'rate_sends_notice'.tr(),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _sending ? null : () => Navigator.of(context).pop(),
+          child: Text('rate_later'.tr()),
+        ),
+        TextButton(
+          onPressed: _sending ? null : _send,
+          child: Text('rate_send'.tr()),
+        ),
+      ],
+    );
+  }
+}

--- a/SlimSocial_for_Facebook/test/consts_test.dart
+++ b/SlimSocial_for_Facebook/test/consts_test.dart
@@ -73,4 +73,24 @@ void main() {
       expect(kDesktopUserAgent, isNot(contains('Mobile')));
     });
   });
+
+  group('rating prompt keys', () {
+    test('are distinct from each other and from every other key', () {
+      const keys = <String>[
+        SpKeys.ratingOpens,
+        SpKeys.ratingAsks,
+        SpKeys.ratingAnswered,
+        SpKeys.ratingLastAskedOpen,
+      ];
+
+      expect(keys.toSet(), hasLength(keys.length));
+      //a collision with a live key silently reinterprets a stored value as
+      //something of a different type
+      for (final key in keys) {
+        expect(key, isNot(SpKeys.telemetryEnabled));
+        expect(key, isNot(SpKeys.adsBlockedTotal));
+        expect(key, isNot(SpKeys.textZoom));
+      }
+    });
+  });
 }

--- a/SlimSocial_for_Facebook/test/lang_test.dart
+++ b/SlimSocial_for_Facebook/test/lang_test.dart
@@ -56,6 +56,18 @@ void main() {
         // unable to tell what they are turning off.
         'telemetry_reports',
         'telemetry_reports_desc',
+        // The rating prompt. A blank string here leaves a dialog with an
+        // unlabelled button, and the dialog is shown to people who have not
+        // gone looking for it.
+        'rate_title',
+        'rate_subtitle',
+        'rate_later',
+        'rate_low_title',
+        'rate_low_hint',
+        'rate_send',
+        'rate_sends_notice',
+        'rate_thanks',
+        'rate_failed',
       ];
 
       for (final path in _fallbackLangFiles) {

--- a/SlimSocial_for_Facebook/test/utils/rating_prompt_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/rating_prompt_test.dart
@@ -82,4 +82,73 @@ void main() {
       expect(_ask(opens: 3, lastAskedOpen: 1), isTrue);
     });
   });
+
+  group('SessionLoadCounter', () {
+    late SessionLoadCounter counter;
+
+    setUp(() => counter = SessionLoadCounter());
+
+    /// One navigation, in the order the webview reports it. [failed] plays the
+    /// Android sequence for a failed load: the error arrives first, and then
+    /// the error page commits and finishes like any other document.
+    bool navigate({bool failed = false, bool isForMainFrame = true}) {
+      counter.onNavigationStarted();
+      if (failed) counter.onLoadError(isForMainFrame: isForMainFrame);
+      return counter.onNavigationFinished();
+    }
+
+    test('counts a load that finished with nothing reported against it', () {
+      expect(navigate(), isTrue);
+      expect(counter.completed, 1);
+    });
+
+    test('does not count the error page that a failed load finishes as', () {
+      expect(navigate(failed: true), isFalse);
+      expect(counter.completed, 0);
+    });
+
+    test('a whole retry sequence leaves the session with nothing loaded', () {
+      //the first attempt plus the three the retry policy makes: on the later
+      //trigger opens one of these counting is enough to put the prompt on top
+      //of the error screen
+      for (var attempt = 0; attempt < 4; attempt++) {
+        expect(navigate(failed: true), isFalse, reason: 'attempt $attempt');
+      }
+      expect(counter.completed, 0);
+    });
+
+    test('a dropped image does not spoil the page it fell out of', () {
+      expect(navigate(failed: true, isForMainFrame: false), isTrue);
+      expect(counter.completed, 1);
+    });
+
+    test('the failure belongs to its own navigation, not the next one', () {
+      expect(navigate(failed: true), isFalse);
+      expect(navigate(), isTrue);
+      expect(counter.completed, 1);
+    });
+
+    test('a second finish on a failed navigation still does not count', () {
+      counter.onNavigationStarted();
+      counter.onLoadError(isForMainFrame: true);
+      counter.onNavigationFinished();
+
+      expect(counter.onNavigationFinished(), isFalse);
+      expect(counter.completed, 0);
+    });
+
+    test('reaches the later asks only on loads that worked', () {
+      navigate(failed: true);
+      expect(
+        counter.completed,
+        lessThan(RatingPrompt.kLaterAskInteractions),
+        reason: 'a failed load must not open the lowest gate',
+      );
+      navigate();
+      expect(
+        counter.completed,
+        greaterThanOrEqualTo(RatingPrompt.kLaterAskInteractions),
+      );
+    });
+  });
 }

--- a/SlimSocial_for_Facebook/test/utils/rating_prompt_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/rating_prompt_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/rating_prompt.dart';
+
+/// The state of someone who has just reached a trigger open having used the
+/// app normally, i.e. every gate open. Each test below closes exactly one.
+///
+/// [opens] is required because which open a case runs at is the substance of
+/// nearly every test below, and [loadsThisSession] defaults past the largest
+/// threshold so the engagement gate is never the accidental reason a case
+/// fails.
+bool _ask({
+  required int opens,
+  int asks = 0,
+  bool answered = false,
+  int lastAskedOpen = 0,
+  int loadsThisSession = RatingPrompt.kFirstAskInteractions + 1,
+}) =>
+    RatingPrompt.shouldAsk(
+      opens: opens,
+      asks: asks,
+      answered: answered,
+      lastAskedOpen: lastAskedOpen,
+      loadsThisSession: loadsThisSession,
+    );
+
+void main() {
+  group('trigger opens', () {
+    test('asks on each scheduled open', () {
+      for (final open in RatingPrompt.kAskOnOpens) {
+        expect(_ask(opens: open), isTrue, reason: 'open $open');
+      }
+    });
+
+    test('stays quiet on every open either side of a scheduled one', () {
+      for (final open in <int>[2, 4, 9, 11]) {
+        expect(_ask(opens: open), isFalse, reason: 'open $open');
+      }
+    });
+
+    test('stays quiet before the first scheduled open', () {
+      expect(_ask(opens: 0), isFalse);
+    });
+  });
+
+  group('the engagement gate', () {
+    test('the first ask needs a used session, not just a launch', () {
+      expect(
+        _ask(opens: 1, loadsThisSession: RatingPrompt.kFirstAskInteractions - 1),
+        isFalse,
+      );
+      expect(
+        _ask(opens: 1, loadsThisSession: RatingPrompt.kFirstAskInteractions),
+        isTrue,
+      );
+    });
+
+    test('later asks need only a feed that loaded at all', () {
+      //asking over a blank screen buys a one-star rating and teaches nothing
+      expect(_ask(opens: 3, loadsThisSession: 0), isFalse);
+      expect(_ask(opens: 3, loadsThisSession: 1), isTrue);
+      expect(_ask(opens: 10, loadsThisSession: 0), isFalse);
+      expect(_ask(opens: 10, loadsThisSession: 1), isTrue);
+    });
+  });
+
+  group('stopping conditions', () {
+    test('never asks again once a rating was given', () {
+      expect(_ask(opens: 3, answered: true), isFalse);
+    });
+
+    test('stops at the ceiling even on a scheduled open', () {
+      expect(_ask(opens: 3, asks: RatingPrompt.kMaxAsks), isFalse);
+    });
+
+    test('the ceiling holds independently of the schedule', () {
+      //the backstop has to survive someone lengthening kAskOnOpens
+      expect(RatingPrompt.kMaxAsks, lessThanOrEqualTo(RatingPrompt.kAskOnOpens.length));
+    });
+
+    test('asks at most once per launch', () {
+      expect(_ask(opens: 3, lastAskedOpen: 3), isFalse);
+      expect(_ask(opens: 3, lastAskedOpen: 1), isTrue);
+    });
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/telemetry_dsn_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/telemetry_dsn_test.dart
@@ -36,6 +36,10 @@ const String _needsDsn = 'needs a compiled-in dsn: fvm flutter test '
     '--dart-define=SENTRY_DSN=https://abc123def456@localhost:1/1 '
     'test/utils/telemetry_dsn_test.dart';
 
+/// The same dsn the app itself was compiled with, so a client started from a
+/// test behaves exactly like one [Telemetry] would have started.
+const String _dsn = String.fromEnvironment('SENTRY_DSN');
+
 Future<void> _prefs([Map<String, Object> values = const {}]) async {
   SharedPreferences.setMockInitialValues(values);
   sp = await SharedPreferences.getInstance();
@@ -46,6 +50,21 @@ SentryEvent _feedbackEvent(String message) => SentryEvent(
       type: 'feedback',
       level: SentryLevel.info,
       contexts: Contexts(feedback: SentryFeedback(message: message)),
+    );
+
+/// The same, as the sdk's own event processors leave it: they run ahead of
+/// every `beforeSend` callback in `sentry_client`, so `contexts` is already
+/// full of device, os, app and culture by the time the app is asked.
+SentryEvent _enrichedFeedbackEvent(String message) => SentryEvent(
+      type: 'feedback',
+      level: SentryLevel.info,
+      contexts: Contexts(
+        device: SentryDevice(model: 'Pixel 7', manufacturer: 'Google'),
+        operatingSystem: SentryOperatingSystem(name: 'Android', version: '14'),
+        app: SentryApp(version: '2.4.0'),
+        culture: SentryCulture(locale: 'it-IT', timezone: 'Europe/Rome'),
+        feedback: SentryFeedback(message: message),
+      ),
     );
 
 void main() {
@@ -97,14 +116,59 @@ void main() {
       //A throw out of the try is not reachable from a test: sentry's hub
       //catches and logs every error captureFeedback can raise, so the
       //unroutable dsn above fails silently instead. What is reachable is the
-      //other order-sensitive path through the same block — the close running
-      //first and the flag being cleared second, where anything going wrong
-      //in the close would strand the flag set for the rest of the session
+      //other order-sensitive path through the same block — the clear and the
+      //close, where a close that threw with the clear still queued behind it
+      //would strand the flag set for the rest of the session
       await _prefs({SpKeys.telemetryEnabled: false});
 
       await Telemetry.captureFeedback(stars: 1, text: 'hi');
 
+      //the close half really did run, so the clear is not passing merely by
+      //having skipped the half that can fail
+      expect(Telemetry.sdkRunning, isFalse);
+      expect(Sentry.isEnabled, isFalse);
+
+      //and the flag, which is the only thing between this user and every
+      //later event of theirs, did not outlive the call
       expect(Telemetry.scrubFeedbackEvent(_feedbackEvent('x')), isNull);
+    });
+
+    test('sends only the context blocks the notice names', () async {
+      final options = SentryFlutterOptions();
+      Telemetry.configure(options);
+
+      final scrubbed = await options.beforeSendFeedback!(
+        _enrichedFeedbackEvent('the feed is blank'),
+        Hint(),
+      );
+
+      //the dialog's notice promises an app version, a device model and an
+      //android version
+      expect(scrubbed!.contexts.app!.version, '2.4.0');
+      expect(scrubbed.contexts.device!.model, 'Pixel 7');
+      expect(scrubbed.contexts.operatingSystem!.version, '14');
+
+      //and promises nothing else, so nothing else the sdk attached may ride
+      //along: a locale and a timezone identify a person
+      expect(scrubbed.contexts.culture, isNull);
+      expect(scrubbed.contexts.toJson().keys, isNot(contains('culture')));
+    });
+
+    test('a client the flag never saw is still closed for an opted-out user',
+        () async {
+      //_start assigns _sdkRunning only once SentryFlutter.init has returned,
+      //so an init that raises after bringing the client up leaves exactly
+      //this state behind: no flag, live client. Starting one here reproduces
+      //it without needing init to fail
+      await Sentry.init((options) => options.dsn = _dsn);
+      expect(Sentry.isEnabled, isTrue);
+      expect(Telemetry.sdkRunning, isFalse);
+
+      await Telemetry.setEnabled(false);
+
+      //someone who has reporting off is left with no client, whatever the
+      //local flag happened to say
+      expect(Sentry.isEnabled, isFalse);
     });
 
     test('an opted-out send leaves no sdk running behind it', () async {

--- a/SlimSocial_for_Facebook/test/utils/telemetry_dsn_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/telemetry_dsn_test.dart
@@ -1,0 +1,121 @@
+/// The feedback send path, exercised in a build that has a dsn compiled in.
+///
+/// These cases live apart from `telemetry_test.dart` because the two files
+/// need opposite builds. That file pins down what a dsn-less build does —
+/// `canCollectFeedback` is false, `captureFeedback` refuses, toggling the
+/// setting never leaves an sdk running — and every one of those assertions
+/// flips the moment a dsn exists. One run cannot satisfy both, so everything
+/// that needs a dsn is gathered here instead.
+///
+/// Run it with:
+///
+/// ```sh
+/// fvm flutter test \
+///   --dart-define=SENTRY_DSN=https://abc123def456@localhost:1/1 \
+///   test/utils/telemetry_dsn_test.dart
+/// ```
+///
+/// The dsn only has to parse. `localhost:1` routes nowhere, so nothing these
+/// tests hand the sdk can leave the machine.
+///
+/// Under a plain `fvm flutter test` the group is skipped rather than failed:
+/// `SENTRY_DSN` is empty there, [Telemetry.captureFeedback] returns on its
+/// first line, and every assertion below would be checking nothing.
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:slimsocial_for_facebook/consts.dart';
+import 'package:slimsocial_for_facebook/main.dart';
+import 'package:slimsocial_for_facebook/utils/telemetry.dart';
+
+/// Printed by the runner in place of every case here when the build has no
+/// dsn, so the command that does run them is never more than one line away.
+const String _needsDsn = 'needs a compiled-in dsn: fvm flutter test '
+    '--dart-define=SENTRY_DSN=https://abc123def456@localhost:1/1 '
+    'test/utils/telemetry_dsn_test.dart';
+
+Future<void> _prefs([Map<String, Object> values = const {}]) async {
+  SharedPreferences.setMockInitialValues(values);
+  sp = await SharedPreferences.getInstance();
+}
+
+/// An event shaped the way the sdk hands feedback to the scrubber.
+SentryEvent _feedbackEvent(String message) => SentryEvent(
+      type: 'feedback',
+      level: SentryLevel.info,
+      contexts: Contexts(feedback: SentryFeedback(message: message)),
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('captureFeedback with a dsn compiled in', () {
+    setUp(() async {
+      await _prefs();
+      //the sdk flag is static and outlives a test. setEnabled(false) is the
+      //only lever a test has on it, so every case below starts from no client
+      await Telemetry.setEnabled(false);
+      //and from a user who has not opted out of anything
+      await _prefs();
+      Telemetry.resetSession();
+      Telemetry.feedbackConsented = false;
+    });
+
+    tearDown(() async {
+      await _prefs();
+      await Telemetry.setEnabled(false);
+      Telemetry.feedbackConsented = false;
+    });
+
+    test('the empty-message guard is what refuses an empty send', () async {
+      //with no dsn this returns on the first line, so the guard below it is
+      //only ever reached in this build
+      expect(Telemetry.canCollectFeedback, isTrue);
+
+      expect(await Telemetry.captureFeedback(stars: 1, text: '   '), isFalse);
+      //refused without starting a client to find out
+      expect(Telemetry.sdkRunning, isFalse);
+    });
+
+    test('a completed send leaves consent off behind it', () async {
+      expect(await Telemetry.captureFeedback(stars: 1, text: 'hi'), isTrue);
+      //proves the send really did run: without this the cases here could all
+      //be passing because nothing happened
+      expect(Telemetry.sdkRunning, isTrue);
+
+      //the flag is the only thing between someone who opted out and every
+      //later event of theirs, so it must not outlive the call that set it
+      await _prefs({SpKeys.telemetryEnabled: false});
+      expect(Telemetry.scrubFeedbackEvent(_feedbackEvent('x')), isNull);
+    });
+
+    test('consent is cleared on the path that also closes the client',
+        () async {
+      //this is the `finally` running after the send did not simply succeed.
+      //A throw out of the try is not reachable from a test: sentry's hub
+      //catches and logs every error captureFeedback can raise, so the
+      //unroutable dsn above fails silently instead. What is reachable is the
+      //other order-sensitive path through the same block — the close running
+      //first and the flag being cleared second, where anything going wrong
+      //in the close would strand the flag set for the rest of the session
+      await _prefs({SpKeys.telemetryEnabled: false});
+
+      await Telemetry.captureFeedback(stars: 1, text: 'hi');
+
+      expect(Telemetry.scrubFeedbackEvent(_feedbackEvent('x')), isNull);
+    });
+
+    test('an opted-out send leaves no sdk running behind it', () async {
+      //pressing send is consent for that one message and nothing more: the
+      //client started to carry it must not outlive the call
+      await _prefs({SpKeys.telemetryEnabled: false});
+
+      await Telemetry.captureFeedback(stars: 1, text: 'hi');
+
+      expect(Telemetry.sdkRunning, isFalse);
+      expect(Sentry.isEnabled, isFalse);
+    });
+  }, skip: Telemetry.canCollectFeedback ? null : _needsDsn);
+}

--- a/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
@@ -269,6 +269,33 @@ void main() {
       expect(scrubbed!.message, "navigated to m.facebook.com/<other>");
     });
 
+    test('the registered callback scrubs feedback on its way out', () async {
+      //the assignment in configure() is the whole defence: every other
+      //feedback test calls scrubFeedbackEvent directly, so deleting the line
+      //would leave the raw sentence shipping with the suite still green
+      final options = configured();
+
+      expect(options.beforeSendFeedback, isNotNull);
+
+      final scrubbed = await options.beforeSendFeedback!(
+        SentryEvent(
+          type: 'feedback',
+          level: SentryLevel.info,
+          contexts: Contexts(
+            feedback: SentryFeedback(
+              message: "broken on $_kStoryUrl for 100001234567890",
+            ),
+          ),
+        ),
+        Hint(),
+      );
+
+      final message = scrubbed!.contexts.feedback!.message;
+      expect(message, isNot(contains("story_fbid")));
+      expect(message, isNot(contains("100001234567890")));
+      expect(message, contains("<id>"));
+    });
+
     test('sends nothing that shows what is on screen', () {
       final options = configured();
 

--- a/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
@@ -454,5 +454,35 @@ void main() {
       expect(event, isNotNull);
       expect(event!.contexts.feedback!.message, "hi");
     });
+
+    test('a build with no dsn cannot collect feedback at all', () {
+      //the tests run without --dart-define, so this is the f-droid build
+      expect(Telemetry.canCollectFeedback, isFalse);
+    });
+
+    test('captureFeedback reports failure rather than pretending', () async {
+      //a dialog that says "thanks, sent" when nothing was sent is a lie, so
+      //the return value has to be honest with no dsn compiled in
+      expect(
+        await Telemetry.captureFeedback(stars: 2, text: "the feed is blank"),
+        isFalse,
+      );
+    });
+
+    test('an empty message is never sent', () async {
+      expect(await Telemetry.captureFeedback(stars: 1, text: "   "), isFalse);
+    });
+
+    test('captureFeedback leaves consent off once it returns', () async {
+      await Telemetry.captureFeedback(stars: 1, text: "hi");
+
+      //the flag is the only thing standing between an opted-out user and a
+      //later unrelated event, so it must never be left set
+      await _prefs({SpKeys.telemetryEnabled: false});
+      expect(
+        Telemetry.scrubFeedbackEvent(feedbackEvent("unrelated")),
+        isNull,
+      );
+    });
   });
 }

--- a/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
@@ -361,4 +361,71 @@ void main() {
       expect(Telemetry.allowIssue('injection.no_posts_matched'), isFalse);
     });
   });
+
+  group('feedback events', () {
+    SentryEvent feedbackEvent(String message, {String? email, String? name}) =>
+        SentryEvent(
+          type: 'feedback',
+          level: SentryLevel.info,
+          contexts: Contexts(
+            feedback: SentryFeedback(
+              message: message,
+              contactEmail: email,
+              name: name,
+            ),
+          ),
+        );
+
+    tearDown(() => Telemetry.feedbackConsented = false);
+
+    test('scrubs the url and the ids out of what the user typed', () {
+      //the whole reason beforeSendFeedback is set: contexts rides through
+      //_rebuildScrubbed untouched, so the message has to be cleaned here
+      final event = Telemetry.scrubFeedbackEvent(
+        feedbackEvent("broken on $_kStoryUrl for user 100001234567890"),
+      );
+
+      final message = event!.contexts.feedback!.message;
+      expect(message, isNot(contains("story_fbid")));
+      expect(message, isNot(contains("100001234567890")));
+      expect(message, contains("<id>"));
+      expect(message, contains("m.facebook.com"));
+    });
+
+    test('keeps the type so sentry still routes it to feedback', () {
+      final event =
+          Telemetry.scrubFeedbackEvent(feedbackEvent("the feed is blank"));
+
+      expect(event, isNotNull);
+      expect(event!.type, "feedback");
+      expect(event.contexts.feedback!.message, "the feed is blank");
+    });
+
+    test('drops a contact email and a name even when handed both', () {
+      final event = Telemetry.scrubFeedbackEvent(
+        feedbackEvent("hi", email: "someone@example.com", name: "Someone"),
+      );
+
+      expect(event!.contexts.feedback!.contactEmail, isNull);
+      expect(event.contexts.feedback!.name, isNull);
+      expect(event.contexts.feedback!.url, isNull);
+    });
+
+    test('sends nothing at all for a user who opted out', () async {
+      await _prefs({SpKeys.telemetryEnabled: false});
+
+      expect(Telemetry.scrubFeedbackEvent(feedbackEvent("hi")), isNull);
+    });
+
+    test('lets an opted-out user through only while they are sending',
+        () async {
+      await _prefs({SpKeys.telemetryEnabled: false});
+      Telemetry.feedbackConsented = true;
+
+      final event = Telemetry.scrubFeedbackEvent(feedbackEvent("hi"));
+
+      expect(event, isNotNull);
+      expect(event!.contexts.feedback!.message, "hi");
+    });
+  });
 }

--- a/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
@@ -438,6 +438,40 @@ void main() {
       expect(event.contexts.feedback!.url, isNull);
     });
 
+    test('drops every context block the notice does not name', () {
+      //contexts reaches a beforeSend callback already filled in — sentry runs
+      //its event processors, LoadContextsIntegration and the flutter enricher
+      //among them, before any of the callbacks — so this is the shape a real
+      //feedback event has by the time the app sees it
+      final event = Telemetry.scrubFeedbackEvent(
+        SentryEvent(
+          type: 'feedback',
+          level: SentryLevel.info,
+          contexts: Contexts(
+            device: SentryDevice(model: "Pixel 7", manufacturer: "Google"),
+            operatingSystem:
+                SentryOperatingSystem(name: "Android", version: "14"),
+            app: SentryApp(version: "2.4.0"),
+            culture: SentryCulture(locale: "it-IT", timezone: "Europe/Rome"),
+            feedback: SentryFeedback(message: "the feed is blank"),
+          ),
+        ),
+      );
+
+      //the notice names an app version, a device model and an android
+      //version, and nothing else: a locale and a timezone identify a person
+      //and tell a bug report nothing
+      expect(event!.contexts.culture, isNull);
+      expect(event.contexts.toJson().keys, isNot(contains("culture")));
+
+      //and the three it does name have to survive, or the notice would be
+      //untrue the other way round
+      expect(event.contexts.device!.model, "Pixel 7");
+      expect(event.contexts.operatingSystem!.version, "14");
+      expect(event.contexts.app!.version, "2.4.0");
+      expect(event.contexts.feedback!.message, "the feed is blank");
+    });
+
     test('sends nothing at all for a user who opted out', () async {
       await _prefs({SpKeys.telemetryEnabled: false});
 

--- a/SlimSocial_for_Facebook/test/widgets/rating_dialog_test.dart
+++ b/SlimSocial_for_Facebook/test/widgets/rating_dialog_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/telemetry.dart';
+import 'package:slimsocial_for_facebook/widgets/rating_dialog.dart';
+
+/// Pushes the dialog on a route that can actually be popped.
+///
+/// The 5-star path calls `Navigator.pop`, and popping the *root* route trips
+/// an assertion, so the dialog cannot simply be rendered as a body child.
+Future<void> _open(WidgetTester tester, RatingDialog dialog) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () =>
+                showDialog<void>(context: context, builder: (_) => dialog),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
+
+/// The stars are the first step's own widgets, so their absence is what
+/// "advanced past the stars" means. Both steps are an [AlertDialog], and
+/// `.tr()` yields the raw key here, so neither type nor text can tell them
+/// apart.
+Finder _star(int stars) => find.byKey(ValueKey('rating_star_$stars'));
+
+void main() {
+  group('RatingDialog', () {
+    testWidgets(
+      'the star that was tapped is what onRated receives (five)',
+      (tester) async {
+        int? reported;
+        await _open(
+          tester,
+          RatingDialog(onRated: (stars) async => reported = stars),
+        );
+
+        await tester.tap(_star(5));
+        await tester.pumpAndSettle();
+
+        expect(reported, 5);
+      },
+    );
+
+    testWidgets(
+      'the star that was tapped is what onRated receives (one)',
+      (tester) async {
+        int? reported;
+        await _open(
+          tester,
+          RatingDialog(onRated: (stars) async => reported = stars),
+        );
+
+        await tester.tap(_star(1));
+        await tester.pumpAndSettle();
+
+        expect(reported, 1);
+      },
+    );
+
+    testWidgets(
+      'a low rating is reported even though this build can do nothing '
+      'further with it',
+      (tester) async {
+        int? reported;
+        await _open(
+          tester,
+          RatingDialog(onRated: (stars) async => reported = stars),
+        );
+
+        await tester.tap(_star(2));
+        await tester.pumpAndSettle();
+
+        //the whole point of reporting before branching: with no dsn compiled
+        //in, the step this rating leads to collects nothing, and the answer
+        //would be lost if it were recorded on the way out instead
+        expect(reported, 2);
+        expect(Telemetry.canCollectFeedback, isFalse);
+        expect(find.byType(TextField), findsNothing);
+      },
+    );
+
+    testWidgets('a low rating advances past the stars', (tester) async {
+      await _open(tester, RatingDialog(onRated: (_) async {}));
+
+      await tester.tap(_star(2));
+      await tester.pumpAndSettle();
+
+      expect(_star(2), findsNothing);
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets(
+      'a high rating pops the dialog rather than advancing',
+      (tester) async {
+        await _open(tester, RatingDialog(onRated: (_) async {}));
+
+        await tester.tap(_star(4));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AlertDialog), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'in a build with no dsn the second step offers no feedback box',
+      (tester) async {
+        //asserted, not assumed: `canCollectFeedback` is false exactly because
+        //the suite is compiled without --dart-define=SENTRY_DSN. This test
+        //describes THAT build. A build with a dsn takes the other branch of
+        //`_stepFeedback` and does show a TextField, which nothing here covers
+        expect(Telemetry.canCollectFeedback, isFalse);
+
+        await _open(tester, RatingDialog(onRated: (_) async {}));
+
+        await tester.tap(_star(3));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(_star(3), findsNothing);
+        expect(find.byType(TextField), findsNothing);
+      },
+    );
+
+    testWidgets('dismissing the stars reports nothing', (tester) async {
+      var calls = 0;
+      await _open(tester, RatingDialog(onRated: (_) async => calls++));
+
+      await tester.tap(find.byType(TextButton));
+      await tester.pumpAndSettle();
+
+      expect(calls, 0);
+      expect(find.byType(AlertDialog), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Asks the user to rate the app at three points in the life of an install, and turns a low rating into something you can read instead of a silent uninstall.

## Behaviour

Shown on cold starts **1**, **3** and **10**, and never again after that — three asks, ever.

Each ask requires the feed to have actually worked that session: 5 completed loads before the first, 1 before the later two. Tapping any star marks the question answered, so someone who rates two stars and closes the box is not asked again. Dismissing without tapping consumes that launch's ask but leaves the schedule running.

**4–5 stars** → the Play in-app review card.
**1–3 stars** → a text box whose contents go to Sentry, so the reason arrives with the rating.

## Why the engagement gate is not decoration

`injection.no_posts_matched` fires in production today, and the longest-running complaint in the tracker is a feed that never renders. Prompting someone whose feed did not load buys a guaranteed one-star rating and teaches nothing.

Getting this right needed more than a counter. A failed main-frame load still fires `onPageFinished` on Android — the error page commits and finishes like any other document — and `LoadRetryPolicy` only reports `loadFailed` once its three retries are spent. So a naive counter treats each failed attempt as a completed load, and the prompt opens on top of the error screen. `SessionLoadCounter` tracks failure per navigation instead, and a whole retry sequence now leaves the session with nothing counted.

## Privacy

Feedback is the first thing this app sends that a person typed, so it gets its own gate rather than riding the existing one.

- `beforeSendFeedback` is registered explicitly. Sentry prefers it over `beforeSend` for `type: 'feedback'`, and `_rebuildScrubbed` passes `contexts` through verbatim — which is where the typed message lives. Without the callback the raw sentence would leave the device. There is a test that fails if the registration is removed.
- The message is scrubbed with the same rules as everything else: URLs reduced to host plus page kind, id-shaped digit runs replaced.
- Context blocks are rebuilt from scratch and reduced to the three the consent notice names — app, OS, device — plus the star rating. `culture` is dropped: locale and timezone identify a person and tell a bug report nothing. Sentry fills contexts in via event processors, which run *before* `beforeSend`, so passing them through would have sent a device fingerprint under a notice promising a message.
- No name, email, or URL is ever collected.

Someone who has turned reporting off still gets the box, with a notice saying plainly what sending does. Pressing send is the consent; their stored preference is not changed, and the client started to carry the message is closed again afterwards. The flag that permits this is cleared before anything that could fail, because it is the only thing standing between an opted-out user and every later event of theirs.

A build with no DSN compiled in — F-Droid, self-built APKs — shows no text box at all. A Send button that cannot send is worse than not offering one.

## Tests

444 passing, 6 skipped, analyzer unchanged at 48 infos with zero warnings.

The 6 skipped are a second test target for the paths that need a DSN compiled in; they skip rather than fail under a plain run and name the command that runs them:

```
fvm flutter test --dart-define=SENTRY_DSN=https://abc123def456@localhost:1/1 test/utils/telemetry_dsn_test.dart
```

Every test guarding a privacy or scheduling rule was verified by mutation — the production line was broken, the failure captured, and the line restored. Paths that could not be covered honestly are named as uncovered rather than given a test that passes for the wrong reason.

## Known limits

- `InAppReview.requestReview()` is quota-throttled by Google and has no callback, so some people who tap five stars will see the dialog close and nothing follow. The app cannot detect this. Swapping to `openStoreListing()` is a one-line change if ratings do not move.
- The strings are translated by hand into all 49 locales rather than waiting on Crowdin, which is suspended. `sr-SP` follows its file's existing Latin script; `pcm-NG` is actual Nigerian Pidgin, where "Not now" and "Send" happen to match English.
- The dialog's feedback branch has no widget coverage: it only renders in a build with a DSN, and no test seam was added to force it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

