### PR TITLE
26.09.03+128: Facebook's chat icon opens the built-in Messenger inbox, on the Facebook session

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,9 @@
+v26.09.03+128
+- Facebook's chat icon opens the built-in Messenger screen. It used to show a "Get the Messenger app" page (#338).
+- Messenger uses your Facebook login. No second sign-in on messenger.com (#326, #300, #257).
+- messenger.com and m.me links open in the Messenger screen with your Facebook session.
+- The Messenger screen sends a current Firefox agent; Facebook no longer shows "Your browser is no longer supported".
+
 v26.09.02+127
 - Share menu and Facebook's own dialogs show again: the install-bar rule hid every bottom sheet (#336, #339).
 - The chat icon in the top bar opens the Messenger screen instead of a "Get Messenger" page (#338).

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -1,7 +1,19 @@
 const String kFacebookHomeUrl = 'https://facebook.com/home.php';
 const String kTouchFacebookHomeUrl = 'https://touch.facebook.com/home.php';
 const String kFacebookHomeBasicUrl = 'https://mbasic.facebook.com/home.php';
+
+/// Messenger's own site. Nothing loads it any more — see [kMessengerInboxUrl]
+/// — and it is kept only as the name of a host the app knows about.
 const String kMessengerUrl = 'https://www.messenger.com';
+
+/// Facebook's own Messenger inbox. What the Messenger screen loads.
+///
+/// messenger.com has its own cookies, so it asks for a second sign-in even
+/// while facebook.com is logged in — the app's most reported complaint (#326,
+/// #300, #257). This address is the same inbox on the session the feed is
+/// already using: measured on a device with the desktop agent it renders the
+/// chats list, the compose button and the threads, with no login form.
+const String kMessengerInboxUrl = 'https://www.facebook.com/messages/';
 
 const List<String> kPermittedHostnamesFb = [
   "facebook.com",
@@ -38,18 +50,18 @@ const String suffixDefault = "?sk=h_nor";
 const String kMobileUserAgent =
     "Mozilla/5.0 (Android 10; Mobile; rv:70.0) Gecko/70.0 Firefox/70.0";
 
-/// Desktop Chrome on macOS. Messenger only ships its full markup to a desktop
-/// agent; on a mobile one it pushes the native-app interstitial instead.
-const String kDesktopUserAgent =
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/68.0.3440.84 Safari/537.36";
-
-/// Desktop Firefox on Windows. The feed agent in 26.08.05+119.
+/// Desktop Firefox on Windows. The Messenger screen's agent, and the feed's
+/// "Desktop site" option.
 ///
 /// Facebook serves the desktop site for this string: in-page chat and the
-/// share menu work, and the page is heavier. It is the Settings "Desktop site"
-/// option, not the default — the default is [kMobileUserAgent] so injected
-/// selectors keep matching the touch layout.
+/// share menu work, and the page is heavier. On the feed it is the Settings
+/// "Desktop site" option, not the default — the default is [kMobileUserAgent]
+/// so injected selectors keep matching the touch layout.
+///
+/// The Messenger screen has no choice about it. [kMessengerInboxUrl] only
+/// ships its full markup to a desktop agent, and the agent has to be a current
+/// one: on the 2018 desktop Chrome string this replaced, Facebook adds a "Your
+/// browser is no longer supported" banner to the inbox.
 const String kFirefoxUserAgent =
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:147.0) Gecko/20100101 Firefox/147.0";
 

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -20,14 +20,14 @@ class PrefController {
 
   /// Returns the user agent to use for [role].
   ///
-  /// Messenger is pinned to [kDesktopUserAgent]. A custom string or the
+  /// Messenger is pinned to [kFirefoxUserAgent]. A custom string or the
   /// desktop-site / basic-mode switches would otherwise send it a mobile
   /// agent, and Facebook answers that with the native-app interstitial.
   ///
   /// For the feed: a custom agent wins, then basic mode, then the desktop-site
   /// setting, then the mobile default.
   static String getUserAgent({UserAgentRole role = UserAgentRole.feed}) {
-    if (role == UserAgentRole.messenger) return kDesktopUserAgent;
+    if (role == UserAgentRole.messenger) return kFirefoxUserAgent;
 
     final customUserAgent = _getOverride(SpKeys.customUserAgent);
     if (customUserAgent != null) {

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -443,9 +443,16 @@ class _HomePageState extends ConsumerState<HomePage> {
     final after = await _historyLength();
     if (!mounted) return;
 
-    //nothing was pushed, or the count could not be read: leave the page alone.
-    //A back step taken on a guess would throw away the post the reader was on.
-    if (before == null || after == null || after <= before) return;
+    //the count could not be read, or nothing moved: leave the page alone. A
+    //back step taken on a guess would throw away the post the reader was on.
+    //
+    //Any change counts, in either direction. `history.length` can also shrink
+    //on a jewel tap: a reader who has gone back off a post sits at position 1
+    //of 2, and Facebook's pushState truncates the forward entry before pushing
+    //its own, so the length can hold or drop instead of rising. A shrink is
+    //still proof that a page was pushed on top of the one that was remembered,
+    //and stepping back off it is right.
+    if (before == null || after == null || after == before) return;
 
     if (await _controller.canGoBack()) {
       if (!mounted) return;

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -75,6 +75,22 @@ class _HomePageState extends ConsumerState<HomePage> {
   /// screen on the first.
   bool _messengerOpen = false;
 
+  /// The feed's `history.length` as of the last url it actually moved to, and
+  /// the url that reading was done on.
+  ///
+  /// Read here rather than when the chat icon is tapped, because the tap is a
+  /// race this cannot win. Measured on a Pixel 10 Pro on 2026-09-03: Facebook
+  /// pushed its "Get the Messenger app" page with `pushState` about 10ms
+  /// *before* the `fb-messenger://` request arrived, so a count taken inside
+  /// [_openMessenger] already included the pushed entry and the feed was left
+  /// sitting on the interstitial. A second run had the two the other way round,
+  /// which is what makes it a race rather than an order to code against.
+  ///
+  /// A `pushState` keeps the url it was called on, so it never updates these;
+  /// a real navigation to a different url does.
+  int? _feedHistoryLength;
+  String? _feedHistoryUrl;
+
   @override
   void initState() {
     super.initState();
@@ -176,10 +192,20 @@ class _HomePageState extends ConsumerState<HomePage> {
             if (!mounted) return;
             if (kDebugMode) debugPrint(url);
 
+            await _rememberHistory(url);
+            if (!mounted) return;
+
             //a failed main-frame load finishes like any other document on
             //Android, and asking for a rating over the error page is the
             //one-star review this gate exists to avoid
             if (loadCompleted) unawaited(_maybeAskForRating());
+          },
+          //Facebook's touch layout moves between pages in-document, and no
+          //load finishes for those: without this the remembered count would
+          //still describe whatever page the app last loaded outright
+          onUrlChange: (change) {
+            final url = change.url;
+            if (url != null) unawaited(_rememberHistory(url));
           },
           onProgress: (int progress) {
             if (!mounted) return;
@@ -389,9 +415,15 @@ class _HomePageState extends ConsumerState<HomePage> {
     if (_messengerOpen) return;
 
     //Facebook answers a tap on the chat icon by pushing its "Get the Messenger
-    //app" page as an in-page history entry, without changing the document url.
-    //Counted before the route opens so the feed can be walked back off it.
-    final before = await _historyLength();
+    //app" page as an in-page history entry, without changing the document url,
+    //and the feed has to be walked back off it afterwards. The count to compare
+    //against is the one from before that push, and reading it here is too late:
+    //measured on a Pixel 10 Pro on 2026-09-03 the push landed about 10ms
+    //*before* the `fb-messenger://` request did, so a fresh read already
+    //counted it and the feed stayed on the interstitial. [_rememberHistory]
+    //holds the value from the last real url change instead; reading it now is
+    //only the fallback for a feed that has not had one yet.
+    final before = _feedHistoryLength ?? await _historyLength();
     if (!mounted) return;
 
     Telemetry.captureIssue('messenger.opened', data: {'source': source});
@@ -419,6 +451,26 @@ class _HomePageState extends ConsumerState<HomePage> {
       if (!mounted) return;
       await _controller.goBack();
     }
+  }
+
+  /// Records the feed's history length for [url], at most once per url.
+  ///
+  /// Ignoring a url already seen is what makes this survive the race described
+  /// on [_feedHistoryLength]: Facebook's interstitial is pushed under the url
+  /// the feed is already on, so it never overwrites the count, and the stored
+  /// number keeps describing the page as it was before the chat icon was
+  /// tapped.
+  Future<void> _rememberHistory(String url) async {
+    if (url == _feedHistoryUrl) return;
+
+    //claimed before the await, so a second callback for the same url cannot
+    //race in and read the count twice
+    _feedHistoryUrl = url;
+
+    final length = await _historyLength();
+    if (!mounted) return;
+
+    _feedHistoryLength = length;
   }
 
   /// `history.length` for the page in the feed, or null when it cannot be read.

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -68,6 +68,13 @@ class _HomePageState extends ConsumerState<HomePage> {
   /// depending on `shared_preferences` answering a write from its own cache.
   bool _askingForRating = false;
 
+  /// Set while a Messenger route is on the stack.
+  ///
+  /// The chat icon raises a navigation request per tap, and a second tap
+  /// landing while the route is being pushed would stack a second Messenger
+  /// screen on the first.
+  bool _messengerOpen = false;
+
   @override
   void initState() {
     super.initState();
@@ -320,6 +327,19 @@ class _HomePageState extends ConsumerState<HomePage> {
     //is collected as a breadcrumb on anything reported afterwards
     if (kDebugMode) debugPrint("onNavigationRequest: ${request.url}");
 
+    //the chat icon in the mobile top bar is an `fb-messenger://` deep link, not
+    //a link to /messages/, so it used to fall through to the Custom Tab — which
+    //cannot open the scheme — and leave the feed on Facebook's "Get the
+    //Messenger app" page (#338). See [messengerScreenTargetFor].
+    final messengerTarget = messengerScreenTargetFor(uri);
+    if (messengerTarget != null) {
+      await _openMessenger(
+        messengerTarget,
+        source: uri.scheme == 'fb-messenger' ? 'jewel' : 'link',
+      );
+      return NavigationDecision.prevent;
+    }
+
     //Facebook's mobile web opens its own video player through an `fb://` link
     //meant for the native app. Nothing below handles a scheme that is not http,
     //so these used to fall all the way through to the Custom Tab — which either
@@ -341,35 +361,9 @@ class _HomePageState extends ConsumerState<HomePage> {
       }
     }
 
-    //the chat icon in the mobile top bar links to facebook.com/messages, and
-    //with the mobile user agent that page is only a "Get Messenger"
-    //interstitial (#338). The Messenger screen shows the same conversations.
-    final messengerTarget = facebookMessagesToMessenger(uri);
-    if (messengerTarget != null) {
-      if (!mounted) return NavigationDecision.prevent;
-      await Navigator.of(context).push(
-        MaterialPageRoute<void>(
-          builder: (context) =>
-              MessengerPage(initialUrl: messengerTarget.toString()),
-        ),
-      );
-      return NavigationDecision.prevent;
-    }
-
     for (final other in kPermittedHostnamesFb) {
       if (uri.host.endsWith(other)) {
         return NavigationDecision.navigate;
-      }
-    }
-
-    for (final other in kPermittedHostnamesMessenger) {
-      if (uri.host.endsWith(other)) {
-        await Navigator.of(context).push(
-          MaterialPageRoute<void>(
-            builder: (context) => MessengerPage(initialUrl: uri.toString()),
-          ),
-        );
-        return NavigationDecision.prevent;
       }
     }
 
@@ -379,6 +373,72 @@ class _HomePageState extends ConsumerState<HomePage> {
     if (kDebugMode) debugPrint("Launching external url: ${request.url}");
     launchInAppUrl(context, request.url);
     return NavigationDecision.prevent;
+  }
+
+  /// Opens the Messenger screen on [target], and puts the feed back afterwards
+  /// if the tap that got here pushed a page onto it.
+  ///
+  /// [source] names what asked — 'jewel', 'link' or 'app_bar'. It is a fixed
+  /// slug this app chose, and it is all that is reported: the address itself is
+  /// the reader's browsing.
+  ///
+  /// Every hop is guarded, in the style of the callbacks above: this can be
+  /// suspended for as long as the Messenger screen stays open, and the feed can
+  /// be gone by the time it resumes.
+  Future<void> _openMessenger(Uri target, {required String source}) async {
+    if (_messengerOpen) return;
+
+    //Facebook answers a tap on the chat icon by pushing its "Get the Messenger
+    //app" page as an in-page history entry, without changing the document url.
+    //Counted before the route opens so the feed can be walked back off it.
+    final before = await _historyLength();
+    if (!mounted) return;
+
+    Telemetry.captureIssue('messenger.opened', data: {'source': source});
+
+    _messengerOpen = true;
+    try {
+      await Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) => MessengerPage(initialUrl: target.toString()),
+        ),
+      );
+    } finally {
+      _messengerOpen = false;
+    }
+    if (!mounted) return;
+
+    final after = await _historyLength();
+    if (!mounted) return;
+
+    //nothing was pushed, or the count could not be read: leave the page alone.
+    //A back step taken on a guess would throw away the post the reader was on.
+    if (before == null || after == null || after <= before) return;
+
+    if (await _controller.canGoBack()) {
+      if (!mounted) return;
+      await _controller.goBack();
+    }
+  }
+
+  /// `history.length` for the page in the feed, or null when it cannot be read.
+  ///
+  /// Every failure is one answer, because the number is only ever used to ask
+  /// whether an entry appeared: "unknown" has to mean "change nothing".
+  Future<int?> _historyLength() async {
+    try {
+      final result =
+          await _controller.runJavaScriptReturningResult('history.length');
+      //Android hands numbers back as a String, iOS as a num
+      if (result is num) return result.toInt();
+      return int.tryParse(result.toString());
+    }
+    //deliberately everything: a page that will not run script must not stop
+    //the Messenger screen from opening
+    // ignore: avoid_catches_without_on_clauses
+    catch (_) {
+      return null;
+    }
   }
 
   @override
@@ -469,10 +529,9 @@ class _HomePageState extends ConsumerState<HomePage> {
           if (sp.getBool(SpKeys.enableMessenger) ?? true)
             IconButton(
               onPressed: () async {
-                await Navigator.of(context).push(
-                  MaterialPageRoute<void>(
-                    builder: (context) => const MessengerPage(),
-                  ),
+                await _openMessenger(
+                  Uri.parse(kMessengerInboxUrl),
+                  source: 'app_bar',
                 );
               },
               icon: Image.asset('assets/icons/ic_messenger.png', height: 22),

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -38,9 +38,11 @@ class _HomePageState extends ConsumerState<MessengerPage> {
   }
 
   WebViewController _initWebViewController() {
-    var homepage = widget.initialUrl ?? kMessengerUrl;
+    var homepage = widget.initialUrl ?? kMessengerInboxUrl;
     if (!homepage.startsWith('http')) {
-      homepage = '$kMessengerUrl$homepage';
+      //this screen is on facebook.com now, so a path handed to it belongs to
+      //that host and not to messenger.com
+      homepage = '${Uri.parse(kMessengerInboxUrl).origin}$homepage';
     }
 
     final controller = WebViewController(
@@ -241,6 +243,8 @@ class _HomePageState extends ConsumerState<MessengerPage> {
     final sheets = <String, String>{
       'slim-messenger-adapt': CustomCss.adaptMessengerPageCss.code,
       'slim-messenger-list-height': CustomCss.messengerListHeightCss.code,
+      'slim-messenger-fb-chrome':
+          CustomCss.hideFacebookChromeOnMessengerCss.code,
       'slim-user-sheet':
           CustomCss.buildMessengerCss(PrefController.getUserCustomCss()),
     };

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -356,6 +356,23 @@ class CustomCss {
         '[role="grid"] { min-height: 0 !important; max-height: none !important; }',
   );
 
+  /// Hides Facebook's own top bar on the Messenger screen.
+  ///
+  /// The screen loads the inbox from facebook.com now, so the page arrives
+  /// wrapped in the full site chrome: `[role="banner"]` is the blue bar with
+  /// the search box and the jewels. On the 349px viewport a phone gives this
+  /// app that is a strip of the conversation list spent on navigation nobody
+  /// can reach from here, and the app bar above it already carries Close.
+  ///
+  /// Deliberately not in [cssList]: structural, like [hideAppUpsellCss], not a
+  /// preference.
+  static MyCss hideFacebookChromeOnMessengerCss = MyCss(
+    key: 'hide_facebook_chrome_messenger',
+    description: 'Hide the Facebook top bar on the Messenger screen',
+    defaultEnabled: true,
+    code: '[role="banner"] { display: none !important; }',
+  );
+
   static MyCss adaptMessengerPageCss = MyCss(
     key: 'adaptMessenger',
     description: 'Adapt messenger',

--- a/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
+++ b/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
@@ -115,40 +115,87 @@ MessengerNavAction messengerNavigationFor(Uri uri) {
   return MessengerNavAction.openExternal;
 }
 
-/// Where the Messenger screen should open for a facebook.com messages address,
-/// or null when [uri] is not one.
+/// Hosts an `fb-messenger://` link uses when it names one conversation.
 ///
-/// The chat icon in Facebook's mobile top bar links to `/messages/` on
-/// facebook.com, and with a mobile user agent that page is nothing but a "Get
-/// Messenger" install interstitial — Firefox for Android shows the same one
-/// (#338). The conversations themselves are served to a desktop agent on
-/// messenger.com, which is exactly what the Messenger screen loads, so these
-/// addresses are redirected there instead of being rendered in the feed.
+/// Anything else the scheme carries — `threads`, `compose`, a host this does
+/// not know — opens the inbox rather than a guessed conversation.
+const Set<String> _kMessengerThreadHosts = {
+  'thread',
+  'user',
+  'user-thread',
+};
+
+/// Where the Messenger screen should open for [uri], or null when [uri] is not
+/// a Messenger address at all.
 ///
-/// `/messages/t/<id>` keeps its thread: messenger.com uses the same ids. The
-/// older `/messages/read/?tid=cid.c.A:B` form does not translate, so it and
-/// every other variant open the inbox.
+/// ## The chat icon is not a link
+///
+/// Measured on a device on 2026-09-03: tapping the chat icon in Facebook's
+/// mobile top bar does not navigate to `/messages/`. The page asks for
+/// `fb-messenger://threads?…&entry_point=jewel&…` and the document url never
+/// changes. That is why matching `/messages/` alone did not fix #338 — nothing
+/// matched, the request fell through to the Custom Tab, which cannot open a
+/// custom scheme, and the feed was left on a "Get the Messenger app" page.
+/// The request does reach the navigation delegate, so it is caught here.
+///
+/// ## Everything lands on facebook.com, not messenger.com
+///
+/// messenger.com keeps its own cookies and asks for a second sign-in even
+/// while facebook.com is logged in (#326, #300, #257). [kMessengerInboxUrl] is
+/// the same inbox on the session the feed already has, so messenger.com and
+/// `m.me` links are mapped onto it too.
+///
+/// A conversation id survives every form, because `/messages/t/<id>` takes the
+/// same ids messenger.com does. The older `/messages/read/?tid=cid.c.A:B` form
+/// does not translate, so it opens the inbox rather than a wrong thread.
 ///
 /// Basic mode is left alone: `mbasic.facebook.com/messages/` still renders a
 /// usable inbox on its own, and the whole point of that mode is not loading
 /// the heavier surfaces.
-Uri? facebookMessagesToMessenger(Uri uri) {
+Uri? messengerScreenTargetFor(Uri uri) {
+  final segments =
+      uri.pathSegments.where((segment) => segment.isNotEmpty).toList();
   final host = uri.host.toLowerCase();
+
+  if (uri.scheme == 'fb-messenger') {
+    if (_kMessengerThreadHosts.contains(host) && segments.isNotEmpty) {
+      return _messengerThread(segments.first);
+    }
+    return _messengerInbox();
+  }
+
+  //an m.me link is a page's short link, and the name in it is what the thread
+  //is addressed by
+  if (host == 'm.me') {
+    if (segments.length == 1) return _messengerThread(segments.first);
+    return _messengerInbox();
+  }
+
+  if (host == 'messenger.com' || host.endsWith('.messenger.com')) {
+    if (segments.length >= 2 && segments.first.toLowerCase() == 't') {
+      return _messengerThread(segments[1]);
+    }
+    return _messengerInbox();
+  }
+
   if (host == 'mbasic.facebook.com') return null;
 
   final isFacebook = kPermittedHostnamesFb
       .any((other) => host == other || host.endsWith('.$other'));
   if (!isFacebook) return null;
 
-  final segments =
-      uri.pathSegments.where((segment) => segment.isNotEmpty).toList();
   if (segments.isEmpty || segments.first.toLowerCase() != 'messages') {
     return null;
   }
 
   if (segments.length >= 3 && segments[1].toLowerCase() == 't') {
-    return Uri.parse('$kMessengerUrl/t/${segments[2]}');
+    return _messengerThread(segments[2]);
   }
 
-  return Uri.parse('$kMessengerUrl/');
+  return _messengerInbox();
 }
+
+Uri _messengerInbox() => Uri.parse(kMessengerInboxUrl);
+
+//[kMessengerInboxUrl] ends in a slash, so the thread id appends directly
+Uri _messengerThread(String id) => Uri.parse('${kMessengerInboxUrl}t/$id');

--- a/SlimSocial_for_Facebook/pubspec.yaml
+++ b/SlimSocial_for_Facebook/pubspec.yaml
@@ -9,7 +9,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # the git tag, so this has to be bumped in its own commit *before* the matching
 # tag is pushed - a tag pushed first builds the previous version. Every release
 # tag from 117 onwards matches the value that was in this field at that commit.
-version: 26.09.02+127
+version: 26.09.03+128
 
 # Leonardo Rignanese <dev.rignaneseleo@gmail.com>
 #

--- a/SlimSocial_for_Facebook/test/consts_test.dart
+++ b/SlimSocial_for_Facebook/test/consts_test.dart
@@ -68,13 +68,6 @@ void main() {
     });
   });
 
-  group('kDesktopUserAgent', () {
-    test('is a desktop agent, which is what Messenger needs', () {
-      expect(kDesktopUserAgent, contains('Macintosh'));
-      expect(kDesktopUserAgent, isNot(contains('Mobile')));
-    });
-  });
-
   group('kFirefoxUserAgent', () {
     test('is the 119 desktop feed agent, pinned verbatim', () {
       expect(
@@ -83,7 +76,17 @@ void main() {
       );
       expect(kFirefoxUserAgent, isNot(contains('Mobile')));
       expect(kFirefoxUserAgent, isNot(kMobileUserAgent));
-      expect(kFirefoxUserAgent, isNot(kDesktopUserAgent));
+    });
+  });
+
+  group('kMessengerInboxUrl', () {
+    test("is Facebook's own inbox, not messenger.com", () {
+      // The host is the whole point: messenger.com keeps its own cookies and
+      // asks for a second sign-in even when facebook.com is logged in (#326,
+      // #300). This address renders the same inbox on the session the feed
+      // already has.
+      expect(Uri.parse(kMessengerInboxUrl).host, 'www.facebook.com');
+      expect(kMessengerInboxUrl, endsWith('/messages/'));
     });
   });
 

--- a/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
+++ b/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
@@ -92,10 +92,13 @@ void main() {
       expect(feed, kMobileUserAgent);
     });
 
-    test('gives Messenger the desktop agent', () {
+    test('gives Messenger the current desktop Firefox agent', () {
+      // Desktop, because the inbox only ships its full markup to a desktop
+      // agent. Current, because on the 2018 Chrome string this used to send,
+      // facebook.com/messages/ carries a "browser no longer supported" banner.
       expect(
         PrefController.getUserAgent(role: UserAgentRole.messenger),
-        kDesktopUserAgent,
+        kFirefoxUserAgent,
       );
     });
 
@@ -111,7 +114,7 @@ void main() {
       );
       expect(
         PrefController.getUserAgent(role: UserAgentRole.messenger),
-        kDesktopUserAgent,
+        kFirefoxUserAgent,
       );
     });
 
@@ -127,7 +130,7 @@ void main() {
       );
       expect(
         PrefController.getUserAgent(role: UserAgentRole.messenger),
-        kDesktopUserAgent,
+        kFirefoxUserAgent,
       );
     });
 
@@ -141,7 +144,7 @@ void main() {
       );
       expect(
         PrefController.getUserAgent(role: UserAgentRole.messenger),
-        kDesktopUserAgent,
+        kFirefoxUserAgent,
       );
     });
 

--- a/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/consts.dart';
 import 'package:slimsocial_for_facebook/utils/fb_navigation.dart';
 
 bool isAuth(String url) => isFacebookAuthUrl(Uri.parse(url));
@@ -147,66 +148,116 @@ void main() {
     });
   });
 
-  group('facebookMessagesToMessenger', () {
-    Uri? to(String url) => facebookMessagesToMessenger(Uri.parse(url));
+  group('messengerScreenTargetFor', () {
+    Uri? to(String url) => messengerScreenTargetFor(Uri.parse(url));
 
-    // The chat icon in Facebook's mobile top bar links to /messages/ on
-    // facebook.com, and with a mobile user agent that page is nothing but a
-    // "Get Messenger" install interstitial — the same one Firefox for Android
-    // shows (#338). The app already has a Messenger screen that loads
-    // messenger.com with a desktop agent; these addresses belong there.
-    test('the inbox goes to the Messenger screen', () {
-      expect(
-        to('https://m.facebook.com/messages/'),
-        Uri.parse('https://www.messenger.com/'),
-      );
-      expect(
-        to('https://touch.facebook.com/messages'),
-        Uri.parse('https://www.messenger.com/'),
-      );
+    final inbox = Uri.parse(kMessengerInboxUrl);
+    Uri thread(String id) => Uri.parse('${kMessengerInboxUrl}t/$id');
+
+    group('the chat icon in the top bar', () {
+      // Measured on a Pixel 10 Pro on 2026-09-03: the icon does not link to
+      // /messages/ at all. It asks for this custom scheme, the document url
+      // never changes, and nothing here used to match it — so the request fell
+      // through to the Custom Tab, which cannot open a scheme, and the feed was
+      // left on Facebook's "Get the Messenger app" page (#338).
+      test('the observed jewel deep link opens the inbox', () {
+        expect(
+          to('fb-messenger://threads?vcuid=100000000000000'
+              '&is_msite_sso_eligible=1&entry_point=jewel'
+              '&browser_name=Firefox&mb=AbCdEf123&src=mtouch_diode'),
+          inbox,
+        );
+      });
+
+      test('a deep link naming a thread keeps its id', () {
+        expect(to('fb-messenger://thread/123'), thread('123'));
+        expect(to('fb-messenger://user/123'), thread('123'));
+        expect(to('fb-messenger://user-thread/123'), thread('123'));
+        expect(to('fb-messenger://user/someone'), thread('someone'));
+      });
+
+      test('a deep link with no thread to name opens the inbox', () {
+        // The host says "thread" but there is no id behind it: guessing one
+        // would open somebody else's conversation.
+        expect(to('fb-messenger://thread'), inbox);
+        expect(to('fb-messenger://user/'), inbox);
+        expect(to('fb-messenger://compose'), inbox);
+        expect(to('fb-messenger://'), inbox);
+      });
     });
 
-    test('the jewel entry point and its query are dropped', () {
-      expect(
-        to('https://m.facebook.com/messages/?entrypoint=jewel&folder=inbox'),
-        Uri.parse('https://www.messenger.com/'),
-      );
+    group('facebook.com messages addresses', () {
+      // Same rules as the version this replaced, but pointed at facebook.com
+      // rather than messenger.com: messenger.com keeps its own cookies and
+      // asks for a second sign-in (#326, #300), while /messages/ renders the
+      // whole inbox on the session the feed is already using.
+      test('the inbox', () {
+        expect(to('https://m.facebook.com/messages/'), inbox);
+        expect(to('https://touch.facebook.com/messages'), inbox);
+      });
+
+      test('the jewel entry point and its query are dropped', () {
+        expect(
+          to('https://m.facebook.com/messages/?entrypoint=jewel&folder=inbox'),
+          inbox,
+        );
+      });
+
+      test('a thread keeps its id', () {
+        expect(to('https://m.facebook.com/messages/t/123'), thread('123'));
+        expect(to('https://m.facebook.com/messages/t/123/'), thread('123'));
+      });
+
+      test('the legacy read view opens the inbox, not a guessed thread', () {
+        // `tid=cid.c.A:B` is not a thread id in the /t/ form.
+        expect(
+          to('https://m.facebook.com/messages/read/?tid=cid.c.1:2'),
+          inbox,
+        );
+      });
+
+      test('only the exact /messages segment matches', () {
+        expect(to('https://m.facebook.com/messagesabc/'), isNull);
+        expect(to('https://m.facebook.com/home.php'), isNull);
+        expect(to('https://m.facebook.com/'), isNull);
+        expect(to('https://m.facebook.com/groups/messages/'), isNull);
+      });
+
+      test('mbasic is left alone: its messages page renders on its own', () {
+        expect(to('https://mbasic.facebook.com/messages/'), isNull);
+      });
     });
 
-    test('a thread keeps its id', () {
-      expect(
-        to('https://m.facebook.com/messages/t/1234567890'),
-        Uri.parse('https://www.messenger.com/t/1234567890'),
-      );
-      expect(
-        to('https://m.facebook.com/messages/t/1234567890/'),
-        Uri.parse('https://www.messenger.com/t/1234567890'),
-      );
+    group('messenger.com and m.me links', () {
+      // These used to open the Messenger screen on messenger.com itself, which
+      // is the second sign-in (#326, #300, #257). Mapped onto the facebook.com
+      // inbox they open on the session the user already has.
+      test('messenger.com goes to the inbox', () {
+        expect(to('https://www.messenger.com/'), inbox);
+        expect(to('https://messenger.com'), inbox);
+        expect(to('https://www.messenger.com/marketplace/'), inbox);
+      });
+
+      test('a messenger.com thread keeps its id', () {
+        expect(to('https://www.messenger.com/t/123'), thread('123'));
+        expect(to('https://www.messenger.com/t/123/'), thread('123'));
+      });
+
+      test('m.me goes to the inbox', () {
+        expect(to('https://m.me/'), inbox);
+      });
+
+      test('an m.me short link keeps the name it points at', () {
+        expect(to('https://m.me/someone'), thread('someone'));
+      });
     });
 
-    test('the legacy read view opens the inbox, not a guessed thread', () {
-      // `tid=cid.c.A:B` is not a messenger.com thread id.
-      expect(
-        to('https://m.facebook.com/messages/read/?tid=cid.c.1:2'),
-        Uri.parse('https://www.messenger.com/'),
-      );
-    });
-
-    test('only the exact /messages segment matches', () {
-      expect(to('https://m.facebook.com/messagesabc/'), isNull);
-      expect(to('https://m.facebook.com/home.php'), isNull);
-      expect(to('https://m.facebook.com/'), isNull);
-      expect(to('https://m.facebook.com/groups/messages/'), isNull);
-    });
-
-    test('other hosts are not touched', () {
-      expect(to('https://www.messenger.com/t/1'), isNull);
+    test('everything else is left to the feed', () {
       expect(to('https://example.com/messages/'), isNull);
-    });
-
-    test('mbasic is left alone: its messages page renders without Messenger',
-        () {
-      expect(to('https://mbasic.facebook.com/messages/'), isNull);
+      expect(to('https://youtube.com/watch?v=1'), isNull);
+      expect(to('https://touch.facebook.com/home.php'), isNull);
+      expect(to('fb://reel/123'), isNull);
+      expect(to('about:blank'), isNull);
     });
   });
 }


### PR DESCRIPTION
## What users reported after 127

- Play review 2026-09-03 on 127: "now, messenger doesnt work, so 50% of the functionality just died".
- #338 (125, F-Droid): chat icon in the top bar shows "Get Messenger". The 127 change for it did not work — see below.
- #326, #300, #257 and the 3★ review of 2026-09-01: cannot log in to Messenger / Messenger button opens a download page.

## Root cause, measured on a Pixel 10 Pro over the WebView DevTools socket (2026-09-03)

1. **The chat icon is not a link to `/messages/`.** Tapping the Messenger jewel in Facebook's mobile top bar asks the WebView to navigate to
   `fb-messenger://threads?vcuid=…&is_msite_sso_eligible=1&entry_point=jewel&…&src=mtouch_diode` and keeps the document URL at `touch.facebook.com/` (only `navigatedWithinDocument` fires).
   So `facebookMessagesToMessenger` in 127 never matched; the request fell through to the Custom Tab, which cannot open the scheme, and Facebook rendered its "Get the Messenger app" page in the feed.
2. **messenger.com wants its own login.** The Messenger screen loaded `www.messenger.com`. That host keeps separate cookies, so it shows a password form even while facebook.com is signed in. There is no token to hand over.
3. **`www.facebook.com/messages/` is the same inbox on the Facebook session.** Loaded in the Messenger WebView with a desktop agent it renders Chats, search, compose and threads with no login. The old `kDesktopUserAgent` (Chrome 68, 2018) gets a "Your browser is no longer supported" banner on it; Firefox 147 (already in consts.dart as the desktop-site agent) does not.

## Changes

- `messengerScreenTargetFor` replaces `facebookMessagesToMessenger`: `fb-messenger://…` (jewel, thread, user), `facebook.com/messages…`, `messenger.com/…` and `m.me/…` all map to `https://www.facebook.com/messages/` or `/messages/t/<id>`. mbasic untouched.
- Feed `onNavigationRequest` handles that mapping first and opens the Messenger screen (`_openMessenger`), for the jewel, for links and for the app-bar button.
- Messenger screen defaults to `kMessengerInboxUrl`; Messenger agent is `kFirefoxUserAgent`; `kDesktopUserAgent` removed.
- `[role="banner"]` hidden on the Messenger screen (Facebook's blue bar, dead weight at 349px; the app bar has Close).
- After the Messenger screen closes, the feed steps back off the "Get the Messenger app" entry Facebook pushes on the jewel tap. The history length is remembered at the last URL change (`_rememberHistory`) because the push can land before the deep-link request.
- Telemetry: `messenger.opened` with `source` = jewel | link | app_bar, so Sentry shows whether the intercept fires in the wild.
- Version 26.09.03+128, Changelog.

## Verified on device (debug build of this branch, test account, DevTools)

- Jewel tap → new WebView at `https://www.facebook.com/messages/`, UA Firefox 147, title "Messenger | Facebook", Chats list rendered, no password field, Facebook top bar hidden, Chats header visible.
- App-bar Messenger button → same inbox, no login.
- Close → feed back on the timeline (`history.back()` from the interstitial restores it).
- `flutter test`: 496 passed, 6 skipped (was 489). `flutter analyze`: 55 pre-existing infos, no new issue.

## Known gap

If the reader opened a post, went back, then tapped the jewel, Facebook's push truncates the history and the length does not change, so the feed stays on the interstitial after Messenger closes. One tap on its X returns to the feed. Fix later with a `pushState` hook if Sentry shows it matters.

## Not in this PR

- messenger.com links arriving through app_links (opened from another app) still load in the feed WebView.
- SLIMSOCIAL-5 (Play Billing NPE) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
