### PR TITLE
Unblock photo upload on Android 12 and older

### DIFF
--- a/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
+++ b/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
@@ -6,8 +6,14 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- to allow to save photos -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <!-- to allow to read photos -->
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- READ_MEDIA_IMAGES is deliberately not declared. Nothing requests it:
+         the file chooser hands the page a URI from the system document picker,
+         which grants access per-pick and needs no runtime permission. It used
+         to back a "photo permission" toggle that gated the picker, and because
+         READ_MEDIA_IMAGES only exists from API 33 that gate made photo upload
+         impossible on anything older. Play also treats broad media access as a
+         sensitive permission requiring a declaration form, and the listing says
+         this app asks for no special permissions. -->
     <!-- to take pictures from inside Facebook: without this the "Camera
          permission" toggle in the settings can never be turned on -->
     <uses-permission android:name="android.permission.CAMERA" />

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -19,6 +18,7 @@ import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/ad_filter.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/dark_theme.dart';
+import 'package:slimsocial_for_facebook/utils/file_chooser.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/load_retry_policy.dart';
 import 'package:slimsocial_for_facebook/utils/telemetry.dart';
@@ -177,25 +177,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             Navigator.of(context).pop();
           },
         )
-        ..setOnShowFileSelector(
-          (FileSelectorParams params) async {
-            final photosPermission =
-                sp.getBool(SpKeys.photosPermission) ?? false;
-
-            if (photosPermission) {
-              final result = await FilePicker.platform.pickFiles();
-
-              if (result != null && result.files.single.path != null) {
-                final file = File(result.files.single.path!);
-                return [file.uri.toString()];
-              }
-            } else {
-              // Handle the case when the permission is not granted
-              showToast("check_permission".tr());
-            }
-            return [];
-          },
-        )
+        ..setOnShowFileSelector(handleFileChooser)
         ..setGeolocationPermissionsPromptCallbacks(
           onShowPrompt: (request) async {
             final gpsPermission = sp.getBool(SpKeys.gpsPermission) ?? false;

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:easy_localization/easy_localization.dart';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -13,6 +11,7 @@ import 'package:slimsocial_for_facebook/main.dart';
 import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/fb_navigation.dart';
+import 'package:slimsocial_for_facebook/utils/file_chooser.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
@@ -91,25 +90,7 @@ class _HomePageState extends ConsumerState<MessengerPage> {
         //let videos and voice clips play with sound on the first tap
         ..setMediaPlaybackRequiresUserGesture(false)
         ..setTextZoom(PrefController.getTextZoom())
-        ..setOnShowFileSelector(
-          (FileSelectorParams params) async {
-            final photosPermission =
-                sp.getBool(SpKeys.photosPermission) ?? false;
-
-            if (photosPermission) {
-              final result = await FilePicker.platform.pickFiles();
-
-              if (result != null && result.files.single.path != null) {
-                final file = File(result.files.single.path!);
-                return [file.uri.toString()];
-              }
-            } else {
-              // Handle the case when the permission is not granted
-              showToast("check_permission".tr());
-            }
-            return [];
-          },
-        )
+        ..setOnShowFileSelector(handleFileChooser)
         ..setGeolocationPermissionsPromptCallbacks(
           onShowPrompt: (request) async {
             final gpsPermission = sp.getBool(SpKeys.gpsPermission) ?? false;

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -32,10 +32,14 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   StreamSubscription<List<PurchaseDetails>>? _paymentSubscription;
   bool isDev = false;
 
+  //photosPermission is deliberately absent: the file chooser no longer gates on
+  //it. Permission.photos maps to READ_MEDIA_IMAGES, which only exists from API
+  //33, so below that it could never be granted and the gate blocked uploads
+  //outright. The SpKeys constant is kept — the key still exists on ~925k
+  //installs — but nothing reads it any more.
   final Map<String, Permission> permissions = const {
     SpKeys.gpsPermission: Permission.locationWhenInUse,
     SpKeys.cameraPermission: Permission.camera,
-    SpKeys.photosPermission: Permission.photos,
   };
 
   @override
@@ -178,43 +182,27 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
               ),
               SettingsTile.switchTile(
                 onToggle: (value) async {
-                  final oldVal = value == true;
-                  const permission = Permission.camera;
+                  final wanted = value;
+                  final granted =
+                      await handlePermission(wanted, Permission.camera);
 
-                  //value is set based on the new value of granted
-                  value = await handlePermission(value, permission);
+                  //Turning on: the OS decides, so store what it actually
+                  //granted. Turning off: the user's intent wins. handlePermission
+                  //returns isGranted, and an OS grant survives until it is
+                  //revoked in system settings, so storing it here would pin the
+                  //switch on and make it impossible to turn off.
+                  final stored = wanted && granted;
 
-                  if (oldVal != value) {
-                    setState(() {
-                      sp.setBool(SpKeys.cameraPermission, value);
-                    });
-                    ref.invalidate(fbWebViewProvider);
-                  }
+                  if (!mounted) return;
+                  setState(() {
+                    sp.setBool(SpKeys.cameraPermission, stored);
+                  });
+                  ref.invalidate(fbWebViewProvider);
                 },
                 //fixme bug on sp, I shoudl use the permission handler .isgranted
                 initialValue: sp.getBool(SpKeys.cameraPermission) ?? false,
                 leading: const Icon(Icons.camera_alt),
                 title: Text('camera_permission'.tr()),
-              ),
-              SettingsTile.switchTile(
-                onToggle: (value) async {
-                  final oldVal = value == true;
-                  const permission = Permission.photos;
-
-                  //value is set based on the new value of granted
-                  value = await handlePermission(value, permission);
-
-                  if (oldVal != value) {
-                    setState(() {
-                      sp.setBool(SpKeys.photosPermission, value);
-                    });
-                    ref.invalidate(fbWebViewProvider);
-                  }
-                },
-                //fixme bug on sp, I shoudl use the permission handler .isgranted
-                initialValue: sp.getBool(SpKeys.photosPermission) ?? false,
-                leading: const Icon(Icons.photo_camera_back_outlined),
-                title: Text('photo_permission'.tr()),
               ),
               SettingsTile.switchTile(
                 onToggle: (value) async {
@@ -523,8 +511,24 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
   }
 
   Future<void> buildPaymentWidget(String idItem) async {
+    try {
+      await _launchPurchase(idItem);
+    } on Object catch (e, stack) {
+      //Nothing used to catch here, so a throw anywhere in the billing flow left
+      //the user staring at a screen that did nothing.
+      Telemetry.captureError(e, stack, hint: 'donation flow');
+      showToast("error_trylater".tr());
+    }
+  }
+
+  Future<void> _launchPurchase(String idItem) async {
     //get the product
     final response = await InAppPurchase.instance.queryProductDetails({idItem});
+    if (response.error != null) {
+      Telemetry.captureIssue('billing.query_failed');
+      showToast("error_trylater".tr());
+      return;
+    }
     if (response.notFoundIDs.isNotEmpty) {
       debugPrint("Product not found");
       showToast("error_trylater".tr());
@@ -563,10 +567,26 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     );
 
     //show the dialog
-    final products = response.productDetails;
-    final product = products.first;
+    final product = response.productDetails.firstOrNull;
+    if (product == null) {
+      showToast("error_trylater".tr());
+      return;
+    }
     final purchaseParam = PurchaseParam(productDetails: product);
-    await InAppPurchase.instance.buyConsumable(purchaseParam: purchaseParam);
+
+    //One breadcrumb before the handoff. SLIMSOCIAL-5 is a crash inside Google's
+    //own ProxyBillingActivity.onCreate, which Dart cannot catch; this is what
+    //tells us on the next occurrence whether the app ever asked for it.
+    Telemetry.addBreadcrumb('billing.flow_launching');
+
+    //buyConsumable returns false when launchBillingFlow came back non-OK.
+    //Discarding it meant a declined flow looked identical to a successful one.
+    final started =
+        await InAppPurchase.instance.buyConsumable(purchaseParam: purchaseParam);
+    if (!started) {
+      Telemetry.captureIssue('billing.flow_not_started');
+      showToast("error_trylater".tr());
+    }
 
     return;
   }
@@ -783,6 +803,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       final spKey = entry.key;
 
       final permissionValue = await permission.isGranted;
+      if (!mounted) return;
       setState(() {
         sp.setBool(spKey, permissionValue);
       });

--- a/SlimSocial_for_Facebook/lib/utils/ad_filter.dart
+++ b/SlimSocial_for_Facebook/lib/utils/ad_filter.dart
@@ -123,6 +123,15 @@ const String kDiagnosticsChannelName = 'SlimDiag';
 /// hides nothing, and nothing crashes — adverts simply come back.
 const String kDiagNoPostsMatched = 'injection.no_posts_matched';
 
+/// The post-container selector matched at least one post.
+///
+/// The denominator [kDiagNoPostsMatched] never had. On its own a count of
+/// failures says nothing: six reports is indistinguishable from six-out-of-six
+/// and six-out-of-six-thousand. Raised once per process, exactly like the
+/// failure signal, so the two counts are directly comparable and the break rate
+/// is `no_posts_matched / (no_posts_matched + posts_matched)`.
+const String kDiagPostsMatched = 'injection.posts_matched';
+
 /// A pass of the injected filter threw.
 const String kDiagScriptThrew = 'injection.script_threw';
 
@@ -150,6 +159,7 @@ const String kDiagFilterMissing = 'injection.filter_missing';
 /// using the app as a way out for its own text.
 const Map<String, Set<String>> kDiagnosticFields = {
   kDiagNoPostsMatched: {'page', 'selector', 'dom_size'},
+  kDiagPostsMatched: <String>{},
   kDiagScriptThrew: {'error'},
   kDiagFilterMissing: <String>{},
 };
@@ -262,9 +272,13 @@ Diagnostic? parseDiagnostic(String message) {
   return Diagnostic(kind, data);
 }
 
-/// How long after a load the feed is given to render before zero posts is read
-/// as a stale selector rather than as a page still arriving.
-const int kFeedHealthDelayMs = 8000;
+/// When, after a load, the feed is checked for rendered posts.
+///
+/// Three attempts rather than one. A single 8 s shot cannot tell a stale
+/// selector from a low-end phone that simply had not painted yet — and the
+/// majority of this app's users are on exactly those devices. Only a page that
+/// still has no posts at 25 s is reported.
+const List<int> kFeedHealthDelaysMs = [8000, 15000, 25000];
 
 /// How many `div`s the page must hold before its post count means anything.
 ///
@@ -420,7 +434,7 @@ String adFilterScript({
   var FEED_HOSTS = ${jsonEncode(kFeedHosts)};
   var ERROR_NAMES = ${jsonEncode(kDiagnosticErrorNames.toList())};
   var OTHER = ${jsonEncode(kDiagnosticOtherValue)};
-  var HEALTH_DELAY_MS = $kFeedHealthDelayMs;
+  var HEALTH_DELAYS_MS = ${jsonEncode(kFeedHealthDelaysMs)};
   var MIN_DIVS = $kFeedHealthMinDivs;
   var memo = null;
   var reported = {};
@@ -485,13 +499,24 @@ String adFilterScript({
   // seconds of any load, so the check runs once, late, and only where a feed
   // was genuinely expected — on both sides of the wait, since the page can
   // navigate in place while it runs.
-  function checkFeedHealth() {
-    if (sawPosts) return;
+  function checkFeedHealth(isFinal) {
+    // Earlier attempts exist only to give a slow device a chance to paint and
+    // set sawPosts. Reporting from one of them is the false positive the
+    // schedule exists to remove, so only the last attempt may speak.
+    if (!isFinal) return;
     if (!isFeedPage()) return;
     if (document.readyState !== 'complete') return;
 
     var divs = document.getElementsByTagName('div').length;
     if (divs < MIN_DIVS) return;
+
+    // Both signals leave from here, past the same gates, so the pair describes
+    // one population and the ratio between them means something. A numerator
+    // counted against a different denominator would not.
+    if (sawPosts) {
+      report(${jsonEncode(kDiagPostsMatched)}, {});
+      return;
+    }
 
     report(${jsonEncode(kDiagNoPostsMatched)}, {
       page: 'feed',
@@ -828,7 +853,16 @@ String adFilterScript({
 
   if (isFeedPage()) {
     try {
-      setTimeout(checkFeedHealth, HEALTH_DELAY_MS);
+      var lastDelay = HEALTH_DELAYS_MS.length - 1;
+      for (var d = 0; d < HEALTH_DELAYS_MS.length; d++) {
+        // Only the last attempt reports. The earlier ones exist so that a feed
+        // which paints late clears sawPosts before anything is claimed.
+        (function (isFinal) {
+          setTimeout(function () {
+            checkFeedHealth(isFinal);
+          }, HEALTH_DELAYS_MS[d]);
+        })(d === lastDelay);
+      }
     } catch (e) {}
   }
 })();

--- a/SlimSocial_for_Facebook/lib/utils/file_chooser.dart
+++ b/SlimSocial_for_Facebook/lib/utils/file_chooser.dart
@@ -1,0 +1,45 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:slimsocial_for_facebook/utils/telemetry.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+
+/// Handles the WebView's request for files to hand back to a page `<input
+/// type="file">` — the Facebook composer's photo picker, in practice.
+///
+/// This used to be gated behind the stored `photos_permission` flag, which made
+/// photo upload permanently unreachable below Android 13: `Permission.photos` maps to
+/// `READ_MEDIA_IMAGES`, which only exists from API 33, so on anything older the
+/// permission could never be granted, the stored flag stayed false, and the
+/// picker was never opened at all. The gate was also unnecessary — the system
+/// document picker returns a URI the app is already granted access to, so it
+/// needs no runtime permission on any API level.
+Future<List<String>> handleFileChooser(FileSelectorParams params) async {
+  //One probe, once per process, to learn what Facebook actually asks for.
+  //`acceptTypes` is markup Facebook authored, not anything the user typed.
+  Telemetry.captureIssue(
+    'file_chooser.params',
+    data: {
+      'accept': params.acceptTypes.join('|'),
+      'mode': params.mode.name,
+    },
+  );
+
+  try {
+    final result = await FilePicker.platform.pickFiles();
+    if (result == null) return [];
+
+    //Walk the list rather than reading `.single`, which throws a StateError on
+    //any result that is not exactly one long.
+    return result.files
+        .map((f) => f.path)
+        .whereType<String>()
+        .map((p) => File(p).uri.toString())
+        .toList();
+  } on Object catch (e, stack) {
+    //A throw here escapes into the WebView callback and takes the upload with
+    //it, silently. Nothing has ever reported a failure from this path.
+    Telemetry.captureError(e, stack, hint: 'file chooser');
+    return [];
+  }
+}

--- a/SlimSocial_for_Facebook/lib/utils/telemetry.dart
+++ b/SlimSocial_for_Facebook/lib/utils/telemetry.dart
@@ -177,6 +177,22 @@ abstract final class Telemetry {
     }
   }
 
+  /// Records a breadcrumb from the app's own code.
+  ///
+  /// [message] must be a fixed literal this app chose, never page content or
+  /// anything the user typed — `enablePrintBreadcrumbs` is off precisely so
+  /// that nothing reaches Sentry by accident, and this is the one deliberate
+  /// way back in.
+  static void addBreadcrumb(String message) {
+    if (!_canReport || !isEnabled) return;
+
+    unawaited(
+      Sentry.addBreadcrumb(
+        Breadcrumb(message: scrubText(message), level: SentryLevel.info),
+      ),
+    );
+  }
+
   /// Reports a caught error.
   static void captureError(Object error, StackTrace? stack, {String? hint}) {
     if (!_canReport || !isEnabled) return;

--- a/SlimSocial_for_Facebook/test/utils/ad_filter_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/ad_filter_test.dart
@@ -512,7 +512,7 @@ void main() {
     test('sends only the fields declared for the kind it reports', () {
       // Same trap in the other direction: a field added here but not to
       // kDiagnosticFields is stripped before it leaves the app.
-      final stale = _objectKeys(_functionBody(health, 'function checkFeedHealth()'));
+      final stale = _objectKeys(_functionBody(health, 'function checkFeedHealth(isFinal)'));
       final threw = _objectKeys(_functionBody(health, 'function describe(e)'));
 
       final staleFields = kDiagnosticFields[kDiagNoPostsMatched]!;
@@ -537,7 +537,7 @@ void main() {
         'document.cookie',
       ]) {
         expect(
-          _functionBody(health, 'function checkFeedHealth()'),
+          _functionBody(health, 'function checkFeedHealth(isFinal)'),
           isNot(contains(source)),
         );
         expect(_functionBody(health, 'function describe(e)'), isNot(contains(source)));
@@ -597,7 +597,7 @@ void main() {
       // Only ever read as "did the page render at all", so an exact count is
       // detail nobody needs and a fingerprint nobody should have.
       expect(
-        _functionBody(health, 'function checkFeedHealth()'),
+        _functionBody(health, 'function checkFeedHealth(isFinal)'),
         contains('Math.floor(divs / 100) * 100'),
       );
     });
@@ -610,9 +610,9 @@ void main() {
       // Zero posts is the normal state of a photo view, a group, Marketplace
       // and every settings page. Reporting from those is not a weaker signal,
       // it is noise that buries the one case this exists for.
-      final body = _functionBody(health, 'function checkFeedHealth()');
+      final body = _functionBody(health, 'function checkFeedHealth(isFinal)');
 
-      expect(body, contains('if (sawPosts) return;'));
+      expect(body, contains('if (sawPosts) {'));
       expect(body, contains('if (!isFeedPage()) return;'));
       expect(body, contains("if (document.readyState !== 'complete') return;"));
       expect(body, contains('if (divs < MIN_DIVS) return;'));
@@ -689,15 +689,61 @@ void main() {
 
     test('waits for the feed to arrive before judging it', () {
       // The first pass runs at page-finished, when a feed legitimately holds
-      // no posts yet. One shot, late, is also the throttle for this signal.
-      final delay = int.parse(
-        RegExp(r'var HEALTH_DELAY_MS = (\d+);').firstMatch(health)!.group(1)!,
-      );
+      // no posts yet, so every check is late. A low-end phone can still be
+      // painting at the first one, which is why there is more than one.
+      final delays = RegExp(r'var HEALTH_DELAYS_MS = \[([\d,\s]+)\];')
+          .firstMatch(health)!
+          .group(1)!
+          .split(',')
+          .map((d) => int.parse(d.trim()))
+          .toList();
 
-      expect(delay, kFeedHealthDelayMs);
-      expect(delay, greaterThanOrEqualTo(5000));
-      expect(health, contains('setTimeout(checkFeedHealth, HEALTH_DELAY_MS)'));
-      expect(RegExp('checkFeedHealth').allMatches(health).length, 2);
+      expect(delays, kFeedHealthDelaysMs);
+      expect(delays.first, greaterThanOrEqualTo(5000));
+      expect(delays, orderedEquals(List.of(delays)..sort()));
+      expect(delays.length, greaterThan(1));
+    });
+
+    test('only the last attempt is allowed to report', () {
+      // Every earlier attempt exists so a slow device can set sawPosts first.
+      // If one of them could report, the extra attempts would be pointless —
+      // the Dart-side throttle keeps only the first event per process, so an
+      // early false positive would be the one that survived.
+      expect(health, contains('function checkFeedHealth(isFinal)'));
+      expect(health, contains('if (!isFinal) return;'));
+      expect(health, contains('d === lastDelay'));
+
+      // The guard has to sit before the report, not after it.
+      final body = _functionBody(health, 'function checkFeedHealth(isFinal)');
+      expect(
+        body.indexOf('if (!isFinal) return;'),
+        lessThan(body.indexOf('report(')),
+      );
+    });
+
+    test('a rendered feed reports the denominator', () {
+      // no_posts_matched on its own is a numerator with nothing under it: six
+      // events reads the same whether it is six-in-six or six-in-six-thousand.
+      final body = _functionBody(health, 'function checkFeedHealth(isFinal)');
+      expect(body, contains(kDiagPostsMatched));
+
+      // Both signals have to leave from behind the same gates, or the ratio
+      // describes two different populations and means nothing.
+      final gateAt = body.indexOf('if (divs < MIN_DIVS) return;');
+      expect(gateAt, greaterThan(0));
+      expect(body.indexOf(kDiagPostsMatched), greaterThan(gateAt));
+      expect(body.indexOf(kDiagNoPostsMatched), greaterThan(gateAt));
+    });
+
+    test('the filter itself still never consults the telemetry gate', () {
+      // Restating the invariant from the host-gate test at the point where it
+      // was actually broken once: an earlier version of the denominator called
+      // isFeedPage() from inside runPass(), which would have let a fault in the
+      // signal take the ad filter down with it.
+      expect(
+        _functionBody(health, 'function runPass()'),
+        isNot(contains(kDiagPostsMatched)),
+      );
     });
 
     test('one matched post anywhere in the page clears it', () {
@@ -716,7 +762,7 @@ void main() {
 
       expect(selector, contains('data-tracking-duration-id'));
       expect(
-        _functionBody(health, 'function checkFeedHealth()'),
+        _functionBody(health, 'function checkFeedHealth(isFinal)'),
         contains('selector: POST_SELECTOR'),
       );
     });

--- a/SlimSocial_for_Facebook/test/utils/file_chooser_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/file_chooser_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _read(String path) => File(path).readAsStringSync();
+
+/// Source with comments removed.
+///
+/// These assertions are all of the form "this identifier is gone". Run against
+/// raw source they also match the comments explaining why it is gone, so every
+/// one of them fails on its own documentation.
+String _code(String path) => _read(path)
+    .split('\n')
+    .where((l) => !l.trimLeft().startsWith('//'))
+    .join('\n');
+
+void main() {
+  //Source-level guards, in the style of lang_test.dart. The behaviour these
+  //protect is a WebView callback that needs a device to exercise, but the
+  //regression that broke it was visible in the source the whole time: a
+  //permission gate in front of the picker. That is what is asserted here.
+  group('the file chooser is not gated on a runtime permission', () {
+    const screens = [
+      'lib/screens/home_page.dart',
+      'lib/screens/messenger_page.dart',
+    ];
+
+    for (final path in screens) {
+      test('$path opens the picker unconditionally', () {
+        final source = _code(path);
+
+        //The gate that made photo upload unreachable below Android 13.
+        //Permission.photos maps to READ_MEDIA_IMAGES, which does not exist
+        //before API 33, so the stored flag could never become true and the
+        //picker was never opened at all.
+        expect(source, isNot(contains('SpKeys.photosPermission')));
+        expect(source, isNot(contains('check_permission')));
+
+        //Both screens carried a byte-identical copy. One handler now.
+        expect(source, contains('setOnShowFileSelector(handleFileChooser)'));
+      });
+    }
+
+    test('the settings screen no longer offers a photos toggle', () {
+      final source = _code('lib/screens/settings_page.dart');
+
+      expect(source, isNot(contains('Permission.photos')));
+      expect(source, isNot(contains("'photo_permission'")));
+    });
+
+    test('the storage key itself is kept', () {
+      //It exists on roughly 925k installs. Nothing reads it any more, but
+      //deleting the constant would let a future change reuse the name for
+      //something else and inherit whatever those devices already stored.
+      expect(_code('lib/consts.dart'), contains('photosPermission'));
+    });
+  });
+
+  group('the handler cannot throw into the WebView callback', () {
+    late String source;
+
+    setUpAll(() => source = _code('lib/utils/file_chooser.dart'));
+
+    test('walks the result list instead of reading .single', () {
+      //`.single` throws a StateError on any list that is not exactly one long,
+      //and the throw escapes into the callback and takes the upload with it.
+      expect(source, isNot(contains('.single')));
+      expect(source, contains('whereType<String>()'));
+    });
+
+    test('catches everything and reports it', () {
+      expect(source, contains('on Object catch'));
+      expect(source, contains('Telemetry.captureError'));
+
+      //Returning [] is what tells the page the user picked nothing, which is
+      //the only honest answer once the pick has failed.
+      final catchAt = source.indexOf('on Object catch');
+      expect(source.substring(catchAt), contains('return [];'));
+    });
+
+    test('probes what Facebook actually asks for', () {
+      //acceptTypes is markup Facebook authored, not anything the user typed.
+      //Nothing in this repo records what arrives here, and the normaliser that
+      //would use it cannot be written until that is known.
+      expect(source, contains('file_chooser.params'));
+      expect(source, contains('params.acceptTypes'));
+    });
+  });
+}


### PR DESCRIPTION
## The bug

Photo upload has been impossible on Android 12 and older since the permission gate went in.

```dart
// home_page.dart:181, and messenger_page.dart:95 byte-identical
final photosPermission = sp.getBool(SpKeys.photosPermission) ?? false;
if (photosPermission) { ...open picker... }
else { showToast("check_permission".tr()); }
return [];
```

`Permission.photos` maps to `READ_MEDIA_IMAGES`, which **only exists from API 33**. Below that the permission can never be granted, the stored flag stays false, and the picker is never opened at all. Not a degraded experience — the feature is unreachable.

That is the majority of this app's users. Crash-by-brand is TECNO 99 and Infinix 79 average daily users against samsung 607, and the API 29/30 band is ~15% of ~1000 DAU. "Unable to upload pictures" has been open since 2025 (#279, #274, #252) and photo/post problems are the largest single theme in low-rated reviews.

On API 33+ there was a second bug. `oldVal` held the *wanted* state and `value` the *granted* one, so on the success path both were `true`, `oldVal != value` never fired, and `sp.setBool` never ran. The switch did not move until you visited settings twice.

The gate was unnecessary either way: the system document picker returns a URI the app already has access to, and needs no runtime permission on any API level.

## Changes

**Photo upload**
- Gate removed from both webviews. The two copies were byte-identical; both now call one `handleFileChooser` in `lib/utils/file_chooser.dart`.
- Photos toggle and `READ_MEDIA_IMAGES` dropped. Nothing requests it now, Play treats broad media access as sensitive and wants a declaration form, and the listing says this app needs no special permissions. `SpKeys.photosPermission` is **kept** — the key is on ~925k devices and the name must not be reused.
- Same inverted guard fixed on the surviving camera toggle. It stores the granted state when turning on and the user's intent when turning off: an OS grant outlives the toggle, so storing it on the off path would pin the switch on permanently.
- `.single` replaced with a list walk. It raises `StateError` on any result that is not exactly one long, and the throw escaped into the WebView callback and took the upload with it.
- Whole body caught and reported. Nothing has ever had visibility into a failure here.
- One probe records what `acceptTypes` and `mode` actually arrive as. Nothing in this repo records it, and the normaliser that would use it cannot be written until it is known.

**Injection health**
- `injection.no_posts_matched` was a numerator with nothing under it — six events reads the same whether that is six-in-six or six-in-six-thousand. `injection.posts_matched` is now reported from inside `checkFeedHealth`, past the same four gates, so the pair describes one population and the ratio means something.
- Re-tries at 8s/15s/25s, only the last attempt allowed to report. One shot at 8s cannot tell a stale selector from a low-end phone that has not painted yet — and those phones are most of the user base.

**Billing**
- `buildPaymentWidget` had no `try`/`catch`, ignored `response.error`, discarded the bool from `buyConsumable` (a declined flow looked exactly like a successful one), and used `.first`. All four addressed.
- A breadcrumb before the handoff to Google's `ProxyBillingActivity`. The one crash seen there is inside Google's own activity and Dart cannot catch it, so the crumb is what will say whether the app ever asked for it.

## A note on the denominator

The first draft reported `posts_matched` from inside `runPass()`. `ad_filter_test.dart:679` rejected it, correctly — that file's invariant is that the ad filter must never consult `isFeedPage()`, so that a fault in the telemetry cannot take ad-blocking down with it. Moving both signals into `checkFeedHealth` is better anyway: they now leave from behind the same gates, so the two counts are actually comparable. The earlier version would have produced a break rate that was quietly wrong.

## Verification

- `flutter test` — **419 passing**, up from 409
- `flutter analyze` — zero errors, zero warnings; info lints 50 → 46

## Not verified

**Nobody in this repo has ever recorded a successful upload.** It is untested whether Facebook's uploader accepts the `file://` URI the picker returns. If it does not, this gets users to a picker that still fails and the answer is a `content://` URI, which needs native work. That needs a real device — this box has no `/dev/kvm` and only boots API 30.

The API 33+ half of the toggle fix is also unverified for the same reason. The hard block below API 33 is verified against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
