### PR TITLE
fix(webview): give the desktop layout a desktop-sized viewport (#369)

### DIFF
--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -92,6 +92,14 @@ const int kMinTextZoom = 80;
 const int kMaxTextZoom = 150;
 const int kDefaultTextZoom = 100;
 
+/// Layout width, in CSS pixels, given to Facebook's desktop layout.
+///
+/// 980 is what a WebView with a wide viewport uses for a page that ships no
+/// viewport tag at all, so a desktop page is laid out the same whether
+/// Facebook sends `width=device-width` (which `CustomJs.unlockZoomFunc`
+/// rewrites to this) or nothing.
+const int kDesktopLayoutWidth = 980;
+
 /// Which surface a user agent is being requested for.
 ///
 /// Facebook varies the markup it serves by user agent, so one string for the

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -53,6 +53,20 @@ class PrefController {
     return kMobileUserAgent;
   }
 
+  /// Whether the feed is served Facebook's desktop layout.
+  ///
+  /// True exactly when the feed is sent the desktop agent, so it follows the
+  /// same precedence as [getUserAgent]: basic mode and a custom agent both
+  /// win over the desktop-site switch.
+  ///
+  /// The feed screen uses this to give the page a desktop-sized viewport as
+  /// well as a desktop agent — see `CustomJs.unlockZoomFunc`. The agent alone
+  /// is not enough: Facebook ships `width=device-width` with the desktop
+  /// layout too, so the WebView lays a page built for ~1000px out at the
+  /// phone's 349px, where it overflows sideways, cannot be pinched out far
+  /// enough to fit a post, and stops scrolling after the first screen (#369).
+  static bool usesDesktopLayout() => getUserAgent() == kFirefoxUserAgent;
+
   /// Whether external links should open in the system browser app.
   ///
   /// Read on every link open, so the setting takes effect with no restart.

--- a/SlimSocial_for_Facebook/lib/screens/home_page.dart
+++ b/SlimSocial_for_Facebook/lib/screens/home_page.dart
@@ -216,11 +216,21 @@ class _HomePageState extends ConsumerState<HomePage> {
             }
 
             //before the dark theme, because unlocking the viewport reflows the
-            //page and the theme script reads colours back out of it
+            //page and the theme script reads colours back out of it.
+            //The desktop layout also gets a desktop-sized viewport here; read
+            //per load like the agent is read per start, and the setting
+            //restarts the app anyway
             await runIsolatedJs(
               'zoom unlock',
-              () => _controller
-                  .runJavaScript(CustomJs.whenDomReady(CustomJs.unlockZoomFunc())),
+              () => _controller.runJavaScript(
+                CustomJs.whenDomReady(
+                  CustomJs.unlockZoomFunc(
+                    layoutWidth: PrefController.usesDesktopLayout()
+                        ? kDesktopLayoutWidth
+                        : null,
+                  ),
+                ),
+              ),
             );
             if (!mounted) return;
 

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -88,15 +88,28 @@ class CustomJs {
   ///
   /// This only lifts the lock the page puts on itself. The WebView has to allow
   /// the gesture too (`enableZoom`), or none of this reaches the user.
-  static String unlockZoomFunc() {
+  ///
+  /// [layoutWidth], when given, also lays the page out that many CSS pixels
+  /// wide: the `width` clause is rewritten to it (or added when there is
+  /// none) and `initial-scale` is dropped, so the WebView picks the scale
+  /// that fits the whole width on screen. This is what "Desktop site" in
+  /// Chrome does. Facebook sends `width=device-width` with its desktop layout
+  /// as well, and the WebView honours it, so the desktop agent alone gets a
+  /// page built for a 1000px window squeezed into the phone's 349px: it
+  /// overflows sideways, cannot be pinched out far enough to fit a post, and
+  /// stops scrolling after the first screen (#369). Left null for the touch
+  /// layout, which is built for the phone's width and must keep it.
+  static String unlockZoomFunc({int? layoutWidth}) {
     return """
 (function () {
   try {
     var MARK = 'data-slim-zoom';
+    var LAYOUT_WIDTH = ${layoutWidth ?? 'null'};
 
     function unlockedContent(content) {
       var out = [];
       var sawUserScalable = false;
+      var sawWidth = false;
       var clauses = content.split(',');
       for (var i = 0; i < clauses.length; i++) {
         var clause = clauses[i].trim();
@@ -110,9 +123,20 @@ class CustomJs {
           sawUserScalable = true;
           continue;
         }
+        if (LAYOUT_WIDTH) {
+          if (key === 'width') {
+            out.push('width=' + LAYOUT_WIDTH);
+            sawWidth = true;
+            continue;
+          }
+          // A fixed initial scale would show the top-left corner of the wide
+          // page at 1:1; without one the WebView scales the page to fit.
+          if (key === 'initial-scale') continue;
+        }
         out.push(clause);
       }
       if (!sawUserScalable) out.push('user-scalable=yes');
+      if (LAYOUT_WIDTH && !sawWidth) out.push('width=' + LAYOUT_WIDTH);
       return out.join(', ');
     }
 

--- a/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
+++ b/SlimSocial_for_Facebook/test/controllers/fb_controller_test.dart
@@ -36,6 +36,34 @@ void main() {
     });
   });
 
+  group('usesDesktopLayout', () {
+    test('is off on the mobile default', () {
+      expect(PrefController.usesDesktopLayout(), isFalse);
+    });
+
+    test('is on with the desktop-site switch', () async {
+      await withPrefs({SpKeys.useDesktopSite: true});
+
+      expect(PrefController.usesDesktopLayout(), isTrue);
+    });
+
+    test('stays off when basic mode overrides the desktop site', () async {
+      await withPrefs({SpKeys.useDesktopSite: true, SpKeys.useMbasic: true});
+
+      expect(PrefController.usesDesktopLayout(), isFalse);
+    });
+
+    test('stays off when a custom agent overrides the desktop site', () async {
+      await withPrefs({
+        SpKeys.useDesktopSite: true,
+        SpKeys.enabled(SpKeys.customUserAgent): true,
+        SpKeys.customUserAgent: 'Mozilla/5.0 (custom)',
+      });
+
+      expect(PrefController.usesDesktopLayout(), isFalse);
+    });
+  });
+
   group('startsOnMessenger', () {
     test('is off until it is asked for', () {
       expect(PrefController.startsOnMessenger(), isFalse);

--- a/SlimSocial_for_Facebook/test/utils/js_test.dart
+++ b/SlimSocial_for_Facebook/test/utils/js_test.dart
@@ -173,6 +173,42 @@ void main() {
       // script; the prefix belongs to the older members that were used as URLs.
       expect(CustomJs.unlockZoomFunc(), isNot(contains('javascript:')));
     });
+
+    test('leaves the width alone by default', () {
+      // The touch layout is built for the phone's width and has to keep it:
+      // every width rewrite sits behind the LAYOUT_WIDTH guard, and the guard
+      // is off unless a width was asked for.
+      final js = CustomJs.unlockZoomFunc();
+
+      expect(js, contains('var LAYOUT_WIDTH = null;'));
+      expect(js, contains('if (LAYOUT_WIDTH) {'));
+      expect(js, contains('if (LAYOUT_WIDTH && !sawWidth)'));
+    });
+
+    test('lays the page out at the asked-for width', () {
+      // Facebook ships width=device-width with the desktop layout too, so the
+      // desktop agent alone squeezes a 1000px page into the phone's width.
+      final js = CustomJs.unlockZoomFunc(layoutWidth: 980);
+
+      expect(js, contains('var LAYOUT_WIDTH = 980;'));
+      expect(js, contains("if (key === 'width') {"));
+      expect(js, contains("out.push('width=' + LAYOUT_WIDTH);"));
+    });
+
+    test('adds the width when the page names none', () {
+      final js = CustomJs.unlockZoomFunc(layoutWidth: 980);
+
+      expect(js, contains('if (LAYOUT_WIDTH && !sawWidth) out.push'));
+    });
+
+    test('drops a fixed initial scale along with the width rewrite', () {
+      // At initial-scale=1 a 980px page shows its top-left corner; without the
+      // clause the WebView scales the page to fit the screen, like Chrome's
+      // desktop-site mode.
+      final js = CustomJs.unlockZoomFunc(layoutWidth: 980);
+
+      expect(js, contains("if (key === 'initial-scale') continue;"));
+    });
   });
 
   group('CustomJs.removeAdsObserver', () {


### PR DESCRIPTION
## What

With **Desktop site** on, the feed is served Facebook's desktop layout through a desktop user agent, but that page still ships `width=device-width` in its viewport tag and the WebView honours it. A page built for a ~1000px window gets laid out at the phone's 349px: it overflows sideways, cannot be pinched out far enough to fit a post, and stops scrolling after the first screen (#369, and gbakeman's report in #366).

`CustomJs.unlockZoomFunc` already rewrites the viewport tag to hand pinch zoom back. It now takes an optional `layoutWidth`: when set, the `width` clause is rewritten to it (or added when the page has none) and `initial-scale` is dropped, so the WebView scales the page to fit. This is what Chrome's "Request desktop site" does. The feed passes 980 whenever `PrefController.usesDesktopLayout()` is true, which follows the same precedence as the user agent (basic mode and a custom agent win over the desktop switch). The touch layout keeps its width: every new clause sits behind the width guard.

Wide viewport itself was not the problem. The pinned `webview_flutter_android` 4.3.4 already enables `useWideViewPort` and `loadWithOverviewMode` in its controller constructor.

## Why it matters

The touch layout Facebook serves today is its server-driven "weblite" UI. Its Feeds screen has no URL of its own (the menu entry is a `role="button"` with an opaque `data-action-id`), so "Show recent posts first" cannot work on the mobile layout any more (#366). Desktop site is the only way left to get the chronological feed, and it has to be usable.

## Verification

- `flutter analyze`: no new issues in the touched code.
- `flutter test` on `test/utils/js_test.dart`, `test/controllers/fb_controller_test.dart`, `test/consts_test.dart`: 111 passed.
- **Not yet tried on a device.** Checklist for the Pixel, with Desktop site on:
  1. Feed opens zoomed out to fit the whole page width; pinch in and out both work.
  2. Scrolling continues past the first screen on the feed and on Marketplace.
  3. With "Show recent posts first" on, the feed is chronological.
  4. Turn Desktop site off: the touch layout is unchanged (device width, pinch zoom still unlocked).
  5. Messenger screen unchanged (it does not call this script).

Closes #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
