### PR TITLE
fix: save photos when Facebook's Save starts a download

### DIFF
--- a/SlimSocial_for_Facebook/assets/lang/_.json
+++ b/SlimSocial_for_Facebook/assets/lang/_.json
@@ -52,6 +52,7 @@
   "Image saved to {}": "Image saved to {}",
   "sharing": "Sharing",
   "downloading": "Downloading",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Custom proxy",
   "error_proxy with {}:{}": "Error with proxy {}:{}",
   "error_proxy": "Error with proxy",

--- a/SlimSocial_for_Facebook/assets/lang/af-ZA.json
+++ b/SlimSocial_for_Facebook/assets/lang/af-ZA.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "Beeld gestoor in {}",
   "sharing": "Deel tans",
   "downloading": "Laai tans af",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Word 'n held",
   "custom_proxy": "Pasgemaakte proxy",
   "error_proxy with {}:{}": "Fout met proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/ar-AR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ar-AR.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "تم حفظ الصورة في {}",
   "sharing": "مشاركة",
   "downloading": "تحميل",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "بروكسي مخصص",
   "error_proxy with {}:{}": "خطأ في البروكسي {}:{}",
   "error_proxy": "خطأ في البروكسي",

--- a/SlimSocial_for_Facebook/assets/lang/bg-BG.json
+++ b/SlimSocial_for_Facebook/assets/lang/bg-BG.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Картинката е записана в {}",
   "sharing": "Споделяне",
   "downloading": "Изтегляне",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Персонализиран прокси",
   "error_proxy with {}:{}": "Грешка с прокси {}:{}",
   "error_proxy": "Грешка с прокси",

--- a/SlimSocial_for_Facebook/assets/lang/bn-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/bn-IN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "চিত্র {} সংরক্ষিত হয়েছে",
   "sharing": "ভাগাভাগি করা হচ্ছে",
   "downloading": "ডাউনলোড করা হচ্ছে",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "কাস্টম প্রক্সি",
   "error_proxy with {}:{}": "{}:{} প্রক্সিতে সমস্যা হচ্ছে",
   "error_proxy": "প্রক্সিতে সমস্যা হচ্ছে",

--- a/SlimSocial_for_Facebook/assets/lang/ca-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/ca-ES.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "Imatge desada a {}",
   "sharing": "S'està compartint",
   "downloading": "S'està baixant",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Converteix-te en un heroi",
   "custom_proxy": "Proxy personalitzat",
   "error_proxy with {}:{}": "Error amb el proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
+++ b/SlimSocial_for_Facebook/assets/lang/cs-CZ.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Obrázek uložen do {}",
   "sharing": "Sdílení",
   "downloading": "Stahuji",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Vlastní proxy",
   "error_proxy with {}:{}": "Chyba s proxy {}:{}",
   "error_proxy": "Chyba s proxy",

--- a/SlimSocial_for_Facebook/assets/lang/da-DK.json
+++ b/SlimSocial_for_Facebook/assets/lang/da-DK.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Billede gemt i {}",
   "sharing": "Deling",
   "downloading": "Downloader",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Brugerdefineret proxy",
   "error_proxy with {}:{}": "Fejl med proxy {}:{}",
   "error_proxy": "Fejl med proxy",

--- a/SlimSocial_for_Facebook/assets/lang/de-DE.json
+++ b/SlimSocial_for_Facebook/assets/lang/de-DE.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Bild wurde unter {} gespeichert",
   "sharing": "Teilen",
   "downloading": "Herunterladen",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Benutzerdefiniertes Proxy",
   "error_proxy with {}:{}": "Fehler mit Proxy {}:{}",
   "error_proxy": "Fehler mit Proxy",

--- a/SlimSocial_for_Facebook/assets/lang/el-GR.json
+++ b/SlimSocial_for_Facebook/assets/lang/el-GR.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "Η εικόνα αποθηκεύτηκε στο {}",
   "sharing": "Κοινοποίηση",
   "downloading": "Λήψη",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Γίνε ήρωας",
   "custom_proxy": "Προσαρμοσμένος διακομιστής μεσολάβησης",
   "error_proxy with {}:{}": "Σφάλμα με τον διακομιστή μεσολάβησης {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/en-US.json
+++ b/SlimSocial_for_Facebook/assets/lang/en-US.json
@@ -56,6 +56,7 @@
   "Image saved to {}": "Image saved to {}",
   "sharing": "Sharing",
   "downloading": "Downloading",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Become a hero",
   "custom_proxy": "Custom proxy",
   "error_proxy with {}:{}": "Error with proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/es-ES.json
+++ b/SlimSocial_for_Facebook/assets/lang/es-ES.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Imagen guardada en {}",
   "sharing": "Compartiendo",
   "downloading": "Descargando",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Proxy personalizado",
   "error_proxy with {}:{}": "Error con proxy {}:{}",
   "error_proxy": "Error con proxy",

--- a/SlimSocial_for_Facebook/assets/lang/et-EE.json
+++ b/SlimSocial_for_Facebook/assets/lang/et-EE.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Pilt on salvestatud: {}",
   "sharing": "Jagamine",
   "downloading": "Laen alla",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Kohandatud proksü",
   "error_proxy with {}:{}": "Viga proksüga {}:{}",
   "error_proxy": "Viga proksüga",

--- a/SlimSocial_for_Facebook/assets/lang/fa-IR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fa-IR.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "تصویر در {} ذخیره شد",
   "sharing": "اشتراک‌گذاری",
   "downloading": "دریافت",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "پروکسی اختصاصی",
   "error_proxy with {}:{}": "خطا در پروکسی با {}:{}",
   "error_proxy": "خطا در پروکسی",

--- a/SlimSocial_for_Facebook/assets/lang/fi-FI.json
+++ b/SlimSocial_for_Facebook/assets/lang/fi-FI.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Kuva tallennettu sijaintiin {}",
   "sharing": "Jakaminen",
   "downloading": "Lataus",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Mukautettu välityspalvelin",
   "error_proxy with {}:{}": "Virhe välityspalvelimessa {}:{}",
   "error_proxy": "Virhe välityspalvelimessa",

--- a/SlimSocial_for_Facebook/assets/lang/fr-FR.json
+++ b/SlimSocial_for_Facebook/assets/lang/fr-FR.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Image enregistrée sous le nom {}",
   "sharing": "Partage",
   "downloading": "Téléchargement",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Proxy personnalisé",
   "error_proxy with {}:{}": "Erreur avec le proxy {}:{}",
   "error_proxy": "Erreur avec le proxy",

--- a/SlimSocial_for_Facebook/assets/lang/ha-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ha-NG.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "An adana hoto a {}",
   "sharing": "Ana rabawa",
   "downloading": "Ana saukewa",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Zama jarumi",
   "custom_proxy": "Proxy na musamman",
   "error_proxy with {}:{}": "Kuskure da proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/he-IL.json
+++ b/SlimSocial_for_Facebook/assets/lang/he-IL.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "תמונה נשמרה ב{}",
   "sharing": "משותף",
   "downloading": "מוריד",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "פרוקסי מותאם אישית",
   "error_proxy with {}:{}": "שגיאת פרוקסי עם {}:{}",
   "error_proxy": "שגיאת פרוקסי",

--- a/SlimSocial_for_Facebook/assets/lang/hi-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/hi-IN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "छवि {} में सहेजी गई",
   "sharing": "साझा करना",
   "downloading": "डाउनलोड हो रहा है",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "कस्टम प्रॉक्सी",
   "error_proxy with {}:{}": "{}:{} के साथ प्रॉक्सी में त्रुटि",
   "error_proxy": "प्रॉक्सी में त्रुटि",

--- a/SlimSocial_for_Facebook/assets/lang/hr-HR.json
+++ b/SlimSocial_for_Facebook/assets/lang/hr-HR.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Slika spremljena u {}",
   "sharing": "Dijeljenje",
   "downloading": "Preuzimanje",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Prilagođeni proxy poslužitelj",
   "error_proxy with {}:{}": "Greška s proxy poslužiteljem {}:{}",
   "error_proxy": "Greška s proxy poslužiteljem",

--- a/SlimSocial_for_Facebook/assets/lang/hu-HU.json
+++ b/SlimSocial_for_Facebook/assets/lang/hu-HU.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Kép mentve a {} helyre",
   "sharing": "Megosztás",
   "downloading": "Letöltés",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Egyedi proxy",
   "error_proxy with {}:{}": "Hiba a proxy használatakor {}:{}",
   "error_proxy": "Hiba a proxy használatakor",

--- a/SlimSocial_for_Facebook/assets/lang/ig-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/ig-NG.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "Echekwara foto na {}",
   "sharing": "Na-ekesa",
   "downloading": "Na-ebudata",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Bụrụ dike",
   "custom_proxy": "Proxy nke gị",
   "error_proxy with {}:{}": "Njehie na proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/it-IT.json
+++ b/SlimSocial_for_Facebook/assets/lang/it-IT.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Immagine salvata in {}",
   "sharing": "Condivisione",
   "downloading": "Download",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Proxy personalizzato",
   "error_proxy with {}:{}": "Errore con il proxy {}:{}",
   "error_proxy": "Errore con il proxy",

--- a/SlimSocial_for_Facebook/assets/lang/ja-JP.json
+++ b/SlimSocial_for_Facebook/assets/lang/ja-JP.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "画像が{}に保存されました",
   "sharing": "共有中",
   "downloading": "ダウンロード中",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "カスタムプロキシ",
   "error_proxy with {}:{}": "{}:{} でのプロキシエラー",
   "error_proxy": "プロキシエラー",

--- a/SlimSocial_for_Facebook/assets/lang/ko-KR.json
+++ b/SlimSocial_for_Facebook/assets/lang/ko-KR.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "이미지가 {}에 저장되었습니다.",
   "sharing": "공유 중",
   "downloading": "다운로드 중",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "사용자 정의 프록시",
   "error_proxy with {}:{}": "{}:{} 프록시 오류",
   "error_proxy": "프록시 오류",

--- a/SlimSocial_for_Facebook/assets/lang/lt-LT.json
+++ b/SlimSocial_for_Facebook/assets/lang/lt-LT.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Paveikslėlis išsaugotas kaip {}",
   "sharing": "Dalijimasis",
   "downloading": "Atsisiunčiama",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Pasirinktinis serveris",
   "error_proxy with {}:{}": "Klaida su serveriu {}:{}",
   "error_proxy": "Klaida su serveriu",

--- a/SlimSocial_for_Facebook/assets/lang/lv-LV.json
+++ b/SlimSocial_for_Facebook/assets/lang/lv-LV.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Attēls saglabāts {}",
   "sharing": "Dalīšanās",
   "downloading": "Lejupielādēšana",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Pielāgots proksija",
   "error_proxy with {}:{}": "Kļūda ar proksiju {}:{}",
   "error_proxy": "Kļūda ar proksiju",

--- a/SlimSocial_for_Facebook/assets/lang/ml-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ml-IN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "{}-ലേക്ക് ചിത്രം സംരക്ഷിച്ചു",
   "sharing": "പങ്കിടുന്നു",
   "downloading": "ഡൗൺലോഡുചെയ്യുന്നു",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "കസ്റ്റം പ്രോക്സി",
   "error_proxy with {}:{}": "{}:{} പ്രോക്സി പിശക് സംബന്ധിച്ച്",
   "error_proxy": "പ്രോക്സി പിശക്",

--- a/SlimSocial_for_Facebook/assets/lang/mr-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/mr-IN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "प्रतिमा {} वर सेव्ह केली गेली आहे",
   "sharing": "सामायिक करत आहे",
   "downloading": "डाउनलोड करत आहे",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "कस्टम प्रॉक्सी",
   "error_proxy with {}:{}": "{}:{} सहित प्रॉक्सी त्रुटि",
   "error_proxy": "प्रॉक्सी त्रुटि",

--- a/SlimSocial_for_Facebook/assets/lang/nl-NL.json
+++ b/SlimSocial_for_Facebook/assets/lang/nl-NL.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Afbeelding opgeslagen in {}",
   "sharing": "Delen",
   "downloading": "Bezig met downloaden",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Aangepaste proxy",
   "error_proxy with {}:{}": "Fout met proxy {}:{}",
   "error_proxy": "Fout met proxy",

--- a/SlimSocial_for_Facebook/assets/lang/no-NO.json
+++ b/SlimSocial_for_Facebook/assets/lang/no-NO.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Bilde lagret til {}",
   "sharing": "Deling",
   "downloading": "Laster ned",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Egendefinert-proxy",
   "error_proxy with {}:{}": "Feil med proxy {}:{}",
   "error_proxy": "Feil med proxy",

--- a/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/pcm-NG.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "Image don save for {}",
   "sharing": "E dey share",
   "downloading": "E dey download",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Be hero",
   "custom_proxy": "Your own proxy",
   "error_proxy with {}:{}": "Error with proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/pl-PL.json
+++ b/SlimSocial_for_Facebook/assets/lang/pl-PL.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Obraz zapisany do {}",
   "sharing": "Dzielenie się",
   "downloading": "Pobieranie",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Niestandardowy serwer proxy",
   "error_proxy with {}:{}": "Błąd serwera proxy {}:{}",
   "error_proxy": "Błąd serwera proxy",

--- a/SlimSocial_for_Facebook/assets/lang/pt-BR.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-BR.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Imagem salva em {}",
   "sharing": "Compartilhando",
   "downloading": "Baixando",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Torne-se um herói",
   "custom_proxy": "Proxy personalizado",
   "error_proxy with {}:{}": "Erro com o proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/pt-PT.json
+++ b/SlimSocial_for_Facebook/assets/lang/pt-PT.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Imagem salva em {}",
   "sharing": "Compartilhando",
   "downloading": "Baixando",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Proxy personalizado",
   "error_proxy with {}:{}": "Erro com proxy {}:{}",
   "error_proxy": "Erro com proxy",

--- a/SlimSocial_for_Facebook/assets/lang/ro-RO.json
+++ b/SlimSocial_for_Facebook/assets/lang/ro-RO.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Imaginea salvată la {}",
   "sharing": "Partajare",
   "downloading": "Se descarcă",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Proxy personalizat",
   "error_proxy with {}:{}": "Eroare cu proxy-ul {}:{}",
   "error_proxy": "Eroare cu proxy-ul",

--- a/SlimSocial_for_Facebook/assets/lang/ru-RU.json
+++ b/SlimSocial_for_Facebook/assets/lang/ru-RU.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Изображение сохранено в {}",
   "sharing": "Публикация",
   "downloading": "Загрузка",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Пользовательский прокси",
   "error_proxy with {}:{}": "Ошибка с прокси {}:{}",
   "error_proxy": "Ошибка с прокси",

--- a/SlimSocial_for_Facebook/assets/lang/sk-SK.json
+++ b/SlimSocial_for_Facebook/assets/lang/sk-SK.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Obrázok bol uložený do {}",
   "sharing": "Zdieľanie",
   "downloading": "Sťahovanie",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Vlastný proxy server",
   "error_proxy with {}:{}": "Chyba s proxy serverom {}:{}",
   "error_proxy": "Chyba s proxy serverom",

--- a/SlimSocial_for_Facebook/assets/lang/sl-SI.json
+++ b/SlimSocial_for_Facebook/assets/lang/sl-SI.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Slika shranjena v {}",
   "sharing": "Deljenje",
   "downloading": "Prenos",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Pretvornik po meri",
   "error_proxy with {}:{}": "Napaka s pretvornikom {}:{}",
   "error_proxy": "Napaka s pretvornikom",

--- a/SlimSocial_for_Facebook/assets/lang/sr-SP.json
+++ b/SlimSocial_for_Facebook/assets/lang/sr-SP.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Slika sačuvana u {}",
   "sharing": "Deljenje",
   "downloading": "Preuzimanje",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Prilagođeni proksi",
   "error_proxy with {}:{}": "Greška sa proksijem {}:{}",
   "error_proxy": "Greška sa proksijem",

--- a/SlimSocial_for_Facebook/assets/lang/sv-SE.json
+++ b/SlimSocial_for_Facebook/assets/lang/sv-SE.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Bilden sparad till {}",
   "sharing": "Delar",
   "downloading": "Laddar ner",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Anpassad proxy",
   "error_proxy with {}:{}": "Fel med proxy {}:{}",
   "error_proxy": "Fel med proxy",

--- a/SlimSocial_for_Facebook/assets/lang/ta-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/ta-IN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "படம் {} க்குச் சேமிக்கப்பட்டது",
   "sharing": "பகிரும்",
   "downloading": "பதிவிறக்குகிறது",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "தனியார் புரோக்ஸி",
   "error_proxy with {}:{}": "{}:{} புரோக்ஸி பிழை",
   "error_proxy": "புரோக்ஸி பிழை",

--- a/SlimSocial_for_Facebook/assets/lang/te-IN.json
+++ b/SlimSocial_for_Facebook/assets/lang/te-IN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "చిత్రం {} కి సేవ్ చేయబడింది",
   "sharing": "భాగస్వామ్యం",
   "downloading": "డౌన్‌లోడ్ అవుతోంది",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "కస్టమ్ ప్రాక్సి",
   "error_proxy with {}:{}": "{}:{} ప్రాక్సితో లోపం",
   "error_proxy": "ప్రాక్సితో లోపం",

--- a/SlimSocial_for_Facebook/assets/lang/th-TH.json
+++ b/SlimSocial_for_Facebook/assets/lang/th-TH.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "บันทึกรูปภาพใน {}",
   "sharing": "กำลังแชร์",
   "downloading": "กำลังดาวน์โหลด",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "โปรกิจฉบับเอง",
   "error_proxy with {}:{}": "เกิดข้อผิดพลาดกับพร็อกซี่ {}:{}",
   "error_proxy": "เกิดข้อผิดพลาดกับพร็อกซี่",

--- a/SlimSocial_for_Facebook/assets/lang/tr-TR.json
+++ b/SlimSocial_for_Facebook/assets/lang/tr-TR.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Resim {} olarak kaydedildi",
   "sharing": "Paylaşılıyor",
   "downloading": "İndiriliyor",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Özel proxy",
   "error_proxy with {}:{}": "Proxy hatası {}:{}",
   "error_proxy": "Proxy hatası",

--- a/SlimSocial_for_Facebook/assets/lang/uk-UA.json
+++ b/SlimSocial_for_Facebook/assets/lang/uk-UA.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Зображення збережено в {}",
   "sharing": "Поширення",
   "downloading": "Завантаження",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Користувацький проксі",
   "error_proxy with {}:{}": "Помилка з проксі {}:{}",
   "error_proxy": "Помилка з проксі",

--- a/SlimSocial_for_Facebook/assets/lang/ur-PK.json
+++ b/SlimSocial_for_Facebook/assets/lang/ur-PK.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "تصویر {} میں محفوظ کر دی گئی",
   "sharing": "شئیرنگ",
   "downloading": "ڈاؤن لوڈنگ",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "کسٹم پراکسی",
   "error_proxy with {}:{}": "پراکسی میں خرابی {}:{}",
   "error_proxy": "پراکسی میں خرابی",

--- a/SlimSocial_for_Facebook/assets/lang/vi-VN.json
+++ b/SlimSocial_for_Facebook/assets/lang/vi-VN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "Đã lưu hình ảnh vào {}",
   "sharing": "Đang chia sẻ",
   "downloading": "Đang tải xuống",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "Proxy tùy chỉnh",
   "error_proxy with {}:{}": "Lỗi với proxy {}:{}",
   "error_proxy": "Lỗi với proxy",

--- a/SlimSocial_for_Facebook/assets/lang/yo-NG.json
+++ b/SlimSocial_for_Facebook/assets/lang/yo-NG.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "A ti fi àwòrán pamọ́ sí {}",
   "sharing": "Ń pín",
   "downloading": "Ń gbà sílẹ̀",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "Di akọni",
   "custom_proxy": "Proxy tìrẹ",
   "error_proxy with {}:{}": "Àṣìṣe pẹ̀lú proxy {}:{}",

--- a/SlimSocial_for_Facebook/assets/lang/zh-CN.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-CN.json
@@ -46,6 +46,7 @@
   "Image saved to {}": "图像已保存至{}",
   "sharing": "正在分享",
   "downloading": "正在下载",
+  "image_saved": "Image saved to Downloads",
   "custom_proxy": "自定义代理",
   "error_proxy with {}:{}": "代理错误 {}:{}",
   "error_proxy": "代理错误",

--- a/SlimSocial_for_Facebook/assets/lang/zh-TW.json
+++ b/SlimSocial_for_Facebook/assets/lang/zh-TW.json
@@ -49,6 +49,7 @@
   "Image saved to {}": "圖片已儲存至 {}",
   "sharing": "分享中",
   "downloading": "下載中",
+  "image_saved": "Image saved to Downloads",
   "become_an_hero": "成為英雄",
   "custom_proxy": "自訂代理伺服器",
   "error_proxy with {}:{}": "代理伺服器 {}:{} 發生錯誤",

--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -26,6 +26,18 @@ const List<String> kPermittedHostnamesMessenger = [
   "m.me",
 ];
 
+/// Name of the JavaScript channel a blob download is handed back on.
+///
+/// Separate from the ad filter's channels (`kAdCountChannelName`,
+/// `kDiagnosticsChannelName`) because the payloads have nothing in common: a
+/// tally is parsed as a bare integer and a diagnostic against an allow-list of
+/// kinds, so a file posted on either would be dropped as garbage.
+///
+/// A `blob:` url names bytes that only the page can read — Dart cannot fetch
+/// one — so the file has to travel back through here. See
+/// `CustomJs.fetchBlobFunc`.
+const String kBlobDownloadChannelName = "SlimBlobDownload";
+
 //suffix for the feed
 const String suffixRecentFirst = "?sk=h_chr";
 const String suffixDefault = "?sk=h_nor";

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:open_file_plus/open_file_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:slimsocial_for_facebook/consts.dart';
@@ -18,6 +17,7 @@ import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/ad_filter.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
 import 'package:slimsocial_for_facebook/utils/dark_theme.dart';
+import 'package:slimsocial_for_facebook/utils/download_request.dart';
 import 'package:slimsocial_for_facebook/utils/fb_navigation.dart';
 import 'package:slimsocial_for_facebook/utils/file_chooser.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
@@ -146,6 +146,12 @@ class _HomePageState extends ConsumerState<HomePage> {
       ..addJavaScriptChannel(
         kLinkMenuChannelName,
         onMessageReceived: onLinkMenuMessage,
+      )
+      //the only way a `blob:` download can reach Dart: the bytes live in the
+      //page and no url outside it resolves them. See [onBlobDownloadMessage].
+      ..addJavaScriptChannel(
+        kBlobDownloadChannelName,
+        onMessageReceived: onBlobDownloadMessage,
       )
       ..setNavigationDelegate(
         NavigationDelegate(
@@ -372,6 +378,13 @@ class _HomePageState extends ConsumerState<HomePage> {
     unawaited(showLinkMenu(context, link));
   }
 
+  /// Hands the reader a file the page read out of a `blob:` url.
+  ///
+  /// See [shareBlobDownload]: the payload is treated as hostile input, exactly
+  /// like the diagnostics channel above.
+  void onBlobDownloadMessage(JavaScriptMessage message) =>
+      shareBlobDownload(message.message);
+
   /// Hands a failed page load to the retry policy.
   void onWebResourceError(WebResourceError error) {
     //a failure the platform will not classify is treated as the main frame's
@@ -431,6 +444,38 @@ class _HomePageState extends ConsumerState<HomePage> {
         await _controller.loadRequest(target);
         return NavigationDecision.prevent;
       }
+    }
+
+    //Facebook's photo viewer saves through a download, and on Android every
+    //download the webview starts is routed into this delegate — there is no
+    //separate callback (webview_flutter_android 4.3.4,
+    //android_webview_controller.dart:1455). So the Save menu item arrives here
+    //as an ordinary navigation to a cdn address or to a `blob:` url, neither of
+    //which is a permitted host, and both used to be handed to a Custom Tab: the
+    //cdn one opened a browser at best, and a Custom Tab cannot resolve a blob
+    //url at all, so the tap did nothing (#348).
+    //
+    //Only the kind is reported. The address is the photo the reader is looking
+    //at, which is their browsing.
+    switch (classifyDownloadRequest(uri)) {
+      case DownloadKind.image:
+        Telemetry.captureIssue('download.intercepted', data: {'kind': 'image'});
+        await saveImageFromUrl(request.url);
+        return NavigationDecision.prevent;
+      case DownloadKind.blob:
+        Telemetry.captureIssue('download.intercepted', data: {'kind': 'blob'});
+        showToast("${"downloading".tr()}...");
+        //the bytes come back on kBlobDownloadChannelName, asynchronously: see
+        //[onBlobDownloadMessage]
+        await runIsolatedJs(
+          'blob download',
+          () => _controller.runJavaScript(
+            CustomJs.fetchBlobFunc(request.url, kBlobDownloadChannelName),
+          ),
+        );
+        return NavigationDecision.prevent;
+      case DownloadKind.none:
+        break;
     }
 
     for (final other in kPermittedHostnamesFb) {
@@ -608,14 +653,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             IconButton(
               onPressed: () async {
                 final url = await _controller.currentUrl();
-                if (url != null) {
-                  showToast("${"downloading".tr()}...");
-                  final path = await downloadImage(url);
-                  if (path != null) {
-                    //showToast("Image saved to {}".tr(args: [path]));
-                    OpenFile.open(path);
-                  }
-                }
+                if (url != null) await saveImageFromUrl(url);
               },
               icon: const Icon(Icons.save),
             ),

--- a/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/messenger_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,10 +11,12 @@ import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
 import 'package:slimsocial_for_facebook/main.dart';
 import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
 import 'package:slimsocial_for_facebook/utils/css.dart';
+import 'package:slimsocial_for_facebook/utils/download_request.dart';
 import 'package:slimsocial_for_facebook/utils/fb_navigation.dart';
 import 'package:slimsocial_for_facebook/utils/file_chooser.dart';
 import 'package:slimsocial_for_facebook/utils/js.dart';
 import 'package:slimsocial_for_facebook/utils/link_menu.dart';
+import 'package:slimsocial_for_facebook/utils/telemetry.dart';
 import 'package:slimsocial_for_facebook/utils/utils.dart';
 import 'package:slimsocial_for_facebook/utils/webview_permissions.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -57,6 +60,13 @@ class _HomePageState extends ConsumerState<MessengerPage> {
       ..addJavaScriptChannel(
         kLinkMenuChannelName,
         onMessageReceived: onLinkMenuMessage,
+      )
+      //the only way a `blob:` download can reach Dart: the bytes live in the
+      //page and no url outside it resolves them. Registered here too because a
+      //photo in a chat saves through exactly the same path as one in the feed.
+      ..addJavaScriptChannel(
+        kBlobDownloadChannelName,
+        onMessageReceived: (message) => shareBlobDownload(message.message),
       )
       ..setNavigationDelegate(
         NavigationDelegate(
@@ -161,6 +171,39 @@ class _HomePageState extends ConsumerState<MessengerPage> {
     NavigationRequest request,
   ) async {
     final uri = Uri.parse(request.url);
+
+    //saving a photo out of a chat starts a download, and on Android every
+    //download the webview starts is routed into this delegate rather than into
+    //a callback of its own (webview_flutter_android 4.3.4,
+    //android_webview_controller.dart:1455). Without this the cdn address went
+    //to a Custom Tab and a `blob:` url went nowhere at all — see the feed's
+    //copy of this and #348.
+    //
+    //Only the kind is reported. The address is the photo the reader is looking
+    //at, which is their browsing.
+    switch (classifyDownloadRequest(uri)) {
+      case DownloadKind.image:
+        Telemetry.captureIssue('download.intercepted', data: {'kind': 'image'});
+        await saveImageFromUrl(request.url);
+        return NavigationDecision.prevent;
+      case DownloadKind.blob:
+        Telemetry.captureIssue('download.intercepted', data: {'kind': 'blob'});
+        showToast("${"downloading".tr()}...");
+        //the bytes come back on kBlobDownloadChannelName, asynchronously
+        try {
+          await _controller.runJavaScript(
+            CustomJs.fetchBlobFunc(request.url, kBlobDownloadChannelName),
+          );
+        }
+        //a page exception comes back through runJavaScript on iOS, and there is
+        //no recovery to attempt: the reader has already been told it started
+        on Object catch (e, stack) {
+          Telemetry.captureError(e, stack, hint: 'blob download');
+        }
+        return NavigationDecision.prevent;
+      case DownloadKind.none:
+        break;
+    }
 
     switch (messengerNavigationFor(uri)) {
       case MessengerNavAction.stay:

--- a/SlimSocial_for_Facebook/lib/utils/download_request.dart
+++ b/SlimSocial_for_Facebook/lib/utils/download_request.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// What a navigation request that the webview raised for a download is.
+///
+/// `webview_flutter_android` has no download callback of its own: its
+/// `DownloadListener` calls straight into the same handler the navigation
+/// delegate uses (android_webview_controller.dart:1455 in 4.3.4). So a
+/// response carrying `Content-Disposition: attachment`, an `<a download>` and
+/// a `blob:` url all arrive at `onNavigationRequest` looking like an ordinary
+/// link tap, and the app used to hand them to a Custom Tab. That is #348: the
+/// photo viewer's Save does nothing.
+enum DownloadKind {
+  /// Not a download. Handled by the ordinary navigation rules.
+  none,
+
+  /// A media file on Facebook's cdn, downloadable over http.
+  image,
+
+  /// A `blob:` url. Its bytes live in the page and nothing outside the page
+  /// can read them, so the file has to be fetched in JavaScript.
+  blob,
+}
+
+/// Facebook serves user media from `*.fbcdn.net`, which is deliberately not in
+/// `kPermittedHostnamesFb` — the app wants those addresses handled, not loaded
+/// in the feed webview.
+const String _kCdnHostSuffix = 'fbcdn.net';
+
+/// Hosts for the same cdn spell the name in several ways
+/// (`scontent-mxp1-1.xx.fbcdn.net`, `scontent.xx.fbcdn.net`). The suffix above
+/// catches them all today; this is the belt for a host that carries the same
+/// marker under some other domain.
+const String _kCdnHostMarker = 'scontent';
+
+/// Classifies a request the webview raised, so a download can be saved instead
+/// of thrown at a browser that cannot open it.
+DownloadKind classifyDownloadRequest(Uri uri) {
+  if (uri.scheme == 'blob') return DownloadKind.blob;
+
+  if (uri.scheme != 'http' && uri.scheme != 'https') return DownloadKind.none;
+
+  final host = uri.host.toLowerCase();
+  if (host.endsWith(_kCdnHostSuffix)) return DownloadKind.image;
+  if (host.contains(_kCdnHostMarker)) return DownloadKind.image;
+
+  return DownloadKind.none;
+}
+
+/// Largest blob the app will take off the page.
+///
+/// The bytes travel base64-encoded through a JavaScript channel and are held
+/// in memory twice on the way, so an unbounded payload is a way to kill the
+/// app from inside the page. A photo or a short video sits far below this.
+const int kMaxBlobDownloadBytes = 25 * 1024 * 1024;
+
+/// Parses what the blob-download script posts back.
+///
+/// The payload is `{"type": "<mime>", "data": "data:<mime>;base64,<bytes>"}`.
+/// Any script on the page can post on a channel the app registers, so this is
+/// treated as hostile input: anything that is not a decodable base64 data url
+/// within the size cap returns null and is dropped.
+({Uint8List bytes, String mimeType})? parseBlobDownloadMessage(String json) {
+  Object? decoded;
+  try {
+    decoded = jsonDecode(json);
+  } on Object catch (_) {
+    return null;
+  }
+  if (decoded is! Map) return null;
+
+  final data = decoded['data'];
+  if (data is! String) return null;
+
+  //only a data url, and only a base64 one: a `data:` url with percent-encoded
+  //text in it is not a file the page just read for us
+  final comma = data.indexOf(',');
+  if (comma < 0) return null;
+  final header = data.substring(0, comma);
+  if (!header.startsWith('data:')) return null;
+  if (!header.endsWith(';base64')) return null;
+
+  final payload = data.substring(comma + 1);
+  //3 base64 characters carry at most 3 bytes, so this bounds the decode
+  //without doing it first
+  if (payload.length > kMaxBlobDownloadBytes ~/ 3 * 4 + 4) return null;
+
+  Uint8List bytes;
+  try {
+    bytes = base64Decode(payload);
+  } on Object catch (_) {
+    return null;
+  }
+  if (bytes.isEmpty) return null;
+  if (bytes.length > kMaxBlobDownloadBytes) return null;
+
+  //the mime type only ever names a file extension and is reported to nobody,
+  //but it still comes from the page: fall back to the header's own type, and
+  //to octet-stream, rather than trusting a free-form string
+  final type = decoded['type'];
+  final headerType = header.substring('data:'.length, header.length - 7);
+  final mimeType = type is String && type.isNotEmpty
+      ? type
+      : (headerType.isNotEmpty ? headerType : 'application/octet-stream');
+
+  return (bytes: bytes, mimeType: mimeType);
+}
+
+/// File extension for [mimeType], for naming the file the share sheet hands on.
+///
+/// The share sheet's target decides what to do with the file largely by its
+/// name, so an image saved as `.bin` lands in the wrong place or is refused.
+String extensionForMimeType(String mimeType) {
+  final subtype = mimeType.split('/').last.split(';').first.trim().toLowerCase();
+  if (subtype.isEmpty) return 'bin';
+  //`image/jpeg` is the type; `.jpg` is what every gallery expects
+  if (subtype == 'jpeg') return 'jpg';
+  if (subtype == 'svg+xml') return 'svg';
+  if (subtype == 'quicktime') return 'mov';
+  //a subtype with anything odd in it is not an extension
+  if (!RegExp(r'^[a-z0-9]{1,8}$').hasMatch(subtype)) return 'bin';
+  return subtype;
+}

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -291,6 +291,49 @@ class CustomJs {
 ''';
   }
 
+  /// Builds JavaScript that reads a `blob:` url and posts the file back.
+  ///
+  /// A blob url is a handle into the page's own memory. Nothing outside the
+  /// page can resolve one — not Dart, not a Custom Tab, not the download
+  /// manager — so a photo Facebook offers as a blob cannot be saved by
+  /// fetching the address. It has to be read where it lives, which is here.
+  ///
+  /// The bytes come back as a `data:` url because a JavaScript channel carries
+  /// a string and nothing else. That doubles the payload, which is why the Dart
+  /// side caps what it accepts (`kMaxBlobDownloadBytes`).
+  ///
+  /// [channelName] is the channel Dart registered; it is read off `window`
+  /// rather than referenced by name so the identifier cannot be forged into the
+  /// script. Both arguments go through jsonEncode for the same reason as
+  /// [injectCssFunc]: a url is not ours to trust as source code.
+  ///
+  /// Everything is swallowed by a try/catch, and the async failure paths get
+  /// their own: a throw here would surface as nothing on Android, and there is
+  /// no recovery to attempt — the reader has already been told the download
+  /// started.
+  static String fetchBlobFunc(String blobUrl, String channelName) {
+    return '''
+(function (url, channel) {
+  try {
+    fetch(url)
+      .then(function (r) { return r.blob(); })
+      .then(function (b) {
+        var fr = new FileReader();
+        fr.onload = function () {
+          try {
+            window[channel].postMessage(
+              JSON.stringify({ type: b.type, data: fr.result })
+            );
+          } catch (e) {}
+        };
+        fr.readAsDataURL(b);
+      })
+      .catch(function (e) {});
+  } catch (e) {}
+})(${jsonEncode(blobUrl)}, ${jsonEncode(channelName)});
+''';
+  }
+
   static String exampleJs = """
 javascript:function foo() {
 	     document.body.innerHTML = '';

--- a/SlimSocial_for_Facebook/lib/utils/utils.dart
+++ b/SlimSocial_for_Facebook/lib/utils/utils.dart
@@ -1,10 +1,15 @@
+import 'dart:async';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_custom_tabs/flutter_custom_tabs.dart';
 import 'package:flutter_file_downloader/flutter_file_downloader.dart';
 import 'package:fluttertoast/fluttertoast.dart';
+import 'package:open_file_plus/open_file_plus.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:slimsocial_for_facebook/controllers/fb_controller.dart';
 import 'package:slimsocial_for_facebook/style/color_schemes.g.dart';
+import 'package:slimsocial_for_facebook/utils/download_request.dart';
 // flutter_custom_tabs also exports `launchUrl`, so this one needs a prefix.
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
@@ -79,4 +84,54 @@ Future<String?> downloadImage(String url) async {
     },
   );
   return file?.path;
+}
+
+/// Downloads [url] into Downloads, tells the reader, and opens it.
+///
+/// Lives here rather than on a screen because two callers have to behave the
+/// same way: the app bar's save button, and the navigation delegate, which is
+/// where Facebook's own Save menu item lands (#348). Duplicating the toasts is
+/// how the two drifted apart before.
+Future<void> saveImageFromUrl(String url) async {
+  showToast("${"downloading".tr()}...");
+  final path = await downloadImage(url);
+  if (path == null) return;
+
+  showToast('image_saved'.tr());
+  //not awaited: the toast is the confirmation, and opening the viewer is a
+  //convenience that must not hold up the caller
+  unawaited(OpenFile.open(path));
+}
+
+/// Hands the reader a file the page read out of a `blob:` url.
+///
+/// The share sheet, rather than a write into Downloads, because the bytes are
+/// already in memory: sharing them needs no storage permission and no
+/// dependency the app does not already have, and the sheet's own targets cover
+/// saving to Photos or Files.
+///
+/// [message] is what `CustomJs.fetchBlobFunc` posted.
+/// [parseBlobDownloadMessage] does the deciding, because this is hostile
+/// input: any script on the page can post on a channel the app registers. A
+/// rejected message is described, never quoted — `debugPrint` output is
+/// collected as a breadcrumb on whatever is reported next.
+void shareBlobDownload(String message) {
+  final blob = parseBlobDownloadMessage(message);
+  if (blob == null) {
+    debugPrint("ignored blob download: ${message.length} chars");
+    return;
+  }
+
+  //the file only ever exists inside the share sheet, so the name is just
+  //something recognisable in whatever app receives it
+  final name = 'facebook-${DateTime.now().millisecondsSinceEpoch}'
+      '.${extensionForMimeType(blob.mimeType)}';
+
+  //the channel callback is synchronous, and there is nothing to do with the
+  //sheet's outcome: the reader either picks a target or dismisses it
+  unawaited(
+    Share.shareXFiles([
+      XFile.fromData(blob.bytes, mimeType: blob.mimeType, name: name),
+    ]),
+  );
 }

--- a/SlimSocial_for_Facebook/test/lang_test.dart
+++ b/SlimSocial_for_Facebook/test/lang_test.dart
@@ -130,6 +130,9 @@ void main() {
       // above already asserts it, against both fallback files rather than just
       // en-US, which is the stronger check.
       'hide_reels',
+      // The confirmation for a photo saved out of the viewer (#348). A missing
+      // key here renders the raw slug as a toast.
+      'image_saved',
       'retry',
       'sponsored_keyword_fb',
     ]) {

--- a/SlimSocial_for_Facebook/test/utils/download_request_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/download_request_test.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:slimsocial_for_facebook/utils/download_request.dart';
+
+/// The smallest valid PNG: a 1x1 transparent pixel.
+const String _pngBase64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8'
+    '/58BAAAA//8DAAM=';
+
+String _blobMessage(String data, {String type = 'image/png'}) =>
+    jsonEncode({'type': type, 'data': data});
+
+void main() {
+  group('classifyDownloadRequest', () {
+    test('treats an https cdn address as an image', () {
+      expect(
+        classifyDownloadRequest(
+          Uri.parse(
+            'https://scontent-mxp1-1.xx.fbcdn.net/v/t39.30808-6/abc.jpg?dl=1',
+          ),
+        ),
+        DownloadKind.image,
+      );
+    });
+
+    test('treats a host carrying `scontent` as an image', () {
+      // The suffix check covers fbcdn.net today; this is the belt for the same
+      // cdn served under another domain.
+      expect(
+        classifyDownloadRequest(Uri.parse('https://scontent.example.com/a.jpg')),
+        DownloadKind.image,
+      );
+    });
+
+    test('is case-insensitive about the host', () {
+      expect(
+        classifyDownloadRequest(Uri.parse('https://Scontent.FBCDN.net/a.jpg')),
+        DownloadKind.image,
+      );
+    });
+
+    test('treats a blob url as a blob', () {
+      expect(
+        classifyDownloadRequest(
+          Uri.parse('blob:https://www.facebook.com/1234-5678'),
+        ),
+        DownloadKind.blob,
+      );
+    });
+
+    test('leaves an ordinary Facebook page alone', () {
+      expect(
+        classifyDownloadRequest(
+          Uri.parse('https://www.facebook.com/photo/?fbid=1'),
+        ),
+        DownloadKind.none,
+      );
+    });
+
+    test('leaves a javascript url alone', () {
+      // The user's own script runs through `javascript:` urls, and treating one
+      // as a download would swallow it.
+      expect(
+        classifyDownloadRequest(Uri.parse('javascript:void(0)')),
+        DownloadKind.none,
+      );
+    });
+
+    test('leaves a non-http scheme on a cdn-looking host alone', () {
+      expect(
+        classifyDownloadRequest(Uri.parse('fb://scontent.fbcdn.net/a.jpg')),
+        DownloadKind.none,
+      );
+    });
+  });
+
+  group('parseBlobDownloadMessage', () {
+    test('decodes a base64 data url', () {
+      final blob = parseBlobDownloadMessage(
+        _blobMessage('data:image/png;base64,$_pngBase64'),
+      );
+
+      expect(blob, isNotNull);
+      expect(blob!.mimeType, 'image/png');
+      // A PNG starts with the eight-byte signature.
+      expect(blob.bytes.sublist(0, 4), [0x89, 0x50, 0x4E, 0x47]);
+    });
+
+    test('uses the data url own type when the field is missing', () {
+      final blob = parseBlobDownloadMessage(
+        jsonEncode({'data': 'data:image/webp;base64,$_pngBase64'}),
+      );
+
+      expect(blob?.mimeType, 'image/webp');
+    });
+
+    test('returns null on malformed JSON', () {
+      expect(parseBlobDownloadMessage('not json at all'), isNull);
+    });
+
+    test('returns null when the payload is not a data url', () {
+      // Any script on the page can post here, so an address is not a file.
+      expect(
+        parseBlobDownloadMessage(
+          _blobMessage('https://example.com/steal?q=$_pngBase64'),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null on a data url that is not base64', () {
+      expect(
+        parseBlobDownloadMessage(_blobMessage('data:text/plain,hello')),
+        isNull,
+      );
+    });
+
+    test('returns null on undecodable base64', () {
+      expect(
+        parseBlobDownloadMessage(_blobMessage('data:image/png;base64,@@@@')),
+        isNull,
+      );
+    });
+
+    test('returns null on an empty payload', () {
+      expect(
+        parseBlobDownloadMessage(_blobMessage('data:image/png;base64,')),
+        isNull,
+      );
+    });
+
+    test('returns null above the size cap', () {
+      // The bytes travel base64-encoded and are held in memory twice on the
+      // way, so an unbounded payload is a way to kill the app from the page.
+      final oversized = 'A' * (kMaxBlobDownloadBytes ~/ 3 * 4 + 8);
+
+      expect(
+        parseBlobDownloadMessage(
+          _blobMessage('data:image/png;base64,$oversized'),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('extensionForMimeType', () {
+    test('maps jpeg to the extension galleries expect', () {
+      expect(extensionForMimeType('image/jpeg'), 'jpg');
+    });
+
+    test('uses the subtype for an ordinary type', () {
+      expect(extensionForMimeType('image/png'), 'png');
+      expect(extensionForMimeType('video/mp4'), 'mp4');
+    });
+
+    test('drops parameters the page appended', () {
+      expect(extensionForMimeType('image/png; charset=binary'), 'png');
+    });
+
+    test('refuses a subtype that is not an extension', () {
+      // The type comes from the page, and the name is what the receiving app
+      // decides what to do by.
+      expect(extensionForMimeType('application/x-msdownload'), 'bin');
+      expect(extensionForMimeType('image/a b'), 'bin');
+      expect(extensionForMimeType(''), 'bin');
+    });
+  });
+}


### PR DESCRIPTION
Closes #348

## Diagnosis

Reported on an S25, F-Droid build 26.09.03: in the photo viewer the three-dot menu's **Save** does nothing.

`webview_flutter_android` has **no download callback of its own**. Its `DownloadListener` calls straight into the navigation handler — `newDownloadListener` → `_handleNavigation(url, isForMainFrame: true)`, `android_webview_controller.dart:1455` in 4.3.4. So every download the WebView starts (a response with `Content-Disposition: attachment`, an `<a download>`, or a `blob:` url) reaches the app's `onNavigationRequest` looking like an ordinary link tap.

`onNavigationRequest` only lets `kPermittedHostnamesFb` (facebook.com, fb.com, fb.me) load in the WebView. `fbcdn.net` was deliberately removed (`consts.dart:20`), so everything else falls through to `launchInAppUrl` and a Custom Tab:

- a cdn address (`scontent-*.fbcdn.net/...?dl=1`) opened a browser at best, instead of saving;
- a `blob:` url **cannot be opened by a Custom Tab at all**, and `launchInAppUrl` swallows the exception — so the tap produced nothing visible. That matches the report exactly.

## What changed

- **`lib/utils/download_request.dart`** (new, pure): `classifyDownloadRequest(Uri)` → `DownloadKind.{none,image,blob}`, `parseBlobDownloadMessage(String)` and `extensionForMimeType(String)`.
- **`onNavigationRequest`** in both `home_page.dart` and `messenger_page.dart` classifies the request before the permitted-hosts check:
  - `image` → the existing `downloadImage` path (flutter_file_downloader → Downloads), toast, then `OpenFile.open`. This is now `saveImageFromUrl` in `utils.dart`, so the app bar's save button and the intercept are **one code path**.
  - `blob` → Dart cannot read a blob url, so the page fetches it: `CustomJs.fetchBlobFunc` runs `fetch → blob → FileReader.readAsDataURL` and posts the result on a new channel `SlimBlobDownload`. Dart decodes it and hands it to `Share.shareXFiles([XFile.fromData(...)])`. The share sheet lets the reader save to Photos or Files with **no storage permission and no new dependency**.
  - `none` → unchanged.
- Channel payloads are treated as hostile input, like the existing diagnostics channel: anything that is not a decodable base64 `data:` url is dropped, and payloads over **25 MB** are refused.
- A `download.intercepted` breadcrumb records only `{'kind': 'image'|'blob'}`. The URL is never logged, reported, or `debugPrint`ed — the existing privacy rule.
- Translations: `image_saved` added to all 51 files in `assets/lang/`, and to the required-key list in `test/lang_test.dart`.
- Not touched: pubspec version, Changelog.txt, AndroidManifest.

## Tests

- `flutter test test/utils/download_request_test.dart test/utils/js_test.dart test/lang_test.dart` → **117 passed**.
- Full suite `flutter test` → **533 passed**.
- `flutter analyze` → **52 infos, identical to the pre-change baseline on master** (verified by stashing and re-running). No new warnings or errors.

## Caveat — please read

**This was diagnosed and fixed from reading the code, not on a device.** No Android device or emulator was available. The download-listener routing is confirmed in the plugin source; which of the two paths Facebook actually uses on the S25 is not.

That is what the `download.intercepted` breadcrumb is for: once a build with a Sentry DSN is out, it will say whether Save arrives as `image` or as `blob`, so the working path is confirmed by data rather than by guess. Both are handled, so the fix does not depend on the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
