### PR TITLE
feat: option to hide the home feed

### DIFF
--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -83,6 +83,8 @@
   "ads_blocked_count": "{} hidden so far",
   "hide_people_you_may_know": "Hide \"People you may know\"",
   "hide_reels": "Hide reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "telemetry_reports": "Send anonymous reports",
   "telemetry_reports_desc": "Anonymous crash and breakage reports help spot when a Facebook change breaks the app. No personal data and no page content are sent. Turn this off any time.",
   "rate_title": "Enjoying SlimSocial?",

--- a/SlimSocial_for_Facebook/assets/lang/af-ZA.json
+++ b/SlimSocial_for_Facebook/assets/lang/af-ZA.json
@@ -81,6 +81,8 @@
   "exit": "Verlaat app",
   "hide_people_you_may_know": "Versteek \"Mense wat jy dalk ken\"",
   "hide_reels": "Versteek reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Versteek die Messenger-kantbalk",
   "error_page_offline": "Kon nie Facebook laai nie. Kontroleer jou verbinding en probeer weer.",
   "retry": "Probeer weer",

--- a/SlimSocial_for_Facebook/assets/lang/ar-AR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ar-AR.json
@@ -81,6 +81,8 @@
   "exit": "الخروج من التطبيق",
   "hide_people_you_may_know": "إخفاء \"أشخاص قد تعرفهم\"",
   "hide_reels": "إخفاء الريلز",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "إخفاء الشريط الجانبي للمراسلة",
   "error_page_offline": "تعذّر تحميل فيسبوك. تحقق من اتصالك وحاول مرة أخرى.",
   "retry": "إعادة المحاولة",

--- a/SlimSocial_for_Facebook/assets/lang/bg-BG.json
+++ b/SlimSocial_for_Facebook/assets/lang/bg-BG.json
@@ -81,6 +81,8 @@
   "exit": "Изход от приложението",
   "hide_people_you_may_know": "Скриване на „Хора, които може да познавате“",
   "hide_reels": "Скриване на Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Скриване на страничната лента на Messenger",
   "error_page_offline": "Facebook не можа да се зареди. Проверете връзката си и опитайте отново.",
   "retry": "Опитайте отново",

--- a/SlimSocial_for_Facebook/assets/lang/bn-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/bn-IN.json
@@ -81,6 +81,8 @@
   "exit": "অ্যাপ থেকে বেরিয়ে যান",
   "hide_people_you_may_know": "\"আপনি যাদের চিনতে পারেন\" লুকান",
   "hide_reels": "রিলস লুকান",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "মেসেঞ্জার সাইডবার লুকান",
   "error_page_offline": "Facebook লোড করা যায়নি। আপনার সংযোগ পরীক্ষা করে আবার চেষ্টা করুন।",
   "retry": "আবার চেষ্টা করুন",

--- a/SlimSocial_for_Facebook/assets/lang/ca-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/ca-ES.json
@@ -81,6 +81,8 @@
   "exit": "Surt de l'aplicació",
   "hide_people_you_may_know": "Amaga «Persones que potser coneixes»",
   "hide_reels": "Amaga els reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Amaga la barra lateral del Messenger",
   "error_page_offline": "No s'ha pogut carregar el Facebook. Comprova la connexió i torna-ho a provar.",
   "retry": "Torna-ho a provar",

--- a/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
+++ b/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
@@ -81,6 +81,8 @@
   "exit": "Ukončit aplikaci",
   "hide_people_you_may_know": "Skrýt „Lidé, které možná znáš“",
   "hide_reels": "Skrýt reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Skrýt postranní panel Messengeru",
   "error_page_offline": "Facebook se nepodařilo načíst. Zkontrolujte připojení a zkuste to znovu.",
   "retry": "Zkusit znovu",

--- a/SlimSocial_for_Facebook/assets/lang/da-DK.json
+++ b/SlimSocial_for_Facebook/assets/lang/da-DK.json
@@ -81,6 +81,8 @@
   "exit": "Afslut appen",
   "hide_people_you_may_know": "Skjul \"Personer, du måske kender\"",
   "hide_reels": "Skjul reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Skjul Messenger-sidepanelet",
   "error_page_offline": "Facebook kunne ikke indlæses. Tjek din forbindelse, og prøv igen.",
   "retry": "Prøv igen",

--- a/SlimSocial_for_Facebook/assets/lang/de-DE.json
+++ b/SlimSocial_for_Facebook/assets/lang/de-DE.json
@@ -81,6 +81,8 @@
   "exit": "App beenden",
   "hide_people_you_may_know": "„Personen, die du kennen könntest“ ausblenden",
   "hide_reels": "Reels ausblenden",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Messenger-Seitenleiste ausblenden",
   "error_page_offline": "Facebook konnte nicht geladen werden. Überprüfe deine Verbindung und versuche es erneut.",
   "retry": "Erneut versuchen",

--- a/SlimSocial_for_Facebook/assets/lang/el-GR.json
+++ b/SlimSocial_for_Facebook/assets/lang/el-GR.json
@@ -81,6 +81,8 @@
   "exit": "Έξοδος από την εφαρμογή",
   "hide_people_you_may_know": "Απόκρυψη «Άτομα που ίσως γνωρίζετε»",
   "hide_reels": "Απόκρυψη reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Απόκρυψη της πλαϊνής μπάρας του Messenger",
   "error_page_offline": "Δεν ήταν δυνατή η φόρτωση του Facebook. Ελέγξτε τη σύνδεσή σας και δοκιμάστε ξανά.",
   "retry": "Δοκιμή ξανά",

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -18,6 +18,8 @@
   "fixed_bar": "Fixed top bar",
   "hide_stories": "Hide stories",
   "hide_reels": "Hide reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Hide Messenger sidebar",
   "center_text": "Center text on posts",
   "add_space": "Add space between posts",

--- a/SlimSocial_for_Facebook/assets/lang/es-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/es-ES.json
@@ -81,6 +81,8 @@
   "exit": "Salir de la aplicación",
   "hide_people_you_may_know": "Ocultar «Personas que quizá conozcas»",
   "hide_reels": "Ocultar reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Ocultar la barra lateral de Messenger",
   "error_page_offline": "No se pudo cargar Facebook. Comprueba tu conexión e inténtalo de nuevo.",
   "retry": "Reintentar",

--- a/SlimSocial_for_Facebook/assets/lang/et-EE.json
+++ b/SlimSocial_for_Facebook/assets/lang/et-EE.json
@@ -81,6 +81,8 @@
   "exit": "Välju rakendusest",
   "hide_people_you_may_know": "Peida „Inimesed, keda võid tunda”",
   "hide_reels": "Peida reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Peida Messengeri külgriba",
   "error_page_offline": "Facebooki ei õnnestunud laadida. Kontrolli ühendust ja proovi uuesti.",
   "retry": "Proovi uuesti",

--- a/SlimSocial_for_Facebook/assets/lang/fa-IR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fa-IR.json
@@ -81,6 +81,8 @@
   "exit": "خروج از برنامه",
   "hide_people_you_may_know": "پنهان کردن «افرادی که ممکن است بشناسید»",
   "hide_reels": "پنهان کردن ریلز",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "پنهان کردن نوار کناری پیام رسان",
   "error_page_offline": "فیس‌بوک بارگذاری نشد. اتصال خود را بررسی کنید و دوباره تلاش کنید.",
   "retry": "تلاش دوباره",

--- a/SlimSocial_for_Facebook/assets/lang/fi-FI.json
+++ b/SlimSocial_for_Facebook/assets/lang/fi-FI.json
@@ -81,6 +81,8 @@
   "exit": "Sulje sovellus",
   "hide_people_you_may_know": "Piilota \"Ehkä tunnet nämä\"",
   "hide_reels": "Piilota reelsit",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Piilota Messengerin sivupalkki",
   "error_page_offline": "Facebookia ei voitu ladata. Tarkista yhteytesi ja yritä uudelleen.",
   "retry": "Yritä uudelleen",

--- a/SlimSocial_for_Facebook/assets/lang/fr-FR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fr-FR.json
@@ -81,6 +81,8 @@
   "exit": "Quitter l'application",
   "hide_people_you_may_know": "Masquer « Personnes que vous pourriez connaître »",
   "hide_reels": "Masquer les reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Masquer la barre latérale de Messenger",
   "error_page_offline": "Impossible de charger Facebook. Vérifiez votre connexion et réessayez.",
   "retry": "Réessayer",

--- a/SlimSocial_for_Facebook/assets/lang/ha-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ha-NG.json
@@ -81,6 +81,8 @@
   "exit": "Fita daga manhaja",
   "hide_people_you_may_know": "Ɓoye \"Mutanen da wataƙila ka sani\"",
   "hide_reels": "Ɓoye reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Ɓoye sandar gefen Messenger",
   "error_page_offline": "An kasa loda Facebook. Duba haɗin ka sannan ka sake gwadawa.",
   "retry": "Sake gwadawa",

--- a/SlimSocial_for_Facebook/assets/lang/he-IL.json
+++ b/SlimSocial_for_Facebook/assets/lang/he-IL.json
@@ -81,6 +81,8 @@
   "exit": "יציאה מהאפליקציה",
   "hide_people_you_may_know": "הסתר \"אנשים שאולי אתה מכיר\"",
   "hide_reels": "הסתר Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "הסתר את סרגל הצד של מסרים",
   "error_page_offline": "לא ניתן היה לטעון את פייסבוק. בדוק את החיבור ונסה שוב.",
   "retry": "נסה שוב",

--- a/SlimSocial_for_Facebook/assets/lang/hi-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/hi-IN.json
@@ -81,6 +81,8 @@
   "exit": "ऐप से बाहर निकलें",
   "hide_people_you_may_know": "\"वे लोग जिन्हें आप जानते होंगे\" छिपाएं",
   "hide_reels": "रील्स छिपाएं",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "मैसेंजर साइडबार छिपाएं",
   "error_page_offline": "Facebook लोड नहीं हो सका। अपना कनेक्शन जांचें और फिर से कोशिश करें।",
   "retry": "फिर से कोशिश करें",

--- a/SlimSocial_for_Facebook/assets/lang/hr-HR.json
+++ b/SlimSocial_for_Facebook/assets/lang/hr-HR.json
@@ -81,6 +81,8 @@
   "exit": "Izađi iz aplikacije",
   "hide_people_you_may_know": "Sakrij „Ljudi koje možda poznaješ”",
   "hide_reels": "Sakrij reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Sakrij bočnu traku Messengera",
   "error_page_offline": "Facebook se nije mogao učitati. Provjeri vezu i pokušaj ponovno.",
   "retry": "Pokušaj ponovno",

--- a/SlimSocial_for_Facebook/assets/lang/hu-HU.json
+++ b/SlimSocial_for_Facebook/assets/lang/hu-HU.json
@@ -81,6 +81,8 @@
   "exit": "Kilépés az alkalmazásból",
   "hide_people_you_may_know": "Az „Ismerősnek tűnő emberek” elrejtése",
   "hide_reels": "Reels elrejtése",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "A Messenger oldalsávjának elrejtése",
   "error_page_offline": "A Facebook nem tölthető be. Ellenőrizd a kapcsolatot, és próbáld újra.",
   "retry": "Újrapróbálkozás",

--- a/SlimSocial_for_Facebook/assets/lang/ig-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ig-NG.json
@@ -81,6 +81,8 @@
   "exit": "Pụọ na ngwa",
   "hide_people_you_may_know": "Zoo \"Ndị ị nwere ike ịma\"",
   "hide_reels": "Zoo reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Zoo mpaghara akụkụ Messenger",
   "error_page_offline": "Enweghị ike ibudata Facebook. Lelee njikọ gị wee nwaa ọzọ.",
   "retry": "Nwaa ọzọ",

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -81,6 +81,8 @@
   "exit": "Esci dall'app",
   "hide_people_you_may_know": "Nascondi \"Persone che potresti conoscere\"",
   "hide_reels": "Nascondi i reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Nascondi la barra laterale di Messenger",
   "error_page_offline": "Impossibile caricare Facebook. Controlla la connessione e riprova.",
   "retry": "Riprova",

--- a/SlimSocial_for_Facebook/assets/lang/ja-JP.json
+++ b/SlimSocial_for_Facebook/assets/lang/ja-JP.json
@@ -81,6 +81,8 @@
   "exit": "アプリを終了",
   "hide_people_you_may_know": "「知り合いかも」を非表示にする",
   "hide_reels": "リールを非表示にする",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Messengerのサイドバーを非表示にする",
   "error_page_offline": "Facebookを読み込めませんでした。接続を確認してもう一度お試しください。",
   "retry": "再試行",

--- a/SlimSocial_for_Facebook/assets/lang/ko-KR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ko-KR.json
@@ -81,6 +81,8 @@
   "exit": "앱 종료",
   "hide_people_you_may_know": "\"알 수도 있는 사람\" 가리기",
   "hide_reels": "릴스 가리기",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "메신저 사이드바 가리기",
   "error_page_offline": "Facebook을 불러오지 못했습니다. 연결을 확인한 후 다시 시도하세요.",
   "retry": "다시 시도",

--- a/SlimSocial_for_Facebook/assets/lang/lt-LT.json
+++ b/SlimSocial_for_Facebook/assets/lang/lt-LT.json
@@ -81,6 +81,8 @@
   "exit": "Išeiti iš programėlės",
   "hide_people_you_may_know": "Slėpti „Žmonės, kuriuos galbūt pažįstate“",
   "hide_reels": "Slėpti reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Slėpti Messenger šoninę juostą",
   "error_page_offline": "Nepavyko įkelti Facebook. Patikrinkite ryšį ir bandykite dar kartą.",
   "retry": "Bandyti dar kartą",

--- a/SlimSocial_for_Facebook/assets/lang/lv-LV.json
+++ b/SlimSocial_for_Facebook/assets/lang/lv-LV.json
@@ -81,6 +81,8 @@
   "exit": "Iziet no lietotnes",
   "hide_people_you_may_know": "Paslēpt “Cilvēki, kurus tu varētu pazīt”",
   "hide_reels": "Paslēpt reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Paslēpt Messenger sānjoslu",
   "error_page_offline": "Neizdevās ielādēt Facebook. Pārbaudi savienojumu un mēģini vēlreiz.",
   "retry": "Mēģināt vēlreiz",

--- a/SlimSocial_for_Facebook/assets/lang/ml-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ml-IN.json
@@ -81,6 +81,8 @@
   "exit": "ആപ്പിൽ നിന്ന് പുറത്തുകടക്കുക",
   "hide_people_you_may_know": "\"നിങ്ങൾക്ക് അറിയാവുന്ന ആളുകൾ\" മറയ്ക്കുക",
   "hide_reels": "റീലുകൾ മറയ്ക്കുക",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "മെസ്സേഞ്ചർ സൈഡ്ബാർ മറയ്ക്കുക",
   "error_page_offline": "Facebook ലോഡ് ചെയ്യാനായില്ല. കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക.",
   "retry": "വീണ്ടും ശ്രമിക്കുക",

--- a/SlimSocial_for_Facebook/assets/lang/mr-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/mr-IN.json
@@ -81,6 +81,8 @@
   "exit": "अ‍ॅपमधून बाहेर पडा",
   "hide_people_you_may_know": "\"तुम्हाला माहीत असतील अशी लोक\" लपवा",
   "hide_reels": "रील्स लपवा",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "मेसेंजर साइडबार लपवा",
   "error_page_offline": "Facebook लोड होऊ शकले नाही. तुमचे कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.",
   "retry": "पुन्हा प्रयत्न करा",

--- a/SlimSocial_for_Facebook/assets/lang/nl-NL.json
+++ b/SlimSocial_for_Facebook/assets/lang/nl-NL.json
@@ -81,6 +81,8 @@
   "exit": "App afsluiten",
   "hide_people_you_may_know": "Verberg \"Mensen die je misschien kent\"",
   "hide_reels": "Verberg reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Verberg de Messenger-zijbalk",
   "error_page_offline": "Facebook kon niet worden geladen. Controleer je verbinding en probeer het opnieuw.",
   "retry": "Opnieuw proberen",

--- a/SlimSocial_for_Facebook/assets/lang/no-NO.json
+++ b/SlimSocial_for_Facebook/assets/lang/no-NO.json
@@ -81,6 +81,8 @@
   "exit": "Avslutt appen",
   "hide_people_you_may_know": "Skjul \"Personer du kanskje kjenner\"",
   "hide_reels": "Skjul reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Skjul Messenger-sidepanelet",
   "error_page_offline": "Facebook kunne ikke lastes inn. Sjekk tilkoblingen og prøv igjen.",
   "retry": "Prøv igjen",

--- a/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
@@ -81,6 +81,8 @@
   "exit": "Comot from app",
   "hide_people_you_may_know": "Hide \"People wey you fit know\"",
   "hide_reels": "Hide reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Hide Messenger sidebar",
   "error_page_offline": "We no fit load Facebook. Check your connection make you try again.",
   "retry": "Try again",

--- a/SlimSocial_for_Facebook/assets/lang/pl-PL.json
+++ b/SlimSocial_for_Facebook/assets/lang/pl-PL.json
@@ -81,6 +81,8 @@
   "exit": "Wyjdź z aplikacji",
   "hide_people_you_may_know": "Ukryj „Osoby, które możesz znać”",
   "hide_reels": "Ukryj reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Ukryj panel boczny Messengera",
   "error_page_offline": "Nie udało się załadować Facebooka. Sprawdź połączenie i spróbuj ponownie.",
   "retry": "Spróbuj ponownie",

--- a/SlimSocial_for_Facebook/assets/lang/pt-BR.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-BR.json
@@ -81,6 +81,8 @@
   "exit": "Sair do aplicativo",
   "hide_people_you_may_know": "Ocultar \"Pessoas que você talvez conheça\"",
   "hide_reels": "Ocultar reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Ocultar a barra lateral do Messenger",
   "error_page_offline": "Não foi possível carregar o Facebook. Verifique sua conexão e tente novamente.",
   "retry": "Tentar novamente",

--- a/SlimSocial_for_Facebook/assets/lang/pt-PT.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-PT.json
@@ -81,6 +81,8 @@
   "exit": "Sair da aplicação",
   "hide_people_you_may_know": "Ocultar \"Pessoas que talvez conheças\"",
   "hide_reels": "Ocultar reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Ocultar a barra lateral do Messenger",
   "error_page_offline": "Não foi possível carregar o Facebook. Verifica a tua ligação e tenta novamente.",
   "retry": "Tentar novamente",

--- a/SlimSocial_for_Facebook/assets/lang/ro-RO.json
+++ b/SlimSocial_for_Facebook/assets/lang/ro-RO.json
@@ -81,6 +81,8 @@
   "exit": "Ieși din aplicație",
   "hide_people_you_may_know": "Ascundeți „Persoane pe care le-ați putea cunoaște”",
   "hide_reels": "Ascundeți reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Ascundeți bara laterală Messenger",
   "error_page_offline": "Facebook nu a putut fi încărcat. Verificați conexiunea și încercați din nou.",
   "retry": "Reîncercați",

--- a/SlimSocial_for_Facebook/assets/lang/ru-RU.json
+++ b/SlimSocial_for_Facebook/assets/lang/ru-RU.json
@@ -81,6 +81,8 @@
   "exit": "Выйти из приложения",
   "hide_people_you_may_know": "Скрыть «Возможные друзья»",
   "hide_reels": "Скрыть Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Скрыть боковую панель Messenger",
   "error_page_offline": "Не удалось загрузить Facebook. Проверьте подключение и повторите попытку.",
   "retry": "Повторить",

--- a/SlimSocial_for_Facebook/assets/lang/sk-SK.json
+++ b/SlimSocial_for_Facebook/assets/lang/sk-SK.json
@@ -81,6 +81,8 @@
   "exit": "Ukončiť aplikáciu",
   "hide_people_you_may_know": "Skryť „Ľudia, ktorých možno poznáte“",
   "hide_reels": "Skryť reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Skryť bočný panel Messengera",
   "error_page_offline": "Facebook sa nepodarilo načítať. Skontrolujte pripojenie a skúste to znova.",
   "retry": "Skúsiť znova",

--- a/SlimSocial_for_Facebook/assets/lang/sl-SI.json
+++ b/SlimSocial_for_Facebook/assets/lang/sl-SI.json
@@ -81,6 +81,8 @@
   "exit": "Izhod iz aplikacije",
   "hide_people_you_may_know": "Skrij »Ljudje, ki jih morda poznaš«",
   "hide_reels": "Skrij reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Skrij stransko vrstico Messengerja",
   "error_page_offline": "Facebooka ni bilo mogoče naložiti. Preveri povezavo in poskusi znova.",
   "retry": "Poskusi znova",

--- a/SlimSocial_for_Facebook/assets/lang/sr-SP.json
+++ b/SlimSocial_for_Facebook/assets/lang/sr-SP.json
@@ -81,6 +81,8 @@
   "exit": "Izađi iz aplikacije",
   "hide_people_you_may_know": "Sakrij „Ljudi koje možda poznaješ”",
   "hide_reels": "Sakrij reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Sakrij bočnu traku Messengera",
   "error_page_offline": "Facebook nije mogao da se učita. Proveri vezu i pokušaj ponovo.",
   "retry": "Pokušaj ponovo",

--- a/SlimSocial_for_Facebook/assets/lang/sv-SE.json
+++ b/SlimSocial_for_Facebook/assets/lang/sv-SE.json
@@ -81,6 +81,8 @@
   "exit": "Avsluta appen",
   "hide_people_you_may_know": "Dölj \"Personer du kanske känner\"",
   "hide_reels": "Dölj reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Dölj Messengers sidofält",
   "error_page_offline": "Facebook kunde inte läsas in. Kontrollera din anslutning och försök igen.",
   "retry": "Försök igen",

--- a/SlimSocial_for_Facebook/assets/lang/ta-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ta-IN.json
@@ -81,6 +81,8 @@
   "exit": "செயலியிலிருந்து வெளியேறு",
   "hide_people_you_may_know": "\"நீங்கள் அறிந்திருக்கக்கூடிய நபர்கள்\" மறைக்கவும்",
   "hide_reels": "ரீல்களை மறைக்கவும்",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "மெசஞ்சர் பக்கப்பட்டியை மறைக்கவும்",
   "error_page_offline": "Facebook ஐ ஏற்ற முடியவில்லை. இணைப்பைச் சரிபார்த்து மீண்டும் முயலவும்.",
   "retry": "மீண்டும் முயலவும்",

--- a/SlimSocial_for_Facebook/assets/lang/te-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/te-IN.json
@@ -81,6 +81,8 @@
   "exit": "యాప్ నుండి నిష్క్రమించండి",
   "hide_people_you_may_know": "\"మీకు తెలిసి ఉండవచ్చు\" దాచు",
   "hide_reels": "రీల్స్‌ను దాచు",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "మెస్సేంజర్ సైడ్‌బార్‌ను దాచు",
   "error_page_offline": "Facebook లోడ్ కాలేదు. మీ కనెక్షన్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి.",
   "retry": "మళ్లీ ప్రయత్నించండి",

--- a/SlimSocial_for_Facebook/assets/lang/th-TH.json
+++ b/SlimSocial_for_Facebook/assets/lang/th-TH.json
@@ -81,6 +81,8 @@
   "exit": "ออกจากแอป",
   "hide_people_you_may_know": "ซ่อน \"คนที่คุณอาจรู้จัก\"",
   "hide_reels": "ซ่อน Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "ซ่อนแถบด้านข้าง Messenger",
   "error_page_offline": "โหลด Facebook ไม่สำเร็จ โปรดตรวจสอบการเชื่อมต่อแล้วลองอีกครั้ง",
   "retry": "ลองอีกครั้ง",

--- a/SlimSocial_for_Facebook/assets/lang/tr-TR.json
+++ b/SlimSocial_for_Facebook/assets/lang/tr-TR.json
@@ -81,6 +81,8 @@
   "exit": "Uygulamadan çık",
   "hide_people_you_may_know": "\"Tanıyor olabileceğin kişiler\"i gizle",
   "hide_reels": "Reels'i gizle",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Messenger kenar çubuğunu gizle",
   "error_page_offline": "Facebook yüklenemedi. Bağlantını kontrol edip tekrar dene.",
   "retry": "Tekrar dene",

--- a/SlimSocial_for_Facebook/assets/lang/uk-UA.json
+++ b/SlimSocial_for_Facebook/assets/lang/uk-UA.json
@@ -81,6 +81,8 @@
   "exit": "Вийти з додатка",
   "hide_people_you_may_know": "Приховувати «Люди, яких ви можете знати»",
   "hide_reels": "Приховувати Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Приховувати бічну панель Messenger",
   "error_page_offline": "Не вдалося завантажити Facebook. Перевірте з'єднання та повторіть спробу.",
   "retry": "Повторити",

--- a/SlimSocial_for_Facebook/assets/lang/ur-PK.json
+++ b/SlimSocial_for_Facebook/assets/lang/ur-PK.json
@@ -81,6 +81,8 @@
   "exit": "ایپ سے باہر نکلیں",
   "hide_people_you_may_know": "\"وہ لوگ جنہیں آپ جانتے ہوں گے\" چھپائیں",
   "hide_reels": "ریلز چھپائیں",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "میسنجر سائیڈبار چھپائیں",
   "error_page_offline": "فیس بک لوڈ نہیں ہو سکا۔ اپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔",
   "retry": "دوبارہ کوشش کریں",

--- a/SlimSocial_for_Facebook/assets/lang/vi-VN.json
+++ b/SlimSocial_for_Facebook/assets/lang/vi-VN.json
@@ -81,6 +81,8 @@
   "exit": "Thoát ứng dụng",
   "hide_people_you_may_know": "Ẩn \"Những người bạn có thể biết\"",
   "hide_reels": "Ẩn Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Ẩn thanh bên Messenger",
   "error_page_offline": "Không thể tải Facebook. Hãy kiểm tra kết nối và thử lại.",
   "retry": "Thử lại",

--- a/SlimSocial_for_Facebook/assets/lang/yo-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/yo-NG.json
@@ -81,6 +81,8 @@
   "exit": "Jáde nínú ìṣàmúlò",
   "hide_people_you_may_know": "Fi \"Àwọn ènìyàn tí o lè mọ̀\" pamọ́",
   "hide_reels": "Fi àwọn reels pamọ́",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "Fi pẹpẹ ẹ̀gbẹ́ Messenger pamọ́",
   "error_page_offline": "A kò lè gbé Facebook wọlé. Ṣàyẹ̀wò ìsopọ̀ rẹ kí o sì gbìyànjú lẹ́ẹ̀kansí.",
   "retry": "Gbìyànjú lẹ́ẹ̀kansí",

--- a/SlimSocial_for_Facebook/assets/lang/zh-CN.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-CN.json
@@ -81,6 +81,8 @@
   "exit": "退出应用",
   "hide_people_you_may_know": "隐藏“你可能认识的人”",
   "hide_reels": "隐藏 Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "隐藏 Messenger 侧边栏",
   "error_page_offline": "无法加载 Facebook。请检查网络连接后重试。",
   "retry": "重试",

--- a/SlimSocial_for_Facebook/assets/lang/zh-TW.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-TW.json
@@ -81,6 +81,8 @@
   "exit": "結束應用程式",
   "hide_people_you_may_know": "隱藏「你可能認識的人」",
   "hide_reels": "隱藏 Reels",
+  "hide_feed": "Hide the home feed",
+  "hide_feed_desc": "No posts on the home page. Notifications, groups, profiles and Messenger still work",
   "hide_messenger_sidebar": "隱藏 Messenger 側邊欄",
   "error_page_offline": "無法載入 Facebook。請檢查網路連線後重試。",
   "retry": "重試",

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -196,6 +196,25 @@ class _HomePageState extends ConsumerState<HomePage> {
             );
             if (!mounted) return;
 
+            //the feed rule is gated on a class this script puts on <html>, and
+            //not shipped as a plain rule: Facebook navigates in-page, so a
+            //sheet injected on the home page is still there once the reader
+            //taps into a group, and the posts there would go too
+            if (CustomCss.hideFeedCss.isEnabled()) {
+              await runIsolatedJs(
+                'feed gate',
+                () => _controller.runJavaScript(
+                  CustomJs.whenDomReady(
+                    CustomJs.feedGateFunc(
+                      hosts: kFeedGateHosts,
+                      paths: kFeedPaths,
+                    ),
+                  ),
+                ),
+              );
+              if (!mounted) return;
+            }
+
             //before the dark theme, because unlocking the viewport reflows the
             //page and the theme script reads colours back out of it
             await runIsolatedJs(

--- a/SlimSocial_for_Facebook/lib/screens/settings_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/settings_page.dart
@@ -318,6 +318,20 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 SettingsTile.switchTile(
                   onToggle: (value) {
                     setState(() {
+                      sp.setBool(CustomCss.hideFeedCss.key, value);
+                    });
+                    ref.invalidate(fbWebViewProvider);
+                  },
+                  initialValue: CustomCss.hideFeedCss.isEnabled(),
+                  title: Text(CustomCss.hideFeedCss.key.tr()),
+                  //spelled out because the row hides the main screen of the app,
+                  //and the title alone does not say what is left
+                  description: Text('hide_feed_desc'.tr()),
+                  leading: const Icon(Icons.newspaper_outlined),
+                ),
+                SettingsTile.switchTile(
+                  onToggle: (value) {
+                    setState(() {
                       sp.setBool(CustomCss.centerTextPostsCss.key, value);
                     });
                     ref.invalidate(fbWebViewProvider);

--- a/SlimSocial_for_Facebook/lib/utils/css.dart
+++ b/SlimSocial_for_Facebook/lib/utils/css.dart
@@ -21,6 +21,7 @@ class CustomCss {
     addSpaceBetweenPostsCss,
     hideStoriesCss,
     hideReelsCss,
+    hideFeedCss,
     fixedBarCss,
     //hideAdsAndPeopleYouMayKnowCss,
     darkThemeCss,
@@ -165,6 +166,27 @@ class CustomCss {
     code: 'div[data-type="vscroller"] > div:not([data-tracking-duration-id]):has([aria-label*="reel" i]), '
         'div[data-tracking-duration-id]:has([data-is-reels="true"]) '
         '{ display: none !important; }',
+  );
+
+  /// Hides the posts on the home feed, and only there.
+  ///
+  /// For the reader who wants Facebook for notifications, groups and Messenger
+  /// without the feed to scroll (#213). Only the posts go: the top bar, the
+  /// tabs and every other page are untouched.
+  ///
+  /// The `html.slim-hide-feed` gate is what makes "only there" true. The
+  /// selector on its own — a direct child of the feed vscroller carrying
+  /// `data-tracking-duration-id` — matches posts in groups and on profiles as
+  /// well, and injecting the sheet only on the home page does not help:
+  /// Facebook navigates in-page with pushState, so the stylesheet injected on
+  /// the feed is still in the document once the reader taps into a group. So
+  /// the class is put on and taken off `<html>` by `CustomJs.feedGateFunc`,
+  /// which re-reads `location` as the address changes.
+  static MyCss hideFeedCss = MyCss(
+    key: 'hide_feed',
+    description: 'Hide the home feed',
+    code: 'html.slim-hide-feed div[data-type="vscroller"] > '
+        'div[data-tracking-duration-id] { display: none !important; }',
   );
 
   static MyCss fixedBarCss = MyCss(

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -2,6 +2,20 @@ import 'dart:convert';
 
 import 'package:slimsocial_for_facebook/utils/ad_filter.dart';
 
+/// Hosts the feed gate treats as the home feed.
+///
+/// Deliberately wider than [kFeedHosts], which stays narrow because a wrong
+/// host there turns a once-per-launch diagnostic into permanent noise. Here a
+/// wrong host costs one unused class on a page with no feed to hide, while a
+/// missing one costs the whole feature: signed-in home is `touch.facebook.com`
+/// for this app, but a redirect to the `m.` or `www.` host would otherwise
+/// leave the gate off and every post on screen.
+const List<String> kFeedGateHosts = [
+  ...kFeedHosts,
+  'm.facebook.com',
+  'www.facebook.com',
+];
+
 class CustomJs {
   /// Builds JavaScript that appends [css] to the document in a `<style>` tag.
   ///
@@ -331,6 +345,51 @@ class CustomJs {
       .catch(function (e) {});
   } catch (e) {}
 })(${jsonEncode(blobUrl)}, ${jsonEncode(channelName)});
+''';
+  }
+
+  /// Builds JavaScript that marks `<html>` while the reader is on the feed.
+  ///
+  /// The switch behind `CustomCss.hideFeedCss`. That stylesheet hides every
+  /// post it can see, so something has to say when it may see any, and the
+  /// answer cannot be "inject it only on the home page": Facebook is a
+  /// single-page app, and a sheet injected on the feed is still in the document
+  /// after the reader taps into a group. The class goes on and comes off as the
+  /// address changes, so the rule applies to the feed and to nothing else.
+  ///
+  /// pushState fires no event, and monkey-patching `history` to get one is a
+  /// large thing to do to another site's app for a boolean. So `location` is
+  /// re-read on `popstate` and on a half-second interval instead — a string
+  /// comparison twice a second, next to nothing beside the page itself.
+  ///
+  /// [hosts] and [paths] are put in by [jsonEncode], and the whole thing is
+  /// guarded by `window.__slimFeedGate` so re-injection on every navigation
+  /// leaves one interval behind rather than one per page. Everything is
+  /// swallowed by a try/catch for the same reason as [unlockZoomFunc].
+  static String feedGateFunc({
+    required List<String> hosts,
+    required List<String> paths,
+  }) {
+    return '''
+(function () {
+  try {
+    if (window.__slimFeedGate) return;
+    window.__slimFeedGate = true;
+
+    var HOSTS = ${jsonEncode(hosts)};
+    var PATHS = ${jsonEncode(paths)};
+
+    function update() {
+      var on = HOSTS.indexOf(location.hostname) !== -1 &&
+        PATHS.indexOf(location.pathname) !== -1;
+      document.documentElement.classList.toggle('slim-hide-feed', on);
+    }
+
+    update();
+    window.addEventListener('popstate', update);
+    setInterval(update, 500);
+  } catch (e) {}
+})();
 ''';
   }
 

--- a/SlimSocial_for_Facebook/test/lang_test.dart
+++ b/SlimSocial_for_Facebook/test/lang_test.dart
@@ -50,6 +50,10 @@ void main() {
         'dark_theme',
         'fixed_bar',
         'hide_stories',
+        // The feed toggle turns off the app's main screen, so both its label
+        // and the line saying what still works have to be there.
+        'hide_feed',
+        'hide_feed_desc',
         'center_text',
         'add_space',
         'enable_messenger',

--- a/SlimSocial_for_Facebook/test/utils/css_build_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_build_test.dart
@@ -60,6 +60,17 @@ void main() {
       expect(css, isNot(contains('};')));
     });
 
+    test('carries the feed rule when the feed toggle is on', () async {
+      // The toggle is only a stored bool until this list picks it up, and the
+      // class gate the rule depends on is injected separately.
+      await withPrefs({CustomCss.hideFeedCss.key: true});
+
+      expect(
+        CustomCss.buildFacebookCss(null),
+        contains(CustomCss.hideFeedCss.code),
+      );
+    });
+
     test('handles a null and a blank user stylesheet', () {
       expect(CustomCss.buildFacebookCss(null), isNotNull);
       expect(CustomCss.buildFacebookCss(''), isNot(contains('  ')));

--- a/SlimSocial_for_Facebook/test/utils/css_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/css_test.dart
@@ -344,6 +344,46 @@ article {
       expect(keys, contains('hide_reels'));
     });
 
+    test('the feed toggle is offered too', () {
+      expect(CustomCss.hideFeedCss.key, 'hide_feed');
+      expect(CustomCss.cssList.map((c) => c.key), contains('hide_feed'));
+    });
+
+    test('the feed rule only applies behind the class gate', () {
+      // Without the gate this rule hides posts in groups and on profiles as
+      // well: Facebook navigates in-page, so a sheet injected on the home page
+      // is still in the document afterwards. Every selector in the rule has to
+      // carry the class, or the scoping is a fiction.
+      final selectors = CustomCss.hideFeedCss.code
+          .split('{')
+          .first
+          .split(',')
+          .map((s) => s.trim())
+          .where((s) => s.isNotEmpty);
+
+      expect(selectors, isNotEmpty);
+      for (final selector in selectors) {
+        expect(selector, startsWith('html.slim-hide-feed '), reason: selector);
+      }
+    });
+
+    test('the feed rule hides posts rather than the page around them', () {
+      // The top bar, the tabs and the notification jewel are the reason the
+      // reader keeps the app, so the rule targets the post containers only.
+      expect(
+        CustomCss.hideFeedCss.code,
+        contains('div[data-type="vscroller"] > div[data-tracking-duration-id]'),
+      );
+      expect(CustomCss.hideFeedCss.code, isNot(contains('body')));
+      expect(CustomCss.hideFeedCss.code, isNot(contains('#root')));
+      expect(CustomCss.hideFeedCss.code, isNot(contains('#header')));
+    });
+
+    test('the feed toggle ships switched off', () {
+      // It blanks the app's main screen, so nobody gets it without asking.
+      expect(CustomCss.hideFeedCss.isEnabled(), isFalse);
+    });
+
     test('neither rule hides the whole feed', () {
       // A selector that matches an ancestor of the feed would blank the page.
       for (final css in [CustomCss.hideStoriesCss, CustomCss.hideReelsCss]) {

--- a/SlimSocial_for_Facebook/test/utils/js_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/js_test.dart
@@ -386,4 +386,60 @@ void main() {
       expect(js, contains('} catch (e) {}'));
     });
   });
+
+  group('CustomJs.feedGateFunc', () {
+    final js = CustomJs.feedGateFunc(hosts: kFeedGateHosts, paths: kFeedPaths);
+
+    test('installs itself once, guarded by a global', () {
+      // Injection runs on every page start, and the gate leaves an interval
+      // and a listener behind: without the guard each navigation stacks
+      // another one on the same page.
+      expect(js, contains('window.__slimFeedGate'));
+      expect(js, contains('if (window.__slimFeedGate) return;'));
+    });
+
+    test('toggles the class the stylesheet is scoped to', () {
+      expect(js, contains('slim-hide-feed'));
+      expect(js, contains('document.documentElement.classList.toggle'));
+    });
+
+    test('carries the hosts and the paths it was given', () {
+      for (final host in kFeedGateHosts) {
+        expect(js, contains(jsonEncode(host)), reason: host);
+      }
+      for (final path in kFeedPaths) {
+        expect(js, contains(jsonEncode(path)), reason: path);
+      }
+    });
+
+    test('covers the hosts a redirect can land on', () {
+      // Signed-in home is touch.facebook.com, but a redirect to either of the
+      // others would leave the gate off and every post on screen.
+      expect(kFeedGateHosts, containsAll(kFeedHosts));
+      expect(kFeedGateHosts, contains('m.facebook.com'));
+      expect(kFeedGateHosts, contains('www.facebook.com'));
+    });
+
+    test('decides on both the host and the path', () {
+      // Path alone would gate on `/` of any site the webview opens; host alone
+      // would keep the class on inside groups and profiles.
+      expect(js, contains('location.hostname'));
+      expect(js, contains('location.pathname'));
+      expect(js, contains('&&'));
+    });
+
+    test('re-runs as the address changes in-page', () {
+      // pushState fires no event, so a half-second re-read of location is what
+      // catches a navigation into a group and takes the class back off.
+      expect(js, contains("addEventListener('popstate', update)"));
+      expect(js, contains('setInterval(update, 500)'));
+    });
+
+    test('runs as a self-invoking function that swallows its own failure', () {
+      expect(js.trim(), startsWith('(function () {'));
+      expect(js.trim(), endsWith('})();'));
+      expect(js, contains('try {'));
+      expect(js, contains('} catch (e) {}'));
+    });
+  });
 }


### PR DESCRIPTION
Closes #213

Facebook for notifications, groups and Messenger, without the feed to scroll. A new **Style** toggle, *Hide the home feed*, off by default.

## How it works

The posts on the feed are the direct `div[data-tracking-duration-id]` children of the feed `div[data-type="vscroller"]` — the same containers the ad filter and the tray rules already key off. So the rule itself is one line:

```css
html.slim-hide-feed div[data-type="vscroller"] > div[data-tracking-duration-id] { display: none !important; }
```

The `html.slim-hide-feed` gate is the load-bearing part. That selector without the gate also matches posts in groups and on profiles, and injecting the stylesheet only on the home page does not fix it: Facebook navigates in-page with pushState, so the sheet injected on the feed is still in the document once the reader taps into a group, and the posts there would go too.

So a small script (`CustomJs.feedGateFunc`) puts the class on `<html>` and takes it back off as the address changes:

- on when `location.hostname` is one of the feed hosts **and** `location.pathname` is `/` or `/home.php` (`kFeedPaths`);
- re-read on `popstate` and on a 500 ms interval. pushState fires no event, and monkey-patching `history` is a large thing to do to another site's app for one boolean — a string comparison twice a second costs nothing beside the page itself;
- idempotent behind `window.__slimFeedGate`, so re-injection on every navigation leaves one interval rather than one per page, and wrapped in try/catch like the other injected scripts;
- injected only when the toggle is on.

Hosts come from a new `kFeedGateHosts`, which is `kFeedHosts` plus `m.facebook.com` and `www.facebook.com`. `kFeedHosts` itself stays narrow on purpose (its doc comment explains why — a wrong host there turns a diagnostic into permanent noise); here a missing host would cost the whole feature if the page ever redirected off the touch host.

Everything else is untouched: top bar, tabs, notifications, groups, profiles, Messenger.

## Tests

`flutter test test/utils/js_test.dart test/utils/css_test.dart test/utils/css_build_test.dart test/lang_test.dart` — 169 pass.

New cases: the gate installs once behind its global, toggles `slim-hide-feed`, embeds the hosts and paths it was given, covers the redirect hosts, decides on host **and** path, and re-runs on `popstate` plus the interval. On the CSS side: every selector in the rule starts with the class gate, the rule targets post containers and never `body` / `#root` / `#header`, the toggle ships off, and it reaches the built Facebook stylesheet when switched on.

`flutter analyze`: 52 issues, all pre-existing infos, none in the new code.

## Caveats

- **Not device tested.** The selectors are the ones already measured against the live touch layout in this repo, and the gate logic is covered by unit tests, but nobody has watched this work on a phone.
- The stories tray and the reels carousel are **separate existing toggles** (*Hide stories*, *Hide reels*). This one hides the posts; a reader who wants none of the feed at all turns on all three.
- The 500 ms poll is a deliberate trade against patching `history.pushState`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)