### PR TITLE
feat: option to open external links in the system browser

### DIFF
--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -8,6 +8,8 @@
   "use_mbasic_desc": "It works better on older devices or slower connections",
   "use_desktop_site": "Use desktop site",
   "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab",
   "recent_first": "Show recent posts first",
   "hide_all_ads": "Hide ads",
   "style": "style",

--- a/SlimSocial_for_Facebook/assets/lang/af-ZA.json
+++ b/SlimSocial_for_Facebook/assets/lang/af-ZA.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Dankie — dit help.",
   "rate_failed": "Kon nie stuur nie. Probeer later weer.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ar-AR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ar-AR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "شكرًا — هذا يساعدنا.",
   "rate_failed": "تعذّر الإرسال. حاول مرة أخرى لاحقًا.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/bg-BG.json
+++ b/SlimSocial_for_Facebook/assets/lang/bg-BG.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Благодарим — това помага.",
   "rate_failed": "Изпращането не бе успешно. Опитайте отново по-късно.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/bn-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/bn-IN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "ধন্যবাদ — এতে সাহায্য হয়।",
   "rate_failed": "পাঠানো যায়নি। অনুগ্রহ করে পরে আবার চেষ্টা করুন।",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ca-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/ca-ES.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Gràcies — això ajuda.",
   "rate_failed": "No s'ha pogut enviar. Torna-ho a provar més tard.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
+++ b/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Děkujeme — to pomáhá.",
   "rate_failed": "Odeslání se nezdařilo. Zkuste to prosím později.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/da-DK.json
+++ b/SlimSocial_for_Facebook/assets/lang/da-DK.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Tak — det hjælper.",
   "rate_failed": "Kunne ikke sende. Prøv igen senere.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/de-DE.json
+++ b/SlimSocial_for_Facebook/assets/lang/de-DE.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Danke — das hilft.",
   "rate_failed": "Senden fehlgeschlagen. Bitte versuche es später erneut.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/el-GR.json
+++ b/SlimSocial_for_Facebook/assets/lang/el-GR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Ευχαριστούμε — αυτό βοηθάει.",
   "rate_failed": "Η αποστολή απέτυχε. Δοκιμάστε ξανά αργότερα.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -8,6 +8,8 @@
   "use_mbasic_desc": "It works better on older devices or slower connections",
   "use_desktop_site": "Use desktop site",
   "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab",
   "recent_first": "Show recent posts first",
   "hide_ads": "Hide some ads (experimental)",
   "hide_people_you_may_know": "Hide \"People you may know\"",

--- a/SlimSocial_for_Facebook/assets/lang/es-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/es-ES.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Gracias — esto ayuda.",
   "rate_failed": "No se pudo enviar. Inténtalo de nuevo más tarde.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/et-EE.json
+++ b/SlimSocial_for_Facebook/assets/lang/et-EE.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Aitäh — sellest on abi.",
   "rate_failed": "Saatmine ebaõnnestus. Proovi hiljem uuesti.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/fa-IR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fa-IR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "ممنون — این کمک می‌کند.",
   "rate_failed": "ارسال نشد. لطفاً بعداً دوباره تلاش کنید.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/fi-FI.json
+++ b/SlimSocial_for_Facebook/assets/lang/fi-FI.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Kiitos — tästä on apua.",
   "rate_failed": "Lähetys epäonnistui. Yritä myöhemmin uudelleen.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/fr-FR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fr-FR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Merci — c'est utile.",
   "rate_failed": "Envoi impossible. Réessayez plus tard.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ha-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ha-NG.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Na gode — wannan yana taimakawa.",
   "rate_failed": "An kasa aikawa. Da fatan a sake gwadawa daga baya.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/he-IL.json
+++ b/SlimSocial_for_Facebook/assets/lang/he-IL.json
@@ -91,5 +91,7 @@
   "rate_thanks": "תודה — זה עוזר.",
   "rate_failed": "השליחה נכשלה. נסו שוב מאוחר יותר.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/hi-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/hi-IN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "धन्यवाद — इससे मदद मिलती है।",
   "rate_failed": "भेजा नहीं जा सका। कृपया बाद में पुनः प्रयास करें।",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/hr-HR.json
+++ b/SlimSocial_for_Facebook/assets/lang/hr-HR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Hvala — ovo pomaže.",
   "rate_failed": "Slanje nije uspjelo. Pokušajte ponovno kasnije.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/hu-HU.json
+++ b/SlimSocial_for_Facebook/assets/lang/hu-HU.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Köszönjük — ez segít.",
   "rate_failed": "Nem sikerült elküldeni. Próbáld újra később.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ig-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ig-NG.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Daalụ — nke a na-enyere aka.",
   "rate_failed": "Enweghị ike izipu. Biko nwaa ọzọ ma emesịa.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Grazie — è utile.",
   "rate_failed": "Invio non riuscito. Riprova più tardi.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ja-JP.json
+++ b/SlimSocial_for_Facebook/assets/lang/ja-JP.json
@@ -91,5 +91,7 @@
   "rate_thanks": "ありがとうございます — 助かります。",
   "rate_failed": "送信できませんでした。後でもう一度お試しください。",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ko-KR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ko-KR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "감사합니다 — 큰 도움이 됩니다.",
   "rate_failed": "보내지 못했습니다. 나중에 다시 시도해 주세요.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/lt-LT.json
+++ b/SlimSocial_for_Facebook/assets/lang/lt-LT.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Ačiū — tai padeda.",
   "rate_failed": "Nepavyko išsiųsti. Bandykite vėliau.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/lv-LV.json
+++ b/SlimSocial_for_Facebook/assets/lang/lv-LV.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Paldies — tas palīdz.",
   "rate_failed": "Neizdevās nosūtīt. Mēģiniet vēlreiz vēlāk.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ml-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ml-IN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "നന്ദി — ഇത് സഹായകരമാണ്.",
   "rate_failed": "അയയ്ക്കാനായില്ല. ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/mr-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/mr-IN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "धन्यवाद — याची मदत होते.",
   "rate_failed": "पाठवता आले नाही. कृपया नंतर पुन्हा प्रयत्न करा.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/nl-NL.json
+++ b/SlimSocial_for_Facebook/assets/lang/nl-NL.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Bedankt — hier hebben we wat aan.",
   "rate_failed": "Verzenden mislukt. Probeer het later opnieuw.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/no-NO.json
+++ b/SlimSocial_for_Facebook/assets/lang/no-NO.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Takk — dette hjelper.",
   "rate_failed": "Kunne ikke sende. Prøv igjen senere.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Thank you — e dey help.",
   "rate_failed": "E no fit send. Abeg try again later.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pl-PL.json
+++ b/SlimSocial_for_Facebook/assets/lang/pl-PL.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Dziękujemy — to pomaga.",
   "rate_failed": "Nie udało się wysłać. Spróbuj ponownie później.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-BR.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-BR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Obrigado — isso ajuda.",
   "rate_failed": "Não foi possível enviar. Tente novamente mais tarde.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/pt-PT.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-PT.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Obrigado — isto ajuda.",
   "rate_failed": "Não foi possível enviar. Tente novamente mais tarde.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ro-RO.json
+++ b/SlimSocial_for_Facebook/assets/lang/ro-RO.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Mulțumim — asta ajută.",
   "rate_failed": "Trimiterea a eșuat. Încearcă din nou mai târziu.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ru-RU.json
+++ b/SlimSocial_for_Facebook/assets/lang/ru-RU.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Спасибо — это помогает.",
   "rate_failed": "Не удалось отправить. Повторите попытку позже.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sk-SK.json
+++ b/SlimSocial_for_Facebook/assets/lang/sk-SK.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Ďakujeme — to pomáha.",
   "rate_failed": "Odoslanie zlyhalo. Skúste to znova neskôr.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sl-SI.json
+++ b/SlimSocial_for_Facebook/assets/lang/sl-SI.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Hvala — to pomaga.",
   "rate_failed": "Pošiljanje ni uspelo. Poskusite znova pozneje.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sr-SP.json
+++ b/SlimSocial_for_Facebook/assets/lang/sr-SP.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Hvala — ovo pomaže.",
   "rate_failed": "Slanje nije uspelo. Pokušajte ponovo kasnije.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/sv-SE.json
+++ b/SlimSocial_for_Facebook/assets/lang/sv-SE.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Tack — det hjälper.",
   "rate_failed": "Kunde inte skicka. Försök igen senare.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ta-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ta-IN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "நன்றி — இது உதவுகிறது.",
   "rate_failed": "அனுப்ப முடியவில்லை. பிறகு மீண்டும் முயற்சிக்கவும்.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/te-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/te-IN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "ధన్యవాదాలు — ఇది సహాయపడుతుంది.",
   "rate_failed": "పంపడం సాధ్యం కాలేదు. దయచేసి తర్వాత మళ్లీ ప్రయత్నించండి.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/th-TH.json
+++ b/SlimSocial_for_Facebook/assets/lang/th-TH.json
@@ -91,5 +91,7 @@
   "rate_thanks": "ขอบคุณ — ช่วยได้มาก",
   "rate_failed": "ส่งไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/tr-TR.json
+++ b/SlimSocial_for_Facebook/assets/lang/tr-TR.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Teşekkürler — bu yardımcı oluyor.",
   "rate_failed": "Gönderilemedi. Lütfen daha sonra tekrar deneyin.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/uk-UA.json
+++ b/SlimSocial_for_Facebook/assets/lang/uk-UA.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Дякуємо — це допомагає.",
   "rate_failed": "Не вдалося надіслати. Спробуйте пізніше.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/ur-PK.json
+++ b/SlimSocial_for_Facebook/assets/lang/ur-PK.json
@@ -91,5 +91,7 @@
   "rate_thanks": "شکریہ — اس سے مدد ملتی ہے۔",
   "rate_failed": "بھیجا نہیں جا سکا۔ براہ کرم بعد میں دوبارہ کوشش کریں۔",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/vi-VN.json
+++ b/SlimSocial_for_Facebook/assets/lang/vi-VN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "Cảm ơn — điều này rất hữu ích.",
   "rate_failed": "Không thể gửi. Vui lòng thử lại sau.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/yo-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/yo-NG.json
@@ -91,5 +91,7 @@
   "rate_thanks": "O ṣeun — èyí ṣèrànwọ́.",
   "rate_failed": "Kò lè fi ránṣẹ́. Jọ̀wọ́ gbìyànjú lẹ́ẹ̀kansi nígbà mìíràn.",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-CN.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-CN.json
@@ -91,5 +91,7 @@
   "rate_thanks": "谢谢 — 这很有帮助。",
   "rate_failed": "发送失败。请稍后再试。",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/assets/lang/zh-TW.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-TW.json
@@ -91,5 +91,7 @@
   "rate_thanks": "謝謝 — 這很有幫助。",
   "rate_failed": "傳送失敗。請稍後再試。",
   "use_desktop_site": "Use desktop site",
-  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken"
+  "use_desktop_site_desc": "Facebook's desktop layout. Use this if chat, share, or the feed overlay is broken",
+  "use_system_browser": "Open links in the system browser",
+  "use_system_browser_desc": "External links open in your browser app instead of the in-app tab"
 }

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -142,6 +142,10 @@ class SpKeys {
   /// Unset or false keeps the mobile default. Messenger ignores this key.
   static const String useDesktopSite = "use_desktop_site";
 
+  /// When true, external links open in the system browser app instead of
+  /// the in-app custom tab. Unset or false keeps the in-app tab.
+  static const String useSystemBrowser = "use_system_browser";
+
   /// Whether crash and health reporting may send anything. Unset means on.
   static const String telemetryEnabled = "telemetry_enabled";
 

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -42,6 +42,12 @@ class PrefController {
     return kMobileUserAgent;
   }
 
+  /// Whether external links should open in the system browser app.
+  ///
+  /// Read on every link open, so the setting takes effect with no restart.
+  static bool usesSystemBrowser() =>
+      sp.getBool(SpKeys.useSystemBrowser) ?? false;
+
   /// Text scaling for the webview, as a percentage of the page's own size.
   ///
   /// Clamped on the way out as well as on the way in, so a value written by an

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -173,6 +173,17 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 title: Text('use_desktop_site'.tr()),
                 description: Text('use_desktop_site_desc'.tr()),
               ),
+              SettingsTile.switchTile(
+                onToggle: (value) {
+                  setState(() {
+                    sp.setBool(SpKeys.useSystemBrowser, value);
+                  });
+                },
+                initialValue: sp.getBool(SpKeys.useSystemBrowser) ?? false,
+                leading: const Icon(Icons.open_in_browser),
+                title: Text('use_system_browser'.tr()),
+                description: Text('use_system_browser_desc'.tr()),
+              ),
             ],
           ),
           SettingsSection(

--- a/SlimSocial_for_Facebook/lib/utils/utils.dart
+++ b/SlimSocial_for_Facebook/lib/utils/utils.dart
@@ -3,10 +3,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:flutter_file_downloader/flutter_file_downloader.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
 import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
+// flutter_custom_tabs also exports `launchUrl`, so this one needs a prefix.
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
 Future<void> launchInAppUrl(BuildContext context, String url) async {
   try {
+    if (PrefController.usesSystemBrowser()) {
+      await url_launcher.launchUrl(
+        Uri.parse(url),
+        mode: url_launcher.LaunchMode.externalApplication,
+      );
+      return;
+    }
+
     await launchUrl(
       Uri.parse(url),
       customTabsOptions: const CustomTabsOptions(

--- a/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
+++ b/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
@@ -292,4 +292,24 @@ void main() {
       expect((kMaxTextZoom - kMinTextZoom) % 5, 0);
     });
   });
+
+  group('usesSystemBrowser', () {
+    test('defaults to the in-app custom tab', () {
+      // An unset key must keep the old behaviour: existing installs upgrade
+      // without their external links suddenly leaving the app.
+      expect(PrefController.usesSystemBrowser(), isFalse);
+    });
+
+    test('is true once the setting is on', () async {
+      await withPrefs({SpKeys.useSystemBrowser: true});
+
+      expect(PrefController.usesSystemBrowser(), isTrue);
+    });
+
+    test('is false once the setting is turned back off', () async {
+      await withPrefs({SpKeys.useSystemBrowser: false});
+
+      expect(PrefController.usesSystemBrowser(), isFalse);
+    });
+  });
 }

--- a/SlimSocial_for_Facebook/test/lang_test.dart
+++ b/SlimSocial_for_Facebook/test/lang_test.dart
@@ -45,6 +45,8 @@ void main() {
         'text_zoom_desc',
         'use_desktop_site',
         'use_desktop_site_desc',
+        'use_system_browser',
+        'use_system_browser_desc',
         'dark_theme',
         'fixed_bar',
         'hide_stories',


### PR DESCRIPTION
Closes #287

## What changed

External links opened in a Chrome Custom Tab, with no way to change it. This adds a setting that sends them to the system browser app instead.

- `lib/consts.dart`: new `SpKeys.useSystemBrowser` (`use_system_browser`).
- `lib/controllers/fb_controller.dart`: `PrefController.usesSystemBrowser()`, default `false`.
- `lib/utils/utils.dart`: `launchInAppUrl` checks the setting first and calls `url_launcher.launchUrl(uri, mode: LaunchMode.externalApplication)`. `url_launcher` is imported with a prefix because `flutter_custom_tabs` also exports `launchUrl`. The existing try/catch is kept, so a missing browser still logs instead of crashing.
- `lib/screens/settings_page.dart`: a switch tile in the Facebook section, after "Use desktop site". No restart: the key is read on every link open.
- Translations: `use_system_browser` and `use_system_browser_desc` added to `en-US.json` and `_.json`. The English text is also seeded into all other locale files, because `test/lang_test.dart` asserts every locale defines every en-US key. Crowdin can replace those strings.
- Tests: three cases for `usesSystemBrowser` in `test/controllers/fb_controller_test.dart`, and both new keys added to the required-labels list in `test/lang_test.dart`.

Default behaviour is unchanged. Existing installs keep the in-app tab until they turn the switch on.

## How I tested

- `flutter pub get` — OK.
- `flutter test test/controllers/fb_controller_test.dart test/lang_test.dart test/utils/utils_test.dart` — **99 tests, all passed**.
- `flutter analyze` — **0 errors, 0 warnings**; 52 `info` lints, all pre-existing and none on the new code.

Flutter 3.44.8.

## Known limits

- Not run on a device or emulator. The system-browser path is verified by unit test and by static analysis only.
- Callers (`home_page.dart`, `messenger_page.dart`, `settings_page.dart`) are unchanged; they all go through `launchInAppUrl`.
- The other locale files carry the English string until Crowdin translates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)