### PR TITLE
26.09.01+126: desktop-site setting and Messenger nav

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,10 @@
+v26.09.01+126
+- Add a "Use desktop site" setting: the 119 Firefox user agent for the feed. Default stays mobile.
+- Messenger always uses desktop Chrome. A custom user agent no longer overrides it.
+- Changing the custom user agent restarts the app so it takes effect.
+- Facebook.com links stay in Messenger instead of popping to the feed (crash SLIMSOCIAL-A, black profile #337).
+- Unlock page scroll if Facebook's install overlay is left behind (#339).
+
 v1.0.0
 - First release
 

--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -6,6 +6,8 @@
   "Facebook": "Facebook",
   "use_mbasic": "Use basic version of Facebook",
   "use_mbasic_desc": "It works better on older devices or slower connections",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
   "recent_first": "Show recent posts first",
   "hide_all_ads": "Hide ads",
   "style": "style",

--- a/SlimSocial_for_Facebook/assets/lang/af-ZA.json
+++ b/SlimSocial_for_Facebook/assets/lang/af-ZA.json
@@ -89,5 +89,7 @@
   "rate_send": "Stuur",
   "rate_sends_notice": "Dit stuur jou boodskap saam met die programweergawe, toestelmodel en Android-weergawe aan die ontwikkelaar. Jou instelling vir foutverslae bly af.",
   "rate_thanks": "Dankie — dit help.",
-  "rate_failed": "Kon nie stuur nie. Probeer later weer."
+  "rate_failed": "Kon nie stuur nie. Probeer later weer.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ar-AR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ar-AR.json
@@ -89,5 +89,7 @@
   "rate_send": "إرسال",
   "rate_sends_notice": "سيؤدي هذا إلى إرسال رسالتك إلى المطور، مع إصدار التطبيق وطراز الجهاز وإصدار Android. يبقى إعداد تقارير الأعطال لديك متوقفًا.",
   "rate_thanks": "شكرًا — هذا يساعدنا.",
-  "rate_failed": "تعذّر الإرسال. حاول مرة أخرى لاحقًا."
+  "rate_failed": "تعذّر الإرسال. حاول مرة أخرى لاحقًا.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/bg-BG.json
+++ b/SlimSocial_for_Facebook/assets/lang/bg-BG.json
@@ -89,5 +89,7 @@
   "rate_send": "Изпрати",
   "rate_sends_notice": "Това изпраща съобщението ви на разработчика заедно с версията на приложението, модела на устройството и версията на Android. Настройката ви за отчети за грешки остава изключена.",
   "rate_thanks": "Благодарим — това помага.",
-  "rate_failed": "Изпращането не бе успешно. Опитайте отново по-късно."
+  "rate_failed": "Изпращането не бе успешно. Опитайте отново по-късно.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/bn-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/bn-IN.json
@@ -89,5 +89,7 @@
   "rate_send": "পাঠান",
   "rate_sends_notice": "এটি আপনার বার্তা অ্যাপ সংস্করণ, ডিভাইস মডেল এবং Android সংস্করণ সহ ডেভেলপারের কাছে পাঠাবে। আপনার ক্র্যাশ রিপোর্ট সেটিং বন্ধ থাকবে।",
   "rate_thanks": "ধন্যবাদ — এতে সাহায্য হয়।",
-  "rate_failed": "পাঠানো যায়নি। অনুগ্রহ করে পরে আবার চেষ্টা করুন।"
+  "rate_failed": "পাঠানো যায়নি। অনুগ্রহ করে পরে আবার চেষ্টা করুন।",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ca-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/ca-ES.json
@@ -89,5 +89,7 @@
   "rate_send": "Envia",
   "rate_sends_notice": "Això envia el teu missatge al desenvolupador, juntament amb la versió de l'aplicació, el model del dispositiu i la versió d'Android. La teva configuració d'informes d'errors continua desactivada.",
   "rate_thanks": "Gràcies — això ajuda.",
-  "rate_failed": "No s'ha pogut enviar. Torna-ho a provar més tard."
+  "rate_failed": "No s'ha pogut enviar. Torna-ho a provar més tard.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
+++ b/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
@@ -89,5 +89,7 @@
   "rate_send": "Odeslat",
   "rate_sends_notice": "Tímto odešlete vývojáři svou zprávu spolu s verzí aplikace, modelem zařízení a verzí Androidu. Vaše nastavení hlášení chyb zůstává vypnuté.",
   "rate_thanks": "Děkujeme — to pomáhá.",
-  "rate_failed": "Odeslání se nezdařilo. Zkuste to prosím později."
+  "rate_failed": "Odeslání se nezdařilo. Zkuste to prosím později.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/da-DK.json
+++ b/SlimSocial_for_Facebook/assets/lang/da-DK.json
@@ -89,5 +89,7 @@
   "rate_send": "Send",
   "rate_sends_notice": "Dette sender din besked til udvikleren sammen med appversionen, enhedsmodellen og Android-versionen. Din indstilling for fejlrapporter forbliver slået fra.",
   "rate_thanks": "Tak — det hjælper.",
-  "rate_failed": "Kunne ikke sende. Prøv igen senere."
+  "rate_failed": "Kunne ikke sende. Prøv igen senere.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/de-DE.json
+++ b/SlimSocial_for_Facebook/assets/lang/de-DE.json
@@ -89,5 +89,7 @@
   "rate_send": "Senden",
   "rate_sends_notice": "Dies sendet deine Nachricht zusammen mit der App-Version, dem Gerätemodell und der Android-Version an den Entwickler. Deine Einstellung für Fehlerberichte bleibt ausgeschaltet.",
   "rate_thanks": "Danke — das hilft.",
-  "rate_failed": "Senden fehlgeschlagen. Bitte versuche es später erneut."
+  "rate_failed": "Senden fehlgeschlagen. Bitte versuche es später erneut.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/el-GR.json
+++ b/SlimSocial_for_Facebook/assets/lang/el-GR.json
@@ -89,5 +89,7 @@
   "rate_send": "Αποστολή",
   "rate_sends_notice": "Αυτό στέλνει το μήνυμά σας στον προγραμματιστή, μαζί με την έκδοση της εφαρμογής, το μοντέλο της συσκευής και την έκδοση Android. Η ρύθμισή σας για τις αναφορές σφαλμάτων παραμένει απενεργοποιημένη.",
   "rate_thanks": "Ευχαριστούμε — αυτό βοηθάει.",
-  "rate_failed": "Η αποστολή απέτυχε. Δοκιμάστε ξανά αργότερα."
+  "rate_failed": "Η αποστολή απέτυχε. Δοκιμάστε ξανά αργότερα.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -6,6 +6,8 @@
   "Facebook": "Facebook",
   "use_mbasic": "Use basic version of Facebook",
   "use_mbasic_desc": "It works better on older devices or slower connections",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
   "recent_first": "Show recent posts first",
   "hide_ads": "Hide some ads (experimental)",
   "hide_people_you_may_know": "Hide \"People you may know\"",

--- a/SlimSocial_for_Facebook/assets/lang/es-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/es-ES.json
@@ -89,5 +89,7 @@
   "rate_send": "Enviar",
   "rate_sends_notice": "Esto envía tu mensaje al desarrollador, junto con la versión de la aplicación, el modelo del dispositivo y la versión de Android. Tu ajuste de informes de errores sigue desactivado.",
   "rate_thanks": "Gracias — esto ayuda.",
-  "rate_failed": "No se pudo enviar. Inténtalo de nuevo más tarde."
+  "rate_failed": "No se pudo enviar. Inténtalo de nuevo más tarde.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/et-EE.json
+++ b/SlimSocial_for_Facebook/assets/lang/et-EE.json
@@ -89,5 +89,7 @@
   "rate_send": "Saada",
   "rate_sends_notice": "See saadab arendajale sinu sõnumi koos rakenduse versiooni, seadme mudeli ja Androidi versiooniga. Sinu veaaruannete säte jääb välja lülitatuks.",
   "rate_thanks": "Aitäh — sellest on abi.",
-  "rate_failed": "Saatmine ebaõnnestus. Proovi hiljem uuesti."
+  "rate_failed": "Saatmine ebaõnnestus. Proovi hiljem uuesti.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/fa-IR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fa-IR.json
@@ -89,5 +89,7 @@
   "rate_send": "ارسال",
   "rate_sends_notice": "با این کار پیام شما همراه با نسخهٔ برنامه، مدل دستگاه و نسخهٔ Android برای توسعه‌دهنده ارسال می‌شود. تنظیم گزارش خطای شما خاموش باقی می‌ماند.",
   "rate_thanks": "ممنون — این کمک می‌کند.",
-  "rate_failed": "ارسال نشد. لطفاً بعداً دوباره تلاش کنید."
+  "rate_failed": "ارسال نشد. لطفاً بعداً دوباره تلاش کنید.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/fi-FI.json
+++ b/SlimSocial_for_Facebook/assets/lang/fi-FI.json
@@ -89,5 +89,7 @@
   "rate_send": "Lähetä",
   "rate_sends_notice": "Tämä lähettää viestisi kehittäjälle sekä sovelluksen version, laitemallin ja Android-version. Virheraporttien asetuksesi pysyy pois päältä.",
   "rate_thanks": "Kiitos — tästä on apua.",
-  "rate_failed": "Lähetys epäonnistui. Yritä myöhemmin uudelleen."
+  "rate_failed": "Lähetys epäonnistui. Yritä myöhemmin uudelleen.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/fr-FR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fr-FR.json
@@ -89,5 +89,7 @@
   "rate_send": "Envoyer",
   "rate_sends_notice": "Cela envoie votre message au développeur, ainsi que la version de l'application, le modèle de votre appareil et la version d'Android. Votre réglage des rapports d'erreur reste désactivé.",
   "rate_thanks": "Merci — c'est utile.",
-  "rate_failed": "Envoi impossible. Réessayez plus tard."
+  "rate_failed": "Envoi impossible. Réessayez plus tard.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ha-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ha-NG.json
@@ -89,5 +89,7 @@
   "rate_send": "Aika",
   "rate_sends_notice": "Wannan yana aika saƙonka ga mai haɓakawa, tare da sigar manhaja, samfurin na'ura da sigar Android. Saitin rahoton kuskure naka zai kasance a kashe.",
   "rate_thanks": "Na gode — wannan yana taimakawa.",
-  "rate_failed": "An kasa aikawa. Da fatan a sake gwadawa daga baya."
+  "rate_failed": "An kasa aikawa. Da fatan a sake gwadawa daga baya.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/he-IL.json
+++ b/SlimSocial_for_Facebook/assets/lang/he-IL.json
@@ -89,5 +89,7 @@
   "rate_send": "שליחה",
   "rate_sends_notice": "פעולה זו שולחת את ההודעה שלך למפתח, יחד עם גרסת האפליקציה, דגם המכשיר וגרסת Android. ההגדרה שלך לדוחות קריסה נשארת כבויה.",
   "rate_thanks": "תודה — זה עוזר.",
-  "rate_failed": "השליחה נכשלה. נסו שוב מאוחר יותר."
+  "rate_failed": "השליחה נכשלה. נסו שוב מאוחר יותר.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/hi-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/hi-IN.json
@@ -89,5 +89,7 @@
   "rate_send": "भेजें",
   "rate_sends_notice": "इससे आपका संदेश ऐप संस्करण, डिवाइस मॉडल और Android संस्करण के साथ डेवलपर को भेजा जाएगा। आपकी क्रैश रिपोर्ट सेटिंग बंद रहेगी।",
   "rate_thanks": "धन्यवाद — इससे मदद मिलती है।",
-  "rate_failed": "भेजा नहीं जा सका। कृपया बाद में पुनः प्रयास करें।"
+  "rate_failed": "भेजा नहीं जा सका। कृपया बाद में पुनः प्रयास करें।",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/hr-HR.json
+++ b/SlimSocial_for_Facebook/assets/lang/hr-HR.json
@@ -89,5 +89,7 @@
   "rate_send": "Pošalji",
   "rate_sends_notice": "Ovo šalje vašu poruku razvijatelju zajedno s verzijom aplikacije, modelom uređaja i verzijom Androida. Vaša postavka izvješća o pogreškama ostaje isključena.",
   "rate_thanks": "Hvala — ovo pomaže.",
-  "rate_failed": "Slanje nije uspjelo. Pokušajte ponovno kasnije."
+  "rate_failed": "Slanje nije uspjelo. Pokušajte ponovno kasnije.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/hu-HU.json
+++ b/SlimSocial_for_Facebook/assets/lang/hu-HU.json
@@ -89,5 +89,7 @@
   "rate_send": "Küldés",
   "rate_sends_notice": "Ez elküldi az üzenetedet a fejlesztőnek az alkalmazás verziójával, az eszköz modelljével és az Android verziójával együtt. A hibajelentések beállítása kikapcsolva marad.",
   "rate_thanks": "Köszönjük — ez segít.",
-  "rate_failed": "Nem sikerült elküldeni. Próbáld újra később."
+  "rate_failed": "Nem sikerült elküldeni. Próbáld újra később.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ig-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ig-NG.json
@@ -89,5 +89,7 @@
   "rate_send": "Zipu",
   "rate_sends_notice": "Nke a na-ezigara onye mmepe ozi gị, tinyere ụdị ngwa, ụdị ngwaọrụ na ụdị Android. Ntọala mkpesa nkwubi gị ga-anọgide na-agbanyụ.",
   "rate_thanks": "Daalụ — nke a na-enyere aka.",
-  "rate_failed": "Enweghị ike izipu. Biko nwaa ọzọ ma emesịa."
+  "rate_failed": "Enweghị ike izipu. Biko nwaa ọzọ ma emesịa.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -89,5 +89,7 @@
   "rate_send": "Invia",
   "rate_sends_notice": "Questo invia il tuo messaggio allo sviluppatore, insieme alla versione dell'app, al modello del dispositivo e alla versione di Android. L'impostazione sulle segnalazioni di errori resta disattivata.",
   "rate_thanks": "Grazie — è utile.",
-  "rate_failed": "Invio non riuscito. Riprova più tardi."
+  "rate_failed": "Invio non riuscito. Riprova più tardi.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ja-JP.json
+++ b/SlimSocial_for_Facebook/assets/lang/ja-JP.json
@@ -89,5 +89,7 @@
   "rate_send": "送信",
   "rate_sends_notice": "メッセージが、アプリのバージョン、端末のモデル、Android のバージョンとともに開発者に送信されます。クラッシュレポートの設定はオフのままです。",
   "rate_thanks": "ありがとうございます — 助かります。",
-  "rate_failed": "送信できませんでした。後でもう一度お試しください。"
+  "rate_failed": "送信できませんでした。後でもう一度お試しください。",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ko-KR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ko-KR.json
@@ -89,5 +89,7 @@
   "rate_send": "보내기",
   "rate_sends_notice": "메시지가 앱 버전, 기기 모델, Android 버전과 함께 개발자에게 전송됩니다. 오류 보고 설정은 계속 꺼져 있습니다.",
   "rate_thanks": "감사합니다 — 큰 도움이 됩니다.",
-  "rate_failed": "보내지 못했습니다. 나중에 다시 시도해 주세요."
+  "rate_failed": "보내지 못했습니다. 나중에 다시 시도해 주세요.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/lt-LT.json
+++ b/SlimSocial_for_Facebook/assets/lang/lt-LT.json
@@ -89,5 +89,7 @@
   "rate_send": "Siųsti",
   "rate_sends_notice": "Taip kūrėjui bus išsiųsta jūsų žinutė kartu su programėlės versija, įrenginio modeliu ir „Android“ versija. Jūsų klaidų ataskaitų nustatymas lieka išjungtas.",
   "rate_thanks": "Ačiū — tai padeda.",
-  "rate_failed": "Nepavyko išsiųsti. Bandykite vėliau."
+  "rate_failed": "Nepavyko išsiųsti. Bandykite vėliau.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/lv-LV.json
+++ b/SlimSocial_for_Facebook/assets/lang/lv-LV.json
@@ -89,5 +89,7 @@
   "rate_send": "Sūtīt",
   "rate_sends_notice": "Tas nosūta izstrādātājam jūsu ziņojumu kopā ar lietotnes versiju, ierīces modeli un Android versiju. Jūsu kļūdu ziņojumu iestatījums paliek izslēgts.",
   "rate_thanks": "Paldies — tas palīdz.",
-  "rate_failed": "Neizdevās nosūtīt. Mēģiniet vēlreiz vēlāk."
+  "rate_failed": "Neizdevās nosūtīt. Mēģiniet vēlreiz vēlāk.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ml-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ml-IN.json
@@ -89,5 +89,7 @@
   "rate_send": "അയയ്ക്കുക",
   "rate_sends_notice": "ഇത് നിങ്ങളുടെ സന്ദേശം ആപ്പ് പതിപ്പ്, ഉപകരണ മോഡൽ, Android പതിപ്പ് എന്നിവയ്‌ക്കൊപ്പം ഡെവലപ്പർക്ക് അയയ്ക്കും. നിങ്ങളുടെ ക്രാഷ് റിപ്പോർട്ട് ക്രമീകരണം ഓഫായി തുടരും.",
   "rate_thanks": "നന്ദി — ഇത് സഹായകരമാണ്.",
-  "rate_failed": "അയയ്ക്കാനായില്ല. ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക."
+  "rate_failed": "അയയ്ക്കാനായില്ല. ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/mr-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/mr-IN.json
@@ -89,5 +89,7 @@
   "rate_send": "पाठवा",
   "rate_sends_notice": "यामुळे तुमचा संदेश अ‍ॅप आवृत्ती, डिव्हाइस मॉडेल आणि Android आवृत्तीसह विकसकाला पाठवला जाईल. तुमची क्रॅश अहवाल सेटिंग बंदच राहील.",
   "rate_thanks": "धन्यवाद — याची मदत होते.",
-  "rate_failed": "पाठवता आले नाही. कृपया नंतर पुन्हा प्रयत्न करा."
+  "rate_failed": "पाठवता आले नाही. कृपया नंतर पुन्हा प्रयत्न करा.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/nl-NL.json
+++ b/SlimSocial_for_Facebook/assets/lang/nl-NL.json
@@ -89,5 +89,7 @@
   "rate_send": "Verzenden",
   "rate_sends_notice": "Hiermee stuur je je bericht naar de ontwikkelaar, samen met de app-versie, het apparaatmodel en de Android-versie. Je instelling voor foutrapporten blijft uitgeschakeld.",
   "rate_thanks": "Bedankt — hier hebben we wat aan.",
-  "rate_failed": "Verzenden mislukt. Probeer het later opnieuw."
+  "rate_failed": "Verzenden mislukt. Probeer het later opnieuw.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/no-NO.json
+++ b/SlimSocial_for_Facebook/assets/lang/no-NO.json
@@ -89,5 +89,7 @@
   "rate_send": "Send",
   "rate_sends_notice": "Dette sender meldingen din til utvikleren, sammen med appversjonen, enhetsmodellen og Android-versjonen. Innstillingen din for feilrapporter forblir av.",
   "rate_thanks": "Takk — dette hjelper.",
-  "rate_failed": "Kunne ikke sende. Prøv igjen senere."
+  "rate_failed": "Kunne ikke sende. Prøv igjen senere.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
@@ -89,5 +89,7 @@
   "rate_send": "Send",
   "rate_sends_notice": "Dis one go send your message give di developer, plus your app version, device model and Android version. Your crash report setting go still dey off.",
   "rate_thanks": "Thank you — e dey help.",
-  "rate_failed": "E no fit send. Abeg try again later."
+  "rate_failed": "E no fit send. Abeg try again later.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pl-PL.json
+++ b/SlimSocial_for_Facebook/assets/lang/pl-PL.json
@@ -89,5 +89,7 @@
   "rate_send": "Wyślij",
   "rate_sends_notice": "Spowoduje to wysłanie Twojej wiadomości do dewelopera wraz z wersją aplikacji, modelem urządzenia i wersją Androida. Twoje ustawienie raportów o błędach pozostaje wyłączone.",
   "rate_thanks": "Dziękujemy — to pomaga.",
-  "rate_failed": "Nie udało się wysłać. Spróbuj ponownie później."
+  "rate_failed": "Nie udało się wysłać. Spróbuj ponownie później.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-BR.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-BR.json
@@ -89,5 +89,7 @@
   "rate_send": "Enviar",
   "rate_sends_notice": "Isso envia sua mensagem ao desenvolvedor, junto com a versão do aplicativo, o modelo do aparelho e a versão do Android. Sua configuração de relatórios de erro continua desativada.",
   "rate_thanks": "Obrigado — isso ajuda.",
-  "rate_failed": "Não foi possível enviar. Tente novamente mais tarde."
+  "rate_failed": "Não foi possível enviar. Tente novamente mais tarde.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-PT.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-PT.json
@@ -89,5 +89,7 @@
   "rate_send": "Enviar",
   "rate_sends_notice": "Isto envia a sua mensagem ao programador, juntamente com a versão da aplicação, o modelo do dispositivo e a versão do Android. A sua definição de relatórios de erros permanece desativada.",
   "rate_thanks": "Obrigado — isto ajuda.",
-  "rate_failed": "Não foi possível enviar. Tente novamente mais tarde."
+  "rate_failed": "Não foi possível enviar. Tente novamente mais tarde.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ro-RO.json
+++ b/SlimSocial_for_Facebook/assets/lang/ro-RO.json
@@ -89,5 +89,7 @@
   "rate_send": "Trimite",
   "rate_sends_notice": "Aceasta trimite mesajul tău către dezvoltator, împreună cu versiunea aplicației, modelul dispozitivului și versiunea Android. Setarea ta pentru rapoartele de eroare rămâne dezactivată.",
   "rate_thanks": "Mulțumim — asta ajută.",
-  "rate_failed": "Trimiterea a eșuat. Încearcă din nou mai târziu."
+  "rate_failed": "Trimiterea a eșuat. Încearcă din nou mai târziu.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ru-RU.json
+++ b/SlimSocial_for_Facebook/assets/lang/ru-RU.json
@@ -89,5 +89,7 @@
   "rate_send": "Отправить",
   "rate_sends_notice": "Это отправит разработчику ваше сообщение вместе с версией приложения, моделью устройства и версией Android. Настройка отчётов об ошибках останется выключенной.",
   "rate_thanks": "Спасибо — это помогает.",
-  "rate_failed": "Не удалось отправить. Повторите попытку позже."
+  "rate_failed": "Не удалось отправить. Повторите попытку позже.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sk-SK.json
+++ b/SlimSocial_for_Facebook/assets/lang/sk-SK.json
@@ -89,5 +89,7 @@
   "rate_send": "Odoslať",
   "rate_sends_notice": "Týmto odošlete vývojárovi svoju správu spolu s verziou aplikácie, modelom zariadenia a verziou Androidu. Vaše nastavenie hlásení chýb zostáva vypnuté.",
   "rate_thanks": "Ďakujeme — to pomáha.",
-  "rate_failed": "Odoslanie zlyhalo. Skúste to znova neskôr."
+  "rate_failed": "Odoslanie zlyhalo. Skúste to znova neskôr.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sl-SI.json
+++ b/SlimSocial_for_Facebook/assets/lang/sl-SI.json
@@ -89,5 +89,7 @@
   "rate_send": "Pošlji",
   "rate_sends_notice": "S tem boste razvijalcu poslali svoje sporočilo skupaj z različico aplikacije, modelom naprave in različico Androida. Vaša nastavitev poročil o napakah ostane izklopljena.",
   "rate_thanks": "Hvala — to pomaga.",
-  "rate_failed": "Pošiljanje ni uspelo. Poskusite znova pozneje."
+  "rate_failed": "Pošiljanje ni uspelo. Poskusite znova pozneje.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sr-SP.json
+++ b/SlimSocial_for_Facebook/assets/lang/sr-SP.json
@@ -89,5 +89,7 @@
   "rate_send": "Pošalji",
   "rate_sends_notice": "Ovo šalje vašu poruku programeru zajedno sa verzijom aplikacije, modelom uređaja i verzijom Androida. Vaše podešavanje izveštaja o greškama ostaje isključeno.",
   "rate_thanks": "Hvala — ovo pomaže.",
-  "rate_failed": "Slanje nije uspelo. Pokušajte ponovo kasnije."
+  "rate_failed": "Slanje nije uspelo. Pokušajte ponovo kasnije.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sv-SE.json
+++ b/SlimSocial_for_Facebook/assets/lang/sv-SE.json
@@ -89,5 +89,7 @@
   "rate_send": "Skicka",
   "rate_sends_notice": "Detta skickar ditt meddelande till utvecklaren, tillsammans med appversionen, enhetsmodellen och Android-versionen. Din inställning för felrapporter förblir avstängd.",
   "rate_thanks": "Tack — det hjälper.",
-  "rate_failed": "Kunde inte skicka. Försök igen senare."
+  "rate_failed": "Kunde inte skicka. Försök igen senare.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ta-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ta-IN.json
@@ -89,5 +89,7 @@
   "rate_send": "அனுப்பு",
   "rate_sends_notice": "இது உங்கள் செய்தியை ஆப் பதிப்பு, சாதன மாடல் மற்றும் Android பதிப்புடன் உருவாக்குநருக்கு அனுப்பும். உங்கள் செயலிழப்பு அறிக்கை அமைப்பு அணைக்கப்பட்டே இருக்கும்.",
   "rate_thanks": "நன்றி — இது உதவுகிறது.",
-  "rate_failed": "அனுப்ப முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்."
+  "rate_failed": "அனுப்ப முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/te-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/te-IN.json
@@ -89,5 +89,7 @@
   "rate_send": "పంపు",
   "rate_sends_notice": "ఇది మీ సందేశాన్ని యాప్ వెర్షన్, పరికర మోడల్ మరియు Android వెర్షన్‌తో పాటు డెవలపర్‌కు పంపుతుంది. మీ క్రాష్ రిపోర్ట్ సెట్టింగ్ ఆఫ్‌లోనే ఉంటుంది.",
   "rate_thanks": "ధన్యవాదాలు — ఇది సహాయపడుతుంది.",
-  "rate_failed": "పంపడం సాధ్యం కాలేదు. దయచేసి తర్వాత మళ్లీ ప్రయత్నించండి."
+  "rate_failed": "పంపడం సాధ్యం కాలేదు. దయచేసి తర్వాత మళ్లీ ప్రయత్నించండి.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/th-TH.json
+++ b/SlimSocial_for_Facebook/assets/lang/th-TH.json
@@ -89,5 +89,7 @@
   "rate_send": "ส่ง",
   "rate_sends_notice": "การดำเนินการนี้จะส่งข้อความของคุณไปยังผู้พัฒนา พร้อมกับเวอร์ชันแอป รุ่นอุปกรณ์ และเวอร์ชัน Android การตั้งค่ารายงานข้อขัดข้องของคุณจะยังคงปิดอยู่",
   "rate_thanks": "ขอบคุณ — ช่วยได้มาก",
-  "rate_failed": "ส่งไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง"
+  "rate_failed": "ส่งไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/tr-TR.json
+++ b/SlimSocial_for_Facebook/assets/lang/tr-TR.json
@@ -89,5 +89,7 @@
   "rate_send": "Gönder",
   "rate_sends_notice": "Bu, mesajınızı uygulama sürümü, cihaz modeli ve Android sürümüyle birlikte geliştiriciye gönderir. Hata raporu ayarınız kapalı kalır.",
   "rate_thanks": "Teşekkürler — bu yardımcı oluyor.",
-  "rate_failed": "Gönderilemedi. Lütfen daha sonra tekrar deneyin."
+  "rate_failed": "Gönderilemedi. Lütfen daha sonra tekrar deneyin.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/uk-UA.json
+++ b/SlimSocial_for_Facebook/assets/lang/uk-UA.json
@@ -89,5 +89,7 @@
   "rate_send": "Надіслати",
   "rate_sends_notice": "Це надішле розробнику ваше повідомлення разом із версією застосунку, моделлю пристрою та версією Android. Ваше налаштування звітів про помилки залишиться вимкненим.",
   "rate_thanks": "Дякуємо — це допомагає.",
-  "rate_failed": "Не вдалося надіслати. Спробуйте пізніше."
+  "rate_failed": "Не вдалося надіслати. Спробуйте пізніше.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ur-PK.json
+++ b/SlimSocial_for_Facebook/assets/lang/ur-PK.json
@@ -89,5 +89,7 @@
   "rate_send": "بھیجیں",
   "rate_sends_notice": "اس سے آپ کا پیغام ایپ ورژن، ڈیوائس ماڈل اور Android ورژن کے ساتھ ڈویلپر کو بھیجا جائے گا۔ آپ کی کریش رپورٹ کی ترتیب بند رہے گی۔",
   "rate_thanks": "شکریہ — اس سے مدد ملتی ہے۔",
-  "rate_failed": "بھیجا نہیں جا سکا۔ براہ کرم بعد میں دوبارہ کوشش کریں۔"
+  "rate_failed": "بھیجا نہیں جا سکا۔ براہ کرم بعد میں دوبارہ کوشش کریں۔",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/vi-VN.json
+++ b/SlimSocial_for_Facebook/assets/lang/vi-VN.json
@@ -89,5 +89,7 @@
   "rate_send": "Gửi",
   "rate_sends_notice": "Thao tác này sẽ gửi tin nhắn của bạn đến nhà phát triển, cùng với phiên bản ứng dụng, kiểu thiết bị và phiên bản Android. Cài đặt báo cáo sự cố của bạn vẫn tắt.",
   "rate_thanks": "Cảm ơn — điều này rất hữu ích.",
-  "rate_failed": "Không thể gửi. Vui lòng thử lại sau."
+  "rate_failed": "Không thể gửi. Vui lòng thử lại sau.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/yo-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/yo-NG.json
@@ -89,5 +89,7 @@
   "rate_send": "Firánṣẹ́",
   "rate_sends_notice": "Èyí yóò fi iṣẹ́ rẹ ránṣẹ́ sí olùdàgbàsókè, pẹ̀lú ẹ̀yà app, àwòṣe ẹ̀rọ àti ẹ̀yà Android. Ètò ìròyìn àṣìṣe rẹ yóò wà ní pípa.",
   "rate_thanks": "O ṣeun — èyí ṣèrànwọ́.",
-  "rate_failed": "Kò lè fi ránṣẹ́. Jọ̀wọ́ gbìyànjú lẹ́ẹ̀kansi nígbà mìíràn."
+  "rate_failed": "Kò lè fi ránṣẹ́. Jọ̀wọ́ gbìyànjú lẹ́ẹ̀kansi nígbà mìíràn.",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-CN.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-CN.json
@@ -89,5 +89,7 @@
   "rate_send": "发送",
   "rate_sends_notice": "这会将你的留言连同应用版本、设备型号和 Android 版本一起发送给开发者。你的崩溃报告设置仍保持关闭。",
   "rate_thanks": "谢谢 — 这很有帮助。",
-  "rate_failed": "发送失败。请稍后再试。"
+  "rate_failed": "发送失败。请稍后再试。",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-TW.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-TW.json
@@ -89,5 +89,7 @@
   "rate_send": "傳送",
   "rate_sends_notice": "這會將你的訊息連同應用程式版本、裝置型號和 Android 版本一併傳送給開發者。你的當機報告設定仍維持關閉。",
   "rate_thanks": "謝謝 — 這很有幫助。",
-  "rate_failed": "傳送失敗。請稍後再試。"
+  "rate_failed": "傳送失敗。請稍後再試。",
+  "use_desktop_site": "Use desktop site",
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
 }

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -44,6 +44,15 @@ const String kDesktopUserAgent =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 "
     "(KHTML, like Gecko) Chrome/68.0.3440.84 Safari/537.36";
 
+/// Desktop Firefox on Windows. The feed agent in 26.08.05+119.
+///
+/// Facebook serves the desktop site for this string: in-page chat and the
+/// share menu work, and the page is heavier. It is the Settings "Desktop site"
+/// option, not the default — the default is [kMobileUserAgent] so injected
+/// selectors keep matching the touch layout.
+const String kFirefoxUserAgent =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0";
+
 /// Opera Mini. Used only by basic mode, which targets `mbasic.facebook.com`.
 const String kOperaMiniUserAgent =
     "Opera/9.80 (Android; Opera Mini/69.0.2254/191.303; U; en) Presto/2.12.423 Version/12.16";
@@ -109,6 +118,10 @@ class SpKeys {
   static const String adsBlockedTotal = "ads_blocked_total";
   static const String recentFirst = "recent_first";
   static const String useMbasic = "use_mbasic";
+
+  /// When true, the feed uses the 119 desktop Firefox user agent.
+  /// Unset or false keeps the mobile default. Messenger ignores this key.
+  static const String useDesktopSite = "use_desktop_site";
 
   /// Whether crash and health reporting may send anything. Unset means on.
   static const String telemetryEnabled = "telemetry_enabled";

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -20,9 +20,15 @@ class PrefController {
 
   /// Returns the user agent to use for [role].
   ///
-  /// An explicit custom agent wins over everything, then basic mode, then the
-  /// per-role default.
+  /// Messenger is pinned to [kDesktopUserAgent]. A custom string or the
+  /// desktop-site / basic-mode switches would otherwise send it a mobile
+  /// agent, and Facebook answers that with the native-app interstitial.
+  ///
+  /// For the feed: a custom agent wins, then basic mode, then the desktop-site
+  /// setting, then the mobile default.
   static String getUserAgent({UserAgentRole role = UserAgentRole.feed}) {
+    if (role == UserAgentRole.messenger) return kDesktopUserAgent;
+
     final customUserAgent = _getOverride(SpKeys.customUserAgent);
     if (customUserAgent != null) {
       debugPrint("Using custom user agent: $customUserAgent");
@@ -31,12 +37,9 @@ class PrefController {
 
     if (sp.getBool(SpKeys.useMbasic) ?? false) return kOperaMiniUserAgent;
 
-    switch (role) {
-      case UserAgentRole.feed:
-        return kMobileUserAgent;
-      case UserAgentRole.messenger:
-        return kDesktopUserAgent;
-    }
+    if (sp.getBool(SpKeys.useDesktopSite) ?? false) return kFirefoxUserAgent;
+
+    return kMobileUserAgent;
   }
 
   /// Text scaling for the webview, as a percentage of the page's own size.

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -130,43 +130,19 @@ class _HomePageState extends ConsumerState<MessengerPage> {
   ) async {
     final uri = Uri.parse(request.url);
 
-    for (final other in kPermittedHostnamesMessenger) {
-      if (uri.host.endsWith(other)) {
+    switch (messengerNavigationFor(uri)) {
+      case MessengerNavAction.stay:
         return NavigationDecision.navigate;
-      }
-    }
-
-    //Signing in belongs to this screen even though it is served from
-    //facebook.com. Messenger authenticates against Facebook, so the login-code
-    //prompt is a facebook.com page — and the branch below, which exists for a
-    //Facebook link tapped inside a conversation, used to send it to the feed.
-    //The screen closed itself half way through authenticating and the prompt
-    //surfaced in a webview that could not finish it, so Messenger could not be
-    //signed into at all.
-    if (isFacebookAuthUrl(uri)) return NavigationDecision.navigate;
-
-    for (final other in kPermittedHostnamesFb) {
-      if (uri.host.endsWith(other)) {
+      case MessengerNavAction.openExternal:
         if (!mounted) return NavigationDecision.prevent;
-
-        ref.read(fbWebViewProvider.notifier).updateUrl(request.url);
-        Navigator.of(context).pop();
-        //todo hide msg
+        //the address of a link the user tapped is their browsing, and this line
+        //used to run in release builds through a bare `print`: Sentry collects
+        //stdout as a breadcrumb, so every conversation and every link opened
+        //out of Messenger travelled with the next report.
+        if (kDebugMode) debugPrint("Launching external url: ${request.url}");
+        launchInAppUrl(context, request.url);
         return NavigationDecision.prevent;
-      }
     }
-
-    if (!mounted) return NavigationDecision.prevent;
-
-    // open on webview
-    //the address of a link the user tapped is their browsing, and this line
-    //used to run in release builds through a bare `print`: Sentry collects
-    //stdout as a breadcrumb, so every conversation and every link opened out of
-    //Messenger travelled with the next report. Gated the way the feed's own
-    //navigation logging in home_page.dart already was.
-    if (kDebugMode) debugPrint("Launching external url: ${request.url}");
-    launchInAppUrl(context, request.url);
-    return NavigationDecision.prevent;
   }
 
   @override

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -154,6 +154,19 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text('use_mbasic'.tr()),
                 description: Text('use_mbasic_desc'.tr()),
               ),
+              SettingsTile.switchTile(
+                onToggle: (value) {
+                  setState(() {
+                    sp.setBool(SpKeys.useDesktopSite, value);
+                  });
+                  showToast("rebooting".tr());
+                  Restart.restartApp();
+                },
+                initialValue: sp.getBool(SpKeys.useDesktopSite) ?? false,
+                leading: const Icon(Icons.desktop_windows_outlined),
+                title: Text('use_desktop_site'.tr()),
+                description: Text('use_desktop_site_desc'.tr()),
+              ),
             ],
           ),
           SettingsSection(
@@ -316,11 +329,16 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                   child: const Icon(Icons.check_circle),
                 ),
                 onPressed: (context) async {
+                  final before = PrefController.getUserAgent();
                   await showTextInputDialog(
                     spKey: SpKeys.customUserAgent,
                     hint: PrefController.getUserAgent(),
                   );
                   setState(() {});
+                  if (PrefController.getUserAgent() != before) {
+                    showToast("rebooting".tr());
+                    Restart.restartApp();
+                  }
                 },
               ),
               SettingsTile.navigation(

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -239,7 +239,8 @@ class CustomCss {
     defaultEnabled: true,
     code: 'div.fixed-container.bottom'
         ':not(:has(textarea)):not(:has(input)):not(:has([contenteditable]))'
-        ' { display: none !important; }',
+        ' { display: none !important; }'
+        ' html, body { overflow: auto !important; }',
   );
 
   /// Hands the post text back to the reader: selectable, and so copyable.

--- a/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
+++ b/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
@@ -1,3 +1,5 @@
+import 'package:slimsocial_for_facebook/consts.dart';
+
 /// First path segments of Facebook's sign-in and account-verification flow.
 ///
 /// One entry per *first* segment, matched exactly rather than as a prefix, so
@@ -78,4 +80,37 @@ bool isFacebookAuthUrl(Uri uri) {
   }
 
   return false;
+}
+
+/// What the Messenger webview should do with [uri].
+///
+/// Facebook.com addresses used to close this screen and hand the URL to the
+/// feed. That crashed when there was nothing to pop
+/// (SLIMSOCIAL-A, `StateError: No element`) and painted a black page when the
+/// feed's mobile webview tried to render a desktop Messenger profile (#337).
+/// Auth, profiles, and every other facebook.com page now stay here.
+enum MessengerNavAction {
+  /// Load [uri] in the Messenger webview.
+  stay,
+
+  /// Open [uri] outside the app (custom tab / external browser).
+  openExternal,
+}
+
+/// Decides [MessengerNavAction] for a navigation that started on Messenger.
+MessengerNavAction messengerNavigationFor(Uri uri) {
+  for (final host in kPermittedHostnamesMessenger) {
+    if (uri.host.endsWith(host)) return MessengerNavAction.stay;
+  }
+
+  for (final host in kPermittedHostnamesFb) {
+    if (uri.host.endsWith(host)) return MessengerNavAction.stay;
+  }
+
+  // Auth URLs are facebook.com, so the loop above already keeps them. This
+  // call is the belt: a future host that still serves the login flow is
+  // treated as Messenger's own, not as an external page.
+  if (isFacebookAuthUrl(uri)) return MessengerNavAction.stay;
+
+  return MessengerNavAction.openExternal;
 }

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # the git tag, so this has to be bumped in its own commit *before* the matching
 # tag is pushed - a tag pushed first builds the previous version. Every release
 # tag from 117 onwards matches the value that was in this field at that commit.
-version: 26.08.28+124
+version: 26.09.01+126
 
 # Leonardo Rignanese <dev.rignaneseleo@gmail.com>
 #

--- a/SlimSocial_for_Facebook/test/consts_test.dart
+++ b/SlimSocial_for_Facebook/test/consts_test.dart
@@ -14,6 +14,7 @@ void main() {
       expect(SpKeys.hideAds, 'hide_ads');
       expect(SpKeys.recentFirst, 'recent_first');
       expect(SpKeys.useMbasic, 'use_mbasic');
+      expect(SpKeys.useDesktopSite, 'use_desktop_site');
       expect(SpKeys.customUserAgent, 'custom_useragent');
       expect(SpKeys.customCss, 'custom_css');
       expect(SpKeys.customJs, 'custom_js');
@@ -71,6 +72,18 @@ void main() {
     test('is a desktop agent, which is what Messenger needs', () {
       expect(kDesktopUserAgent, contains('Macintosh'));
       expect(kDesktopUserAgent, isNot(contains('Mobile')));
+    });
+  });
+
+  group('kFirefoxUserAgent', () {
+    test('is the 119 desktop feed agent, pinned verbatim', () {
+      expect(
+        kFirefoxUserAgent,
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0',
+      );
+      expect(kFirefoxUserAgent, isNot(contains('Mobile')));
+      expect(kFirefoxUserAgent, isNot(kMobileUserAgent));
+      expect(kFirefoxUserAgent, isNot(kDesktopUserAgent));
     });
   });
 

--- a/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
+++ b/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
@@ -99,30 +99,75 @@ void main() {
       );
     });
 
-    test('basic mode overrides every role', () async {
+    test('basic mode overrides the feed, not Messenger', () async {
       // This file seeds preferences with withPrefs (which calls
       // SharedPreferences.setMockInitialValues and is reset by setUp), never
       // bare sp.setBool — mixing the two leaks state between tests.
       await withPrefs({SpKeys.useMbasic: true});
 
-      for (final role in UserAgentRole.values) {
-        expect(
-          PrefController.getUserAgent(role: role),
-          kOperaMiniUserAgent,
-          reason: 'role $role should honour basic mode',
-        );
-      }
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.feed),
+        kOperaMiniUserAgent,
+      );
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.messenger),
+        kDesktopUserAgent,
+      );
     });
 
-    test('a custom agent overrides every role', () async {
+    test('a custom agent overrides the feed, not Messenger', () async {
       await withPrefs({
         SpKeys.customUserAgent: 'my-agent',
         SpKeys.enabled(SpKeys.customUserAgent): true,
       });
 
-      for (final role in UserAgentRole.values) {
-        expect(PrefController.getUserAgent(role: role), 'my-agent');
-      }
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.feed),
+        'my-agent',
+      );
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.messenger),
+        kDesktopUserAgent,
+      );
+    });
+
+    test('the desktop-site setting serves 119\'s Firefox agent to the feed',
+        () async {
+      await withPrefs({SpKeys.useDesktopSite: true});
+
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.feed),
+        kFirefoxUserAgent,
+      );
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.messenger),
+        kDesktopUserAgent,
+      );
+    });
+
+    test('basic mode wins over the desktop-site setting', () async {
+      await withPrefs({
+        SpKeys.useDesktopSite: true,
+        SpKeys.useMbasic: true,
+      });
+
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.feed),
+        kOperaMiniUserAgent,
+      );
+    });
+
+    test('a custom agent wins over the desktop-site setting', () async {
+      await withPrefs({
+        SpKeys.useDesktopSite: true,
+        SpKeys.customUserAgent: 'my-agent',
+        SpKeys.enabled(SpKeys.customUserAgent): true,
+      });
+
+      expect(
+        PrefController.getUserAgent(role: UserAgentRole.feed),
+        'my-agent',
+      );
     });
 
     test('every role resolves to a non-empty agent', () {

--- a/SlimSocial_for_Facebook/test/lang_test.dart
+++ b/SlimSocial_for_Facebook/test/lang_test.dart
@@ -43,6 +43,8 @@ void main() {
       const required = [
         'text_zoom',
         'text_zoom_desc',
+        'use_desktop_site',
+        'use_desktop_site_desc',
         'dark_theme',
         'fixed_bar',
         'hide_stories',

--- a/SlimSocial_for_Facebook/test/utils/css_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_test.dart
@@ -272,6 +272,16 @@ article {
         isNot(contains('div.fixed-container {')),
       );
     });
+
+    test('unlocks page scroll if the install overlay is left behind', () {
+      // Hiding the bottom bar alone left a dimmer that locked scrolling on
+      // some devices (#339). Restoring overflow lets the feed move even when
+      // Facebook's modal chrome is incomplete.
+      expect(
+        CustomCss.hideAppUpsellCss.code,
+        contains('overflow: auto !important'),
+      );
+    });
   });
 
   group('media trays', () {

--- a/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
@@ -114,4 +114,36 @@ void main() {
       expect(isFacebookAuthUrl(Uri.parse('about:blank')), isFalse);
     });
   });
+
+  group('messengerNavigationFor', () {
+    MessengerNavAction nav(String url) =>
+        messengerNavigationFor(Uri.parse(url));
+
+    test('keeps messenger.com in the Messenger webview', () {
+      expect(nav('https://www.messenger.com/t/123'), MessengerNavAction.stay);
+      expect(nav('https://m.me/123'), MessengerNavAction.stay);
+    });
+
+    test('keeps facebook.com in the Messenger webview', () {
+      // Popping these to the feed crashed (SLIMSOCIAL-A) or painted black
+      // (#337). Profiles, photos, and login all stay here.
+      expect(
+        nav('https://www.facebook.com/someone'),
+        MessengerNavAction.stay,
+      );
+      expect(
+        nav('https://m.facebook.com/checkpoint/start/'),
+        MessengerNavAction.stay,
+      );
+      expect(
+        nav('https://www.facebook.com/photo.php?fbid=1'),
+        MessengerNavAction.stay,
+      );
+    });
+
+    test('sends anything else outside the app', () {
+      expect(nav('https://example.com/x'), MessengerNavAction.openExternal);
+      expect(nav('https://youtube.com/watch?v=1'), MessengerNavAction.openExternal);
+    });
+  });
 }


### PR DESCRIPTION
## Why

125 is at 50% on Play. Messenger can crash or go black; some feeds lock behind an overlay. The mobile user agent stays the default so ad/dark-theme injection still matches. People who need the 119 layout get a setting.

## What changed

- **Settings → Use desktop site.** Off = current mobile UA (default). On = 119 Firefox 147 for the feed. App restarts. Messenger always uses desktop Chrome.
- **Custom UA is feed-only** and restarts the app. It no longer overrides Messenger.
- **facebook.com links stay in Messenger** instead of popping to the feed. Fixes [SLIMSOCIAL-A](https://leorigna.sentry.io/issues/SLIMSOCIAL-A) (`StateError: No element`) and [#337](https://github.com/rignaneseleo/SlimSocial-for-Facebook/issues/337) (black profile).
- **Unlock page scroll** if Facebook's install overlay is left behind ([#339](https://github.com/rignaneseleo/SlimSocial-for-Facebook/issues/339)).

## What this does not fix

Default path is still the mobile feed. The chat icon → `messenger.com` can still show "Get the app" ([#338](https://github.com/rignaneseleo/SlimSocial-for-Facebook/issues/338)). The desktop-site toggle is the escape hatch for that.

## Verify

```
cd SlimSocial_for_Facebook && flutter test
```

462 passed (6 skipped), analyze 0 errors.

## Ship after merge

Codemagic reads `pubspec.yaml` (`26.09.01+126`), then the tag. Tag **after** this lands on master:

```
git tag 26.09.01+126 && git push origin 26.09.01+126
```

Then replace the 50% Play rollout of 125 with 126. Do not complete 125.