### PR TITLE
fix: Back returns to the feed before it closes the app

### DIFF
--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -714,16 +714,33 @@ class _HomePageState extends ConsumerState<HomePage> {
       ),
       body: WillPopScope(
         onWillPop: () async {
-          if (await _controller.canGoBack()) {
-            _controller.goBack();
+          //Facebook's mobile site often replaces the history entry instead of
+          //pushing one, so canGoBack() is false on a post or group the reader
+          //navigated into and Back closed the app (#222). The feed is the
+          //fallback; a second Back, now on the feed, exits as before.
+          final url = await _controller.currentUrl();
+          final action = backActionFor(
+            canGoBack: await _controller.canGoBack(),
+            current: Uri.tryParse(url ?? ''),
+            home: Uri.parse(PrefController.getHomePage()),
+          );
 
-            if (isScontentUrl) {
-              //gotta go back twice to leave scontent (facebook bug?)
-              _controller.goBack();
-            }
-            return false;
+          switch (action) {
+            case BackAction.goBack:
+              await _controller.goBack();
+
+              if (isScontentUrl) {
+                //gotta go back twice to leave scontent (facebook bug?)
+                await _controller.goBack();
+              }
+              return false;
+            case BackAction.goHome:
+              await _controller
+                  .loadRequest(Uri.parse(PrefController.getHomePage()));
+              return false;
+            case BackAction.exit:
+              return true;
           }
-          return true;
         },
         child: Stack(
           alignment: AlignmentDirectional.bottomCenter,

--- a/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
+++ b/SlimSocial_for_Facebook/lib/utils/fb_navigation.dart
@@ -199,3 +199,82 @@ Uri _messengerInbox() => Uri.parse(kMessengerInboxUrl);
 
 //[kMessengerInboxUrl] ends in a slash, so the thread id appends directly
 Uri _messengerThread(String id) => Uri.parse('${kMessengerInboxUrl}t/$id');
+
+/// Hosts that serve the same Facebook feed.
+///
+/// The home page setting names one of them — `touch.facebook.com` by default,
+/// `mbasic.facebook.com` in basic mode — while a link tapped inside the feed
+/// can land the webview on any of the others. Treating them as one host is
+/// what stops a plain `facebook.com/home.php` from being read as a page the
+/// reader navigated to.
+const Set<String> _kHomeFeedHostFamily = {
+  'facebook.com',
+  'www.facebook.com',
+  'm.facebook.com',
+  'touch.facebook.com',
+};
+
+/// Paths that render the feed itself.
+///
+/// The query is not compared: the feed carries `?sk=h_chr` or `?sk=h_nor`
+/// depending on the "most recent first" setting, and both are the same page.
+const Set<String> _kHomeFeedPaths = {
+  '',
+  '/',
+  '/home.php',
+};
+
+/// Whether [current] is the feed named by [home].
+bool isHomeFeed(Uri current, Uri home) {
+  final currentHost = current.host.toLowerCase();
+  final homeHost = home.host.toLowerCase();
+
+  final sameHost = currentHost == homeHost ||
+      (_kHomeFeedHostFamily.contains(currentHost) &&
+          _kHomeFeedHostFamily.contains(homeHost));
+  if (!sameHost) return false;
+
+  return _kHomeFeedPaths.contains(current.path);
+}
+
+/// What the system Back button should do.
+enum BackAction {
+  /// Step back through the webview's own history.
+  goBack,
+
+  /// Load the feed. There is no history to step back through, but the reader
+  /// is not on the feed either.
+  goHome,
+
+  /// Leave the app.
+  exit,
+}
+
+/// Decides [BackAction] for a Back press on the feed screen (#222).
+///
+/// Facebook's mobile site often replaces the current history entry instead of
+/// pushing a new one, so a post, group or profile opened from the feed can
+/// leave `canGoBack()` false. Back then closed the app from a page the reader
+/// had clearly navigated into, which is what #222 reports. Loading the feed
+/// instead gives that press somewhere to go; a second press, now on the feed,
+/// still exits.
+///
+/// The sign-in flow is the exception. It is not the feed, but sending it home
+/// would bounce a signed-out reader between the login form and the redirect
+/// back to it, so Back there keeps closing the app.
+BackAction backActionFor({
+  required bool canGoBack,
+  required Uri? current,
+  required Uri home,
+}) {
+  if (canGoBack) return BackAction.goBack;
+
+  //a url that could not be read says nothing about where the reader is, so the
+  //old behaviour stands rather than a guessed navigation
+  if (current == null) return BackAction.exit;
+
+  if (isHomeFeed(current, home)) return BackAction.exit;
+  if (isFacebookAuthUrl(current)) return BackAction.exit;
+
+  return BackAction.goHome;
+}

--- a/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/fb_navigation_test.dart
@@ -260,4 +260,83 @@ void main() {
       expect(to('about:blank'), isNull);
     });
   });
+
+  group('backActionFor gives Back somewhere to go before it exits (#222)', () {
+    BackAction actionFor(
+      String? current, {
+      bool canGoBack = false,
+      String home = '$kTouchFacebookHomeUrl?sk=h_nor',
+    }) {
+      return backActionFor(
+        canGoBack: canGoBack,
+        current: current == null ? null : Uri.parse(current),
+        home: Uri.parse(home),
+      );
+    }
+
+    test('webview history wins over everything else', () {
+      // Nothing below is consulted while there is a page to step back to.
+      expect(
+        actionFor('https://m.facebook.com/story.php?id=1', canGoBack: true),
+        BackAction.goBack,
+      );
+      expect(
+        actionFor(kTouchFacebookHomeUrl, canGoBack: true),
+        BackAction.goBack,
+      );
+    });
+
+    test('the feed itself still exits, whatever sort order it carries', () {
+      expect(actionFor('$kTouchFacebookHomeUrl?sk=h_nor'), BackAction.exit);
+      expect(actionFor('$kTouchFacebookHomeUrl?sk=h_chr'), BackAction.exit);
+      expect(actionFor(kTouchFacebookHomeUrl), BackAction.exit);
+    });
+
+    test('the feed on a sibling host is the feed too', () {
+      // The home setting names touch.facebook.com, but the webview reports
+      // whichever host Facebook last redirected to.
+      expect(actionFor('https://www.facebook.com/'), BackAction.exit);
+      expect(actionFor('https://m.facebook.com/home.php'), BackAction.exit);
+      expect(actionFor('https://facebook.com/home.php?sk=h_chr'),
+          BackAction.exit);
+    });
+
+    test('basic mode compares against its own home', () {
+      expect(
+        actionFor(kFacebookHomeBasicUrl, home: kFacebookHomeBasicUrl),
+        BackAction.exit,
+      );
+    });
+
+    test('a page reached without a history entry goes to the feed', () {
+      // This is #222: Facebook replaces the history entry, so canGoBack is
+      // false on a post the reader plainly navigated into, and Back used to
+      // close the app.
+      expect(
+        actionFor('https://www.facebook.com/story.php?story_fbid=1&id=2'),
+        BackAction.goHome,
+      );
+      expect(
+        actionFor('https://m.facebook.com/groups/123'),
+        BackAction.goHome,
+      );
+      expect(
+        actionFor('https://m.facebook.com/zuck'),
+        BackAction.goHome,
+      );
+    });
+
+    test('sign-in exits rather than bouncing back to the login form', () {
+      expect(actionFor('https://m.facebook.com/login'), BackAction.exit);
+      expect(actionFor('https://m.facebook.com/login/'), BackAction.exit);
+      expect(
+        actionFor('https://m.facebook.com/login.php?next=%2F'),
+        BackAction.exit,
+      );
+    });
+
+    test('an unreadable url keeps the old behaviour', () {
+      expect(actionFor(null), BackAction.exit);
+    });
+  });
 }


### PR DESCRIPTION
Closes #222

## Cause

`home_page.dart` used `WillPopScope` with `canGoBack()` alone: when the webview
had no history entry to step back to, Back returned `true` and the app closed.

Facebook's mobile site often does not add a history entry for the page you came
from — it replaces the current one (`replaceState`). So from a post, group or
profile opened out of the feed, `canGoBack()` is false and Back killed the app
instead of returning to the feed.

## Change

- New pure helper in `lib/utils/fb_navigation.dart`: `enum BackAction { goBack, goHome, exit }`
  and `backActionFor({canGoBack, current, home})`, plus `isHomeFeed(current, home)`.
  - `goBack` while there is webview history — unchanged, including the scontent
    double-`goBack` quirk.
  - `goHome` when there is no history and the current page is not the feed: Back
    loads the home page instead of exiting.
  - `exit` when already on the feed, so a second Back closes the app as before.
- `isHomeFeed` ignores the query (`?sk=h_chr` / `?sk=h_nor` are the same feed) and
  treats `facebook.com`, `www.`, `m.` and `touch.facebook.com` as one host family,
  because the home setting names `touch.facebook.com` while Facebook redirects
  between them. Basic mode compares against its own `mbasic.facebook.com` home.
- Facebook's sign-in flow is excluded, so a signed-out reader is not bounced
  between the login form and a redirect back to it.
- `messenger_page.dart` is untouched: Back there pops the route to the feed,
  which is already correct.

## Tests

`test/utils/fb_navigation_test.dart` — 7 new cases: `canGoBack` wins; feed with
`?sk=h_nor` and `/home.php?sk=h_chr` exit; the feed on a sibling host exits;
mbasic home with an mbasic setting exits; a post, group and profile URL go home;
the login pages exit; an unreadable URL exits.

- `flutter test test/utils/fb_navigation_test.dart` — 39 passed.
- `flutter analyze` — 50 issues, all pre-existing infos, no errors or warnings.

## Caveat

Not tested on a device. The decision logic is covered by unit tests, but the
`WillPopScope` wiring itself was verified only by analyzer and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)