### PR TITLE
telemetry: sample success signals 1-in-50 to stop burning the Sentry quota

### DIFF
--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -377,7 +377,11 @@ class _HomePageState extends ConsumerState<HomePage> {
       return;
     }
 
-    Telemetry.captureIssue(diagnostic.kind, data: diagnostic.data);
+    Telemetry.captureIssue(
+      diagnostic.kind,
+      data: diagnostic.data,
+      sampleOneIn: kDiagSampleOneIn[diagnostic.kind] ?? 1,
+    );
   }
 
   /// Offers to copy or open the link the reader long-pressed.
@@ -536,7 +540,12 @@ class _HomePageState extends ConsumerState<HomePage> {
     final before = _feedHistoryLength ?? await _historyLength();
     if (!mounted) return;
 
-    Telemetry.captureIssue('messenger.opened', data: {'source': source});
+    Telemetry.captureIssue(
+      'messenger.opened',
+      data: {'source': source},
+      //a usage counter, not a failure: see [kDiagSampleOneIn]
+      sampleOneIn: 50,
+    );
 
     _messengerOpen = true;
     try {

--- a/SlimSocial_for_Facebook/lib/utils/ad_filter.dart
+++ b/SlimSocial_for_Facebook/lib/utils/ad_filter.dart
@@ -127,10 +127,22 @@ const String kDiagNoPostsMatched = 'injection.no_posts_matched';
 ///
 /// The denominator [kDiagNoPostsMatched] never had. On its own a count of
 /// failures says nothing: six reports is indistinguishable from six-out-of-six
-/// and six-out-of-six-thousand. Raised once per process, exactly like the
-/// failure signal, so the two counts are directly comparable and the break rate
-/// is `no_posts_matched / (no_posts_matched + posts_matched)`.
+/// and six-out-of-six-thousand.
+///
+/// Raised once per process, like the failure signal, but sent from only 1 in
+/// [kDiagSampleOneIn] of those processes, so the break rate is
+/// `no_posts_matched / (no_posts_matched + 50 * posts_matched)`.
+/// Sampled because the Sentry plan counts every event against one monthly
+/// quota, and a success that fires for nearly every user would spend that
+/// quota on the half of the picture nobody has to read event by event. A
+/// failure is never sampled.
 const String kDiagPostsMatched = 'injection.posts_matched';
+
+/// How many processes raise a signal for each one that reports it.
+///
+/// A kind that is absent reports in full, which is every failure signal. Only
+/// a success counted in the thousands belongs here.
+const Map<String, int> kDiagSampleOneIn = {kDiagPostsMatched: 50};
 
 /// A pass of the injected filter threw.
 const String kDiagScriptThrew = 'injection.script_threw';

--- a/SlimSocial_for_Facebook/lib/utils/telemetry.dart
+++ b/SlimSocial_for_Facebook/lib/utils/telemetry.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -252,9 +253,18 @@ abstract final class Telemetry {
 
   /// Reports a named health signal, e.g. an injection that matched nothing.
   /// [kind] is a stable machine-readable slug like 'injection.no_posts_matched'.
-  static void captureIssue(String kind, {Map<String, Object?> data = const {}}) {
+  ///
+  /// [sampleOneIn] above 1 sends the signal from only that fraction of the
+  /// processes that raise it. It is for success signals, which are counted in
+  /// the thousands and are only ever read as a denominator; a failure is
+  /// always reported in full.
+  static void captureIssue(
+    String kind, {
+    Map<String, Object?> data = const {},
+    int sampleOneIn = 1,
+  }) {
     if (!_canReport || !isEnabled) return;
-    if (!allowIssue(kind)) return;
+    if (!allowSampled(kind, sampleOneIn)) return;
 
     unawaited(
       Sentry.captureMessage(
@@ -264,10 +274,40 @@ abstract final class Telemetry {
           //group on the slug alone: the same broken selector has to land in
           //one issue across every user, not one issue per stack trace
           scope.fingerprint = <String>[kind];
-          await scope.setContexts(_contextKey, scrubData(data));
+          await scope.setContexts(_contextKey, issueContext(data, sampleOneIn));
         },
       ),
     );
+  }
+
+  /// What an issue carries in the app's own context block.
+  ///
+  /// The sampling rate travels with the event because a sampled count means
+  /// nothing without it: the reader has to multiply by it to recover how many
+  /// processes the events stand for.
+  @visibleForTesting
+  static Map<String, dynamic> issueContext(
+    Map<String, Object?> data,
+    int sampleOneIn,
+  ) =>
+      <String, dynamic>{...scrubData(data), 'sample_one_in': sampleOneIn};
+
+  /// The random source sampling draws from, swapped out by tests.
+  @visibleForTesting
+  static Random random = Random();
+
+  /// Claims this session's slot for [kind], then decides whether this process
+  /// is one of the 1-in-[sampleOneIn] that report it.
+  ///
+  /// The slot is spent either way. Sampling is meant to reduce how many
+  /// processes report, not to give a process that drew a miss another go at
+  /// the same signal later on.
+  @visibleForTesting
+  static bool allowSampled(String kind, int sampleOneIn) {
+    if (!allowIssue(kind)) return false;
+    if (sampleOneIn <= 1) return true;
+
+    return random.nextInt(sampleOneIn) == 0;
   }
 
   /// Whether a feedback box can do anything at all.

--- a/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/telemetry_test.dart
@@ -1,8 +1,11 @@
+import 'dart:math';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:slimsocial_for_facebook/consts.dart';
 import 'package:slimsocial_for_facebook/main.dart';
+import 'package:slimsocial_for_facebook/utils/ad_filter.dart';
 import 'package:slimsocial_for_facebook/utils/telemetry.dart';
 
 /// A story link as Facebook actually serves it: the poster and the post are
@@ -18,6 +21,36 @@ class _Explosive {
   String toString() => throw StateError("boom");
 }
 
+/// A random source that always draws the same number, so a sampling decision
+/// is a fact of the test rather than a coin toss.
+class _FixedRandom implements Random {
+  _FixedRandom(this.value);
+
+  final int value;
+
+  @override
+  int nextInt(int max) => value;
+
+  @override
+  double nextDouble() => value.toDouble();
+
+  @override
+  bool nextBool() => value == 0;
+}
+
+/// A random source that cannot be drawn from, so a test can assert that a
+/// path never reaches one.
+class _ExplosiveRandom implements Random {
+  @override
+  int nextInt(int max) => throw StateError("drawn from");
+
+  @override
+  double nextDouble() => throw StateError("drawn from");
+
+  @override
+  bool nextBool() => throw StateError("drawn from");
+}
+
 Future<void> _prefs([Map<String, Object> values = const {}]) async {
   SharedPreferences.setMockInitialValues(values);
   sp = await SharedPreferences.getInstance();
@@ -29,6 +62,7 @@ void main() {
   setUp(() async {
     await _prefs();
     Telemetry.resetSession();
+    Telemetry.random = Random();
   });
 
   group('a build with no dsn', () {
@@ -386,6 +420,38 @@ void main() {
       expect(Telemetry.allowIssue('injection.no_posts_matched'), isTrue);
       expect(Telemetry.allowIssue('injection.no_ads_matched'), isTrue);
       expect(Telemetry.allowIssue('injection.no_posts_matched'), isFalse);
+    });
+  });
+
+  group('sampling a success signal', () {
+    test('a sampled-out kind sends nothing but still spends its slot', () {
+      //49 out of 50 draws miss
+      Telemetry.random = _FixedRandom(7);
+
+      expect(Telemetry.allowSampled(kDiagPostsMatched, 50), isFalse);
+      //once per process still means once: a miss does not hand the next call
+      //of the same kind a second chance
+      expect(Telemetry.allowIssue(kDiagPostsMatched), isFalse);
+    });
+
+    test('a sampled-in kind goes out saying what it was sampled at', () {
+      Telemetry.random = _FixedRandom(0);
+
+      expect(Telemetry.allowSampled(kDiagPostsMatched, 50), isTrue);
+      expect(
+        Telemetry.issueContext(const {'page': 'feed'}, 50),
+        {'page': 'feed', 'sample_one_in': 50},
+      );
+    });
+
+    test('an unsampled kind never draws from the random source', () {
+      Telemetry.random = _ExplosiveRandom();
+
+      expect(Telemetry.allowSampled(kDiagNoPostsMatched, 1), isTrue);
+    });
+
+    test('only the success signal is sampled', () {
+      expect(kDiagSampleOneIn.keys, [kDiagPostsMatched]);
     });
   });
 


### PR DESCRIPTION
## Why
Sentry org quota (5,000 errors/month) is exhausted. In the last 30 days `injection.posts_matched` sent 2,679 events and `messenger.opened` 317. Both are success/usage signals, not failures. Together they are 60% of the whole org quota.

## What
- `Telemetry.captureIssue` gets `sampleOneIn` (default 1). Sampling runs after the once-per-session gate, so a sampled-out process still spends its slot.
- `injection.posts_matched` and `messenger.opened` report from 1 in 50 processes. Every failure kind still reports in full.
- Each issue context carries `sample_one_in`, so the break rate is `no_posts_matched / (no_posts_matched + 50 * posts_matched)`.
- Tests in `test/utils/telemetry_test.dart`.

## Verified
- `flutter test`: 570 passed, 6 skipped (pre-existing DSN-only group).
- `flutter analyze`: 50 issues, same as master.

Effect is gradual: installed builds keep sending until users update. Until then a Sentry inbound filter on these two message names stops the bleed without a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)