### PR TITLE
26.09.02+127: share menu and dialogs back, chat icon opens Messenger, three crash fixes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,11 @@
+v26.09.02+127
+- Share menu and Facebook's own dialogs show again: the install-bar rule hid every bottom sheet (#336, #339).
+- The chat icon in the top bar opens the Messenger screen instead of a "Get Messenger" page (#338).
+- Fix a crash when a Facebook link is opened while the app is already running (SLIMSOCIAL-4).
+- Stop downloading Roboto from Google on every start; the system font is Roboto already (SLIMSOCIAL-7).
+- Fix a crash when two permission switches are tapped in a row (SLIMSOCIAL-V).
+- Photo upload lets you pick several files at once.
+
 v26.09.01+126
 - Add a "Use desktop site" setting: the 119 Firefox user agent for the feed. Default stays mobile.
 - Messenger always uses desktop Chrome. A custom user agent no longer overrides it.

--- a/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
+++ b/SlimSocial_for_Facebook/android/app/src/main/AndroidManifest.xml
@@ -103,6 +103,14 @@
             <meta-data
                 android:name="io.flutter.embedding.android.NormalTheme"
                 android:resource="@style/NormalTheme" />
+            <!-- app_links reads the VIEW intents above itself. Left at the
+                 engine's default (true), Flutter also pushes every link opened
+                 while the app is running as a named route, and a MaterialApp
+                 with no route by that name crashes on a null onUnknownRoute
+                 (SLIMSOCIAL-4). -->
+            <meta-data
+                android:name="flutter_deeplinking_enabled"
+                android:value="false" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/SlimSocial_for_Facebook/lib/main.dart
+++ b/SlimSocial_for_Facebook/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:app_links/app_links.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:native_flutter_proxy/native_flutter_proxy.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -163,19 +162,17 @@ class _SlimSocialAppState extends State<SlimSocialApp> {
 
     return MaterialApp(
       title: 'SlimSocial for Facebook',
+      //no textTheme: the platform default is Roboto, which is the font this
+      //used to download from fonts.gstatic.com on every cold start — a
+      //request that bought nothing and, when it failed, was reported as a
+      //fatal error (SLIMSOCIAL-7)
       theme: ThemeData(
         useMaterial3: false,
         colorScheme: lightColorScheme,
-        textTheme: GoogleFonts.robotoTextTheme(
-          ThemeData(brightness: Brightness.light).textTheme,
-        ),
       ),
       darkTheme: ThemeData(
         useMaterial3: false,
         colorScheme: darkColorScheme,
-        textTheme: GoogleFonts.robotoTextTheme(
-          ThemeData(brightness: Brightness.dark).textTheme,
-        ),
       ),
       themeMode: _themeMode,
       home: const HomePage(),

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -18,6 +18,7 @@ import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/ad_filter.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/dark_theme.dart';
+import 'package:slimsocial_for_facebook/utils/fb_navigation.dart';
 import 'package:slimsocial_for_facebook/utils/file_chooser.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/load_retry_policy.dart';
@@ -125,6 +126,16 @@ class _HomePageState extends ConsumerState<HomePage> {
 
             //inject the css as soon as the DOM is loaded
             await injectCss();
+            if (!mounted) return;
+
+            //the install bar is decided by structure, in script, because the
+            //stylesheet rule that did this took the share menu with it (#336)
+            await runIsolatedJs(
+              'app upsell',
+              () => _controller.runJavaScript(
+                CustomJs.whenDomReady(CustomJs.hideAppUpsellFunc()),
+              ),
+            );
             if (!mounted) return;
 
             //before the dark theme, because unlocking the viewport reflows the
@@ -328,6 +339,21 @@ class _HomePageState extends ConsumerState<HomePage> {
         await _controller.loadRequest(target);
         return NavigationDecision.prevent;
       }
+    }
+
+    //the chat icon in the mobile top bar links to facebook.com/messages, and
+    //with the mobile user agent that page is only a "Get Messenger"
+    //interstitial (#338). The Messenger screen shows the same conversations.
+    final messengerTarget = facebookMessagesToMessenger(uri);
+    if (messengerTarget != null) {
+      if (!mounted) return NavigationDecision.prevent;
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) =>
+              MessengerPage(initialUrl: messengerTarget.toString()),
+        ),
+      );
+      return NavigationDecision.prevent;
     }
 
     for (final other in kPermittedHostnamesFb) {

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -15,6 +15,7 @@ import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
 import 'package:slimsocial_for_facebook/main.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
+import 'package:slimsocial_for_facebook/utils/permission_gate.dart';
 import 'package:slimsocial_for_facebook/utils/telemetry.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -31,6 +32,11 @@ class SettingsPage extends ConsumerStatefulWidget {
 class _SettingsPageState extends ConsumerState<SettingsPage> {
   StreamSubscription<List<PurchaseDetails>>? _paymentSubscription;
   bool isDev = false;
+
+  //one OS permission dialog at a time: a second request while the first is
+  //still up is refused by permission_handler with an exception that used to
+  //take this screen down (SLIMSOCIAL-V)
+  final _permissionGate = PermissionRequestGate();
 
   //photosPermission is deliberately absent: the file chooser no longer gates on
   //it. Permission.photos maps to READ_MEDIA_IMAGES, which only exists from API
@@ -501,7 +507,9 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         case PermissionStatus.restricted:
         case PermissionStatus.limited:
         case PermissionStatus.denied:
-          await permission.request();
+          //null when another request's dialog is still up; the status read
+          //below is then simply what the OS already had
+          await _permissionGate.run(permission.request);
           break;
         case PermissionStatus.provisional:
         case PermissionStatus.granted:

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -201,30 +201,29 @@ class CustomCss {
     code: '#header-notices { display: none; }',
   );
 
-  /// Hides the "Open app" bar Facebook pins to the bottom of the feed.
+  /// The stylesheet half of hiding the "Open app" bar Facebook pins to the
+  /// bottom of the feed. The bar itself is hidden by
+  /// `CustomJs.hideAppUpsellFunc`; this only keeps the page scrollable.
   ///
-  /// It is an install upsell for the native app, which is the one thing a user
-  /// of this app has already decided against, and it covers the bottom of every
-  /// page until dismissed.
+  /// The bar is an install upsell for the native app, which is the one thing a
+  /// user of this app has already decided against, and it covers the bottom
+  /// of every page until dismissed.
   ///
-  /// Matched by class rather than by its label, which is localised. Verified
-  /// against the live layout: exactly one `.fixed-container.bottom` exists and
-  /// it is the upsell — the only other fixed container is an empty
-  /// `above-bottom` spacer, and the page carries no `role="navigation"` that
-  /// this could catch by accident.
+  /// It used to be hidden from here, by class: every `.fixed-container.bottom`
+  /// without a form control inside it. The guard was written for the comment
+  /// composer, which docks in the same container, and it was not enough —
+  /// the share menu (#336) and Facebook's own dialogs (#339) dock there too,
+  /// hold no form control, and vanished with the bar, leaving their dimmer
+  /// over a page with nothing left to tap. Telling the bar apart from a sheet
+  /// takes counting what is in it, which a stylesheet cannot do, so the
+  /// decision moved to JavaScript.
+  ///
+  /// What stays here is the scroll unlock. A dialog Facebook opens locks
+  /// `overflow` on the body; if its chrome is ever left incomplete the feed
+  /// stops moving, and this puts it back.
   ///
   /// Deliberately not in [cssList]: like the other chrome removals above, it is
   /// structural rather than a preference.
-  /// The `:not(:has(...))` guards are the important part.
-  ///
-  /// Facebook docks the comment composer to the bottom of a post using this
-  /// same container, so hiding every `.fixed-container.bottom` also removed the
-  /// box you type a comment into. Checking the feed alone was not enough to
-  /// catch that — the composer only exists once a post is open.
-  ///
-  /// Excluding any container that holds a form control means a composer can
-  /// never be hidden, whatever Facebook renames the classes to, and without
-  /// depending on a label that changes with the interface language.
   ///
   /// The other upsell — the blue "Open app" pill in the header of the Reels and
   /// video pages — is deliberately not covered. The only thing that told it
@@ -237,10 +236,7 @@ class CustomCss {
     key: 'hide_app_upsell',
     description: 'Hide the install-the-app bar',
     defaultEnabled: true,
-    code: 'div.fixed-container.bottom'
-        ':not(:has(textarea)):not(:has(input)):not(:has([contenteditable]))'
-        ' { display: none !important; }'
-        ' html, body { overflow: auto !important; }',
+    code: 'html, body { overflow: auto !important; }',
   );
 
   /// Hands the post text back to the reader: selectable, and so copyable.

--- a/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
+++ b/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
@@ -114,3 +114,41 @@ MessengerNavAction messengerNavigationFor(Uri uri) {
 
   return MessengerNavAction.openExternal;
 }
+
+/// Where the Messenger screen should open for a facebook.com messages address,
+/// or null when [uri] is not one.
+///
+/// The chat icon in Facebook's mobile top bar links to `/messages/` on
+/// facebook.com, and with a mobile user agent that page is nothing but a "Get
+/// Messenger" install interstitial — Firefox for Android shows the same one
+/// (#338). The conversations themselves are served to a desktop agent on
+/// messenger.com, which is exactly what the Messenger screen loads, so these
+/// addresses are redirected there instead of being rendered in the feed.
+///
+/// `/messages/t/<id>` keeps its thread: messenger.com uses the same ids. The
+/// older `/messages/read/?tid=cid.c.A:B` form does not translate, so it and
+/// every other variant open the inbox.
+///
+/// Basic mode is left alone: `mbasic.facebook.com/messages/` still renders a
+/// usable inbox on its own, and the whole point of that mode is not loading
+/// the heavier surfaces.
+Uri? facebookMessagesToMessenger(Uri uri) {
+  final host = uri.host.toLowerCase();
+  if (host == 'mbasic.facebook.com') return null;
+
+  final isFacebook = kPermittedHostnamesFb
+      .any((other) => host == other || host.endsWith('.$other'));
+  if (!isFacebook) return null;
+
+  final segments =
+      uri.pathSegments.where((segment) => segment.isNotEmpty).toList();
+  if (segments.isEmpty || segments.first.toLowerCase() != 'messages') {
+    return null;
+  }
+
+  if (segments.length >= 3 && segments[1].toLowerCase() == 't') {
+    return Uri.parse('$kMessengerUrl/t/${segments[2]}');
+  }
+
+  return Uri.parse('$kMessengerUrl/');
+}

--- a/SlimSocial_for_Facebook/lib/utils/file_chooser.dart
+++ b/SlimSocial_for_Facebook/lib/utils/file_chooser.dart
@@ -4,6 +4,19 @@ import 'package:file_picker/file_picker.dart';
 import 'package:slimsocial_for_facebook/utils/telemetry.dart';
 import 'package:webview_flutter_android/webview_flutter_android.dart';
 
+/// How the picker is opened for a page request in [mode].
+///
+/// Facebook's composer asks with `openMultiple` and an empty accept list —
+/// measured in production, once per process, over four days (SLIMSOCIAL-9: 72
+/// reports, every one identical). The picker used to ignore the mode and open
+/// single-file regardless, so a photo post that is usually several photos
+/// took one pick per photo.
+///
+/// The accept list is not used: it was always empty, and `FileType.any` is
+/// what an empty list means.
+({bool allowMultiple}) pickerOptionsFor(FileSelectorMode mode) =>
+    (allowMultiple: mode == FileSelectorMode.openMultiple);
+
 /// Handles the WebView's request for files to hand back to a page `<input
 /// type="file">` — the Facebook composer's photo picker, in practice.
 ///
@@ -15,18 +28,12 @@ import 'package:webview_flutter_android/webview_flutter_android.dart';
 /// document picker returns a URI the app is already granted access to, so it
 /// needs no runtime permission on any API level.
 Future<List<String>> handleFileChooser(FileSelectorParams params) async {
-  //One probe, once per process, to learn what Facebook actually asks for.
-  //`acceptTypes` is markup Facebook authored, not anything the user typed.
-  Telemetry.captureIssue(
-    'file_chooser.params',
-    data: {
-      'accept': params.acceptTypes.join('|'),
-      'mode': params.mode.name,
-    },
-  );
+  final options = pickerOptionsFor(params.mode);
 
   try {
-    final result = await FilePicker.platform.pickFiles();
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: options.allowMultiple,
+    );
     if (result == null) return [];
 
     //Walk the list rather than reading `.single`, which throws a StateError on

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -155,6 +155,89 @@ class CustomJs {
 """;
   }
 
+  /// Builds JavaScript that hides the "Open app" bar Facebook pins to the
+  /// bottom of the feed — and nothing else that docks there.
+  ///
+  /// This used to be a stylesheet rule: `div.fixed-container.bottom` without a
+  /// form control inside it was `display: none`. The guard was written for the
+  /// comment composer, which docks in the same container, and it was not
+  /// enough. Facebook renders its share menu (#336), its reaction picker and
+  /// its "turn on notifications" dialog (#339) in that container too. None of
+  /// them holds a form control, so all of them vanished — leaving the dimmer
+  /// they had opened over the page and nothing under it to tap. On the share
+  /// menu that read as a dead share button; on the dialog it read as a feed
+  /// that had gone dark and stopped scrolling.
+  ///
+  /// The stylesheet cannot ask the question that separates the upsell from a
+  /// sheet, which is *how many things there are to tap*. The upsell is one
+  /// label and one button (the structural test Nora uses, see
+  /// docs/research/2026-08-28-nora-comparative-study.md §2). A sheet is a
+  /// column of them. So a container is hidden only when it holds exactly one
+  /// tappable element, no form control, and no feed post — and the verdict
+  /// is re-checked on every pass, so a container that fills in later is put
+  /// back.
+  ///
+  /// Facebook is a single-page app and the bar is inserted after load and on
+  /// every in-page navigation, hence the observer, kept on `window` like the
+  /// others so re-injection does not stack another. Everything is swallowed
+  /// by a try/catch for the same reason as [unlockZoomFunc].
+  static String hideAppUpsellFunc() {
+    return """
+(function () {
+  try {
+    var MARK = 'data-slim-upsell';
+    // A composer, a search box, or a feed post inside the container means it
+    // is content, whatever else it looks like.
+    var CONTENT = 'textarea, input, [contenteditable], $kPostSelector';
+    var TAPPABLE = 'button, [role="button"], a[href]';
+
+    function isUpsell(node) {
+      if (node.querySelector(CONTENT)) return false;
+      // Exactly one: zero is a container still being filled in, and two or
+      // more is a sheet of options.
+      if (node.querySelectorAll(TAPPABLE).length !== 1) return false;
+      return true;
+    }
+
+    function pass() {
+      var nodes = document.querySelectorAll('div.fixed-container.bottom');
+      for (var i = 0; i < nodes.length; i++) {
+        var node = nodes[i];
+        var hidden = node.getAttribute(MARK) === '1';
+        if (isUpsell(node)) {
+          if (hidden) continue;
+          node.setAttribute(MARK, '1');
+          node.style.display = 'none';
+        } else if (hidden) {
+          // Re-used for something with more in it: give it back.
+          node.removeAttribute(MARK);
+          node.style.display = '';
+        }
+      }
+    }
+
+    pass();
+
+    if (!window.slimUpsellObserver) {
+      var pending = null;
+      window.slimUpsellObserver = new MutationObserver(function () {
+        if (pending) return;
+        // The feed appends dozens of nodes in a frame; one pass per burst.
+        pending = setTimeout(function () {
+          pending = null;
+          pass();
+        }, 250);
+      });
+      window.slimUpsellObserver.observe(
+        document.body || document.documentElement,
+        { childList: true, subtree: true }
+      );
+    }
+  } catch (e) {}
+})();
+""";
+  }
+
   static String exampleJs = """
 javascript:function foo() {
 	     document.body.innerHTML = '';

--- a/SlimSocial_for_Facebook/lib/utils/permission_gate.dart
+++ b/SlimSocial_for_Facebook/lib/utils/permission_gate.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+/// Lets one runtime-permission request run at a time.
+///
+/// permission_handler refuses a request while another is still showing its
+/// dialog, and it refuses with a `PlatformException` nothing used to catch
+/// (SLIMSOCIAL-V): a switch tapped twice, or the location and camera switches
+/// tapped one after the other, took the settings screen down. The refusal is
+/// not a failure of the second request so much as a statement that the first
+/// is still on screen, so it is answered with `null` — the caller reads the
+/// status back afterwards and stores that.
+class PermissionRequestGate {
+  bool _busy = false;
+
+  /// The error code permission_handler uses for its re-entrancy refusal.
+  static const String alreadyRunningCode =
+      'PermissionHandler.PermissionManager';
+
+  /// Runs [request], or returns null when one is already in flight — whether
+  /// this gate knows it or the platform says so itself.
+  ///
+  /// Any other failure is the caller's to see.
+  Future<T?> run<T>(Future<T> Function() request) async {
+    if (_busy) return null;
+    _busy = true;
+    try {
+      return await request();
+    } on PlatformException catch (e) {
+      if (e.code == alreadyRunningCode) return null;
+      rethrow;
+    } finally {
+      _busy = false;
+    }
+  }
+}

--- a/SlimSocial_for_Facebook/pubspec.lock
+++ b/SlimSocial_for_Facebook/pubspec.lock
@@ -374,14 +374,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
-  google_fonts:
-    dependency: "direct main"
-    description:
-      name: google_fonts
-      sha256: ba03d03bcaa2f6cb7bd920e3b5027181db75ab524f8891c8bc3aa603885b8055
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.3"
   gtk:
     dependency: transitive
     description:

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # the git tag, so this has to be bumped in its own commit *before* the matching
 # tag is pushed - a tag pushed first builds the previous version. Every release
 # tag from 117 onwards matches the value that was in this field at that commit.
-version: 26.09.01+126
+version: 26.09.02+127
 
 # Leonardo Rignanese <dev.rignaneseleo@gmail.com>
 #
@@ -48,7 +48,6 @@ dependencies:
   easy_localization: ^3.0.8
   package_info_plus: 8.3.0
   restart_app: 1.3.2
-  google_fonts: ^6.3.0
   in_app_review: 2.0.10
   share_plus: 10.1.4
   file_picker: 10.0.0

--- a/SlimSocial_for_Facebook/test/android/manifest_test.dart
+++ b/SlimSocial_for_Facebook/test/android/manifest_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Source-level guards over the Android manifest, in the style of
+/// lang_test.dart: the behaviour needs a device to exercise, but the mistake is
+/// visible in the file.
+void main() {
+  late String manifest;
+
+  setUpAll(() {
+    manifest =
+        File('android/app/src/main/AndroidManifest.xml').readAsStringSync();
+  });
+
+  test('the engine does not push opened links as named routes', () {
+    // Flutter's Android embedding handles VIEW intents itself unless told
+    // otherwise (FlutterActivityLaunchConfigs.deepLinkEnabled defaults to
+    // true). With the app already running, that turns every facebook.com link
+    // the user opens into `Navigator.pushNamed('https://...')`, and a
+    // MaterialApp with no route by that name dereferences a null
+    // `onUnknownRoute` and takes the app down (SLIMSOCIAL-4, 26 crashes in 5
+    // days). app_links reads the same intent on its own, so the engine's copy
+    // is only ever a liability here.
+    final metaData = RegExp(
+      r'<meta-data\s+android:name="flutter_deeplinking_enabled"\s+android:value="false"\s*/>',
+    );
+
+    expect(
+      metaData.hasMatch(manifest),
+      isTrue,
+      reason: 'flutter_deeplinking_enabled must be declared false',
+    );
+  });
+
+  test('the deep-link switch sits inside the launcher activity', () {
+    // The engine reads it off the *activity's* metadata, not the application's.
+    final activityStart = manifest.indexOf('<activity');
+    final activityEnd = manifest.indexOf('</activity>');
+    final metaAt = manifest.indexOf('flutter_deeplinking_enabled');
+
+    expect(activityStart, greaterThanOrEqualTo(0));
+    expect(metaAt, greaterThan(activityStart));
+    expect(metaAt, lessThan(activityEnd));
+  });
+}

--- a/SlimSocial_for_Facebook/test/no_runtime_font_fetch_test.dart
+++ b/SlimSocial_for_Facebook/test/no_runtime_font_fetch_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The app used to build its text theme with google_fonts, which downloads
+/// Roboto from fonts.gstatic.com on every cold start. Roboto is Android's own
+/// system font, so the request bought nothing, and when it failed — captive
+/// portals, flaky cellular, a TLS handshake cut short — it surfaced as a fatal
+/// unhandled exception (SLIMSOCIAL-7, 35 events in three days). For an app
+/// whose pitch is being a thin private wrapper, a call home to Google on
+/// launch is also the wrong default.
+void main() {
+  test('nothing imports google_fonts', () {
+    final offenders = Directory('lib')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.dart'))
+        .where((f) => f.readAsStringSync().contains('google_fonts'))
+        .map((f) => f.path)
+        .toList();
+
+    expect(offenders, isEmpty);
+  });
+
+  test('google_fonts is not a dependency', () {
+    final pubspec = File('pubspec.yaml').readAsStringSync();
+
+    expect(pubspec, isNot(contains('google_fonts')));
+  });
+}

--- a/SlimSocial_for_Facebook/test/utils/css_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_test.dart
@@ -221,14 +221,20 @@ article {
   });
 
   group('app install upsell', () {
-    test('targets the pinned bottom bar by class, not by its label', () {
-      // The label is localised, so matching text would work in one language
-      // and silently stop working in every other.
+    test('no longer hides bottom containers from the stylesheet', () {
+      // The rule `div.fixed-container.bottom:not(:has(<form control>)) {
+      // display: none }` hid every bottom sheet without a form control: the
+      // share menu (#336) and a dialog whose dimmer stayed behind (#339).
+      // Whether a container is the upsell is decided in JavaScript now, from
+      // its structure — see CustomJs.hideAppUpsellFunc.
       expect(
         CustomCss.hideAppUpsellCss.code,
-        contains('div.fixed-container.bottom'),
+        isNot(contains('fixed-container.bottom')),
       );
-      expect(CustomCss.hideAppUpsellCss.code, isNot(contains('Open app')));
+      expect(
+        CustomCss.hideAppUpsellCss.code,
+        isNot(contains('display: none')),
+      );
     });
 
     test('is not offered as a user-facing toggle', () {
@@ -249,27 +255,6 @@ article {
         RegExp(r'bg-s\d').hasMatch(CustomCss.hideAppUpsellCss.code),
         isFalse,
         reason: 'the bg-sN number means something different on every render',
-      );
-    });
-
-    test('can never hide a container holding a form control', () {
-      // Facebook docks the comment composer in the same bottom container as
-      // the upsell, so an unguarded rule removed the box you type a comment
-      // into. Checking the feed did not catch it: the composer only exists
-      // once a post is open.
-      final code = CustomCss.hideAppUpsellCss.code;
-
-      expect(code, contains(':not(:has(textarea))'));
-      expect(code, contains(':not(:has(input))'));
-      expect(code, contains(':not(:has([contenteditable]))'));
-    });
-
-    test('does not hide every fixed container', () {
-      // A bare `.fixed-container` rule would also catch the top bar and the
-      // empty above-bottom spacer that sit alongside the upsell.
-      expect(
-        CustomCss.hideAppUpsellCss.code,
-        isNot(contains('div.fixed-container {')),
       );
     });
 

--- a/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
@@ -146,4 +146,67 @@ void main() {
       expect(nav('https://youtube.com/watch?v=1'), MessengerNavAction.openExternal);
     });
   });
+
+  group('facebookMessagesToMessenger', () {
+    Uri? to(String url) => facebookMessagesToMessenger(Uri.parse(url));
+
+    // The chat icon in Facebook's mobile top bar links to /messages/ on
+    // facebook.com, and with a mobile user agent that page is nothing but a
+    // "Get Messenger" install interstitial — the same one Firefox for Android
+    // shows (#338). The app already has a Messenger screen that loads
+    // messenger.com with a desktop agent; these addresses belong there.
+    test('the inbox goes to the Messenger screen', () {
+      expect(
+        to('https://m.facebook.com/messages/'),
+        Uri.parse('https://www.messenger.com/'),
+      );
+      expect(
+        to('https://touch.facebook.com/messages'),
+        Uri.parse('https://www.messenger.com/'),
+      );
+    });
+
+    test('the jewel entry point and its query are dropped', () {
+      expect(
+        to('https://m.facebook.com/messages/?entrypoint=jewel&folder=inbox'),
+        Uri.parse('https://www.messenger.com/'),
+      );
+    });
+
+    test('a thread keeps its id', () {
+      expect(
+        to('https://m.facebook.com/messages/t/1234567890'),
+        Uri.parse('https://www.messenger.com/t/1234567890'),
+      );
+      expect(
+        to('https://m.facebook.com/messages/t/1234567890/'),
+        Uri.parse('https://www.messenger.com/t/1234567890'),
+      );
+    });
+
+    test('the legacy read view opens the inbox, not a guessed thread', () {
+      // `tid=cid.c.A:B` is not a messenger.com thread id.
+      expect(
+        to('https://m.facebook.com/messages/read/?tid=cid.c.1:2'),
+        Uri.parse('https://www.messenger.com/'),
+      );
+    });
+
+    test('only the exact /messages segment matches', () {
+      expect(to('https://m.facebook.com/messagesabc/'), isNull);
+      expect(to('https://m.facebook.com/home.php'), isNull);
+      expect(to('https://m.facebook.com/'), isNull);
+      expect(to('https://m.facebook.com/groups/messages/'), isNull);
+    });
+
+    test('other hosts are not touched', () {
+      expect(to('https://www.messenger.com/t/1'), isNull);
+      expect(to('https://example.com/messages/'), isNull);
+    });
+
+    test('mbasic is left alone: its messages page renders without Messenger',
+        () {
+      expect(to('https://mbasic.facebook.com/messages/'), isNull);
+    });
+  });
 }

--- a/SlimSocial_for_Facebook/test/utils/file_chooser_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/file_chooser_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/file_chooser.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
 
 String _read(String path) => File(path).readAsStringSync();
 
@@ -78,12 +80,29 @@ void main() {
       expect(source.substring(catchAt), contains('return [];'));
     });
 
-    test('probes what Facebook actually asks for', () {
-      //acceptTypes is markup Facebook authored, not anything the user typed.
-      //Nothing in this repo records what arrives here, and the normaliser that
-      //would use it cannot be written until that is known.
-      expect(source, contains('file_chooser.params'));
-      expect(source, contains('params.acceptTypes'));
+    test('no longer probes what Facebook asks for', () {
+      //The probe ran once per process for four days (SLIMSOCIAL-9, 72 events)
+      //and every report said the same thing: an empty accept list and mode
+      //openMultiple. Answered, so it goes — the signal would otherwise keep an
+      //issue open forever.
+      expect(source, isNot(contains('file_chooser.params')));
+    });
+  });
+
+  group('pickerOptionsFor', () {
+    test('lets the reader pick several files when the page allows it', () {
+      //Facebook's composer asks with mode openMultiple — a photo post is
+      //usually more than one photo — and the picker used to be opened in
+      //single-file mode regardless.
+      expect(
+        pickerOptionsFor(FileSelectorMode.openMultiple).allowMultiple,
+        isTrue,
+      );
+    });
+
+    test('keeps a single-file request single', () {
+      expect(pickerOptionsFor(FileSelectorMode.open).allowMultiple, isFalse);
+      expect(pickerOptionsFor(FileSelectorMode.save).allowMultiple, isFalse);
     });
   });
 }

--- a/SlimSocial_for_Facebook/test/utils/js_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/js_test.dart
@@ -273,4 +273,77 @@ void main() {
       expect(parsed.data, isEmpty);
     });
   });
+
+  group('CustomJs.hideAppUpsellFunc', () {
+    late String js;
+
+    setUpAll(() => js = CustomJs.hideAppUpsellFunc());
+
+    test('looks only at bottom-docked fixed containers', () {
+      expect(js, contains('div.fixed-container.bottom'));
+    });
+
+    test('never touches a container holding a form control', () {
+      // The comment composer docks in the same container as the upsell.
+      expect(js, contains('textarea'));
+      expect(js, contains('input'));
+      expect(js, contains('[contenteditable]'));
+    });
+
+    test('never touches a container holding feed content', () {
+      expect(js, contains(kPostSelector));
+    });
+
+    test('hides only a bar with exactly one thing to tap', () {
+      // The upsell is one label and one button. A share sheet, a reaction
+      // picker or a "turn on notifications" dialog is a column of options,
+      // and the stylesheet rule that hid every bottom container took those
+      // out too — leaving the reader with a dimmer and nothing to tap (#336,
+      // #339). Zero is not hidden either: a container still being filled in
+      // has nothing tappable yet, and is not yet anything.
+      expect(js, contains('[role="button"]'));
+      expect(js, contains('a[href]'));
+      expect(js, contains('.length !== 1'));
+    });
+
+    test('gives a container back once it holds more than the bar', () {
+      // A verdict is re-checked on every pass: the same container filled in
+      // with a sheet must not stay hidden from an earlier pass.
+      expect(js, contains('node.removeAttribute(MARK)'));
+      expect(js, contains("node.style.display = ''"));
+    });
+
+    test('marks what it hid so a pass is idempotent', () {
+      expect(js, contains('data-slim-upsell'));
+      expect(js, contains("display = 'none'"));
+    });
+
+    test('watches for the bar arriving after the first pass', () {
+      // Facebook is a single-page app: the bar is inserted after load and on
+      // every in-page navigation. One observer, kept on window like the ad
+      // observer, so re-injection does not stack another.
+      expect(js, contains('if (!window.slimUpsellObserver) {'));
+      expect(js, contains('window.slimUpsellObserver = new MutationObserver'));
+      expect('new MutationObserver'.allMatches(js), hasLength(1));
+    });
+
+    test('coalesces bursts of mutations into a single pass', () {
+      expect(js, contains('setTimeout'));
+    });
+
+    test('runs as a self-invoking function that swallows its own failure', () {
+      expect(js.trim(), startsWith('(function () {'));
+      expect(js.trim(), endsWith('})();'));
+      expect(js, contains('try {'));
+      expect(js, contains('} catch (e) {}'));
+    });
+
+    test('is not the stylesheet rule that hid every bottom sheet', () {
+      // The old rule was `div.fixed-container.bottom:not(:has(...)) {
+      // display: none !important }`: any sheet without a form control
+      // vanished.
+      expect(js, isNot(contains('display: none !important')));
+      expect(js, isNot(contains(':has(')));
+    });
+  });
 }

--- a/SlimSocial_for_Facebook/test/utils/permission_gate_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/permission_gate_test.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/permission_gate.dart';
+
+void main() {
+  group('PermissionRequestGate', () {
+    test('runs the request and hands back its result', () async {
+      final gate = PermissionRequestGate();
+
+      final result = await gate.run(() async => 'granted');
+
+      expect(result, 'granted');
+    });
+
+    test('refuses a second request while the first is still in flight',
+        () async {
+      // A switch tapped twice, or two switches tapped in a row, used to send
+      // two requests to permission_handler, which answers the second with a
+      // PlatformException that nothing caught (SLIMSOCIAL-V).
+      final gate = PermissionRequestGate();
+      final first = Completer<String>();
+
+      final firstRun = gate.run(() => first.future);
+      final second = await gate.run(() async => 'second');
+
+      expect(second, isNull);
+
+      first.complete('first');
+      expect(await firstRun, 'first');
+    });
+
+    test('opens again once the request has finished', () async {
+      final gate = PermissionRequestGate();
+
+      await gate.run(() async => 'one');
+      final again = await gate.run(() async => 'two');
+
+      expect(again, 'two');
+    });
+
+    test('opens again when the request throws', () async {
+      final gate = PermissionRequestGate();
+
+      await expectLater(
+        gate.run(() async => throw StateError('boom')),
+        throwsStateError,
+      );
+
+      expect(await gate.run(() async => 'after'), 'after');
+    });
+
+    test('swallows the "already running" refusal from permission_handler',
+        () async {
+      // The plugin's own re-entrancy error. Reaching here means the OS dialog
+      // for the other request is still up, so there is nothing to show and
+      // nothing to store: the caller reads the status back afterwards.
+      final gate = PermissionRequestGate();
+
+      final result = await gate.run<String>(
+        () async => throw PlatformException(
+          code: 'PermissionHandler.PermissionManager',
+          message: 'A request for permissions is already running',
+        ),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('lets any other platform failure through', () async {
+      final gate = PermissionRequestGate();
+
+      await expectLater(
+        gate.run<String>(
+          () async => throw PlatformException(code: 'something_else'),
+        ),
+        throwsA(isA<PlatformException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What users reported after 126

- #336 share button dead, #339 feed dark and stuck: the install-bar rule hid every bottom sheet without a text box. Share menu, reaction picker and Facebook's dialogs all docked in that container and vanished, leaving only their dimmer.
- #338 chat icon shows "Get Messenger": facebook.com/messages under the mobile user agent is only the interstitial.
- Play review 2026-09-01 "Messenger is broken" (26.08.29): same family.

## Sentry

- SLIMSOCIAL-4, 26 fatal events in 5 days, still on 126: Flutter's engine pushes every opened link as a named route while the app runs (deep linking defaults to true), and MaterialApp crashes on a null onUnknownRoute. app_links handles the intent; the engine's copy is now off.
- SLIMSOCIAL-7, 35 events: google_fonts fetched Roboto from Google on every cold start. Roboto is the system font. Dependency removed.
- SLIMSOCIAL-V: two permission switches in a row; permission_handler's refusal was uncaught. Gated.
- SLIMSOCIAL-9: the file-chooser probe answered itself (accept empty, openMultiple, 72/72). Probe removed, multi-select honoured.

## Changes

1. Install bar hidden by a script that counts what is in the container (exactly one tappable, no form control, no post), re-checked on every pass. Stylesheet keeps only the scroll unlock from 126.
2. facebook.com/messages* opens the Messenger screen; /messages/t/<id> keeps the thread. mbasic untouched.
3. flutter_deeplinking_enabled=false in the manifest, as in app_links' own example.
4. google_fonts gone; platform text theme.
5. PermissionRequestGate: one OS dialog at a time.
6. Picker honours openMultiple.
7. Version 26.09.02+127 (bumped in the third commit) and Changelog.

## Verification

- flutter test: 489 pass, 6 skipped (was 462 on master; +27 new).
- flutter analyze: 0 warnings, 0 errors; remaining infos pre-existing.
- Not verified on a device: the structural test for the install bar (one tappable) follows the Nora study in docs/research; a bar with a second tappable dismiss control would stay visible, which is the safe failure.

## Not in this PR

- SLIMSOCIAL-5 (Play Billing ProxyBillingActivity NPE, 2 users, one is an x86_64 emulator): library-level, no app-side fix.
- SLIMSOCIAL-6/Y native SIGABRT, SLIMSOCIAL-W/C ANR: 1 user each, no symbols.
- #320 arm64-only APK: Codemagic dashboard change, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)