### PR TITLE
docs(webview): correct why the desktop layout was squeezed (#369)

### DIFF
--- a/SlimSocial_for_Facebook/lib/consts.dart
+++ b/SlimSocial_for_Facebook/lib/consts.dart
@@ -95,9 +95,10 @@ const int kDefaultTextZoom = 100;
 /// Layout width, in CSS pixels, given to Facebook's desktop layout.
 ///
 /// 980 is what a WebView with a wide viewport uses for a page that ships no
-/// viewport tag at all, so a desktop page is laid out the same whether
-/// Facebook sends `width=device-width` (which `CustomJs.unlockZoomFunc`
-/// rewrites to this) or nothing.
+/// viewport tag at all — measured: Facebook's logged-out desktop pages carry
+/// no viewport tag and land on exactly this width. Writing the same number
+/// into the tag when there is one (see `CustomJs.unlockZoomFunc`) means the
+/// desktop layout is laid out identically either way.
 const int kDesktopLayoutWidth = 980;
 
 /// Which surface a user agent is being requested for.

--- a/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
+++ b/SlimSocial_for_Facebook/lib/controllers/fb_controller.dart
@@ -61,10 +61,11 @@ class PrefController {
   ///
   /// The feed screen uses this to give the page a desktop-sized viewport as
   /// well as a desktop agent — see `CustomJs.unlockZoomFunc`. The agent alone
-  /// is not enough: Facebook ships `width=device-width` with the desktop
-  /// layout too, so the WebView lays a page built for ~1000px out at the
-  /// phone's 349px, where it overflows sideways, cannot be pinched out far
-  /// enough to fit a post, and stops scrolling after the first screen (#369).
+  /// is not enough: Facebook's viewport tag names an `initial-scale` and no
+  /// width, which lays any page out at the phone's width, so a layout built
+  /// for ~1000px arrived at 393px — overflowing sideways, impossible to pinch
+  /// out far enough to fit a post, and unable to scroll past the first screen
+  /// (#369).
   static bool usesDesktopLayout() => getUserAgent() == kFirefoxUserAgent;
 
   /// Whether external links should open in the system browser app.

--- a/SlimSocial_for_Facebook/lib/utils/js.dart
+++ b/SlimSocial_for_Facebook/lib/utils/js.dart
@@ -64,17 +64,18 @@ class CustomJs {
 
   /// Builds JavaScript that hands pinch-to-zoom back to the reader.
   ///
-  /// Facebook ships `width=device-width, initial-scale=1, maximum-scale=1,
-  /// user-scalable=no` as its viewport, and those last two clauses are exactly
-  /// what the browser reads as "this page does not zoom". The text-zoom setting
-  /// is no substitute: it reflows text and leaves an image, a screenshot
-  /// somebody posted, or a fixed-width table at whatever size it arrived in.
+  /// Facebook ships `user-scalable=no,initial-scale=1,maximum-scale=1` as its
+  /// viewport — measured on a device; note there is no `width` clause — and the
+  /// first and last of those are exactly what the browser reads as "this page
+  /// does not zoom". The text-zoom setting is no substitute: it reflows text
+  /// and leaves an image, a screenshot somebody posted, or a fixed-width table
+  /// at whatever size it arrived in.
   ///
   /// Only the clauses that block the gesture are dropped. `minimum-scale` goes
   /// with them because a `minimum-scale=1` is what stops the page being pinched
   /// back out again. Every clause we do not recognise is copied through in
-  /// place: replacing the whole content string would take `width=device-width`
-  /// with it, and the page would come back laid out for a 980px desktop.
+  /// place: replacing the whole content string would drop whatever sets the
+  /// layout width, and the page would come back at a width nobody chose.
   ///
   /// The rewrite cannot be a one-shot. Metas are queried as a list because an
   /// in-page navigation can leave a second viewport tag behind, and the
@@ -93,12 +94,28 @@ class CustomJs {
   /// wide: the `width` clause is rewritten to it (or added when there is
   /// none) and `initial-scale` is dropped, so the WebView picks the scale
   /// that fits the whole width on screen. This is what "Desktop site" in
-  /// Chrome does. Facebook sends `width=device-width` with its desktop layout
-  /// as well, and the WebView honours it, so the desktop agent alone gets a
-  /// page built for a 1000px window squeezed into the phone's 349px: it
-  /// overflows sideways, cannot be pinched out far enough to fit a post, and
-  /// stops scrolling after the first screen (#369). Left null for the touch
-  /// layout, which is built for the phone's width and must keep it.
+  /// Chrome does.
+  ///
+  /// `initial-scale` is the clause that matters, not `width`. Facebook's
+  /// viewport tag carries no `width` at all — measured on a device, it is
+  /// `user-scalable=no,initial-scale=1,maximum-scale=1` — and a viewport with
+  /// an initial scale and no width lays the page out at `device-width /
+  /// initial-scale`. So the rewrite above, which kept `initial-scale=1`,
+  /// pinned even the desktop layout to the phone's width: a page built for a
+  /// ~1000px window at 393px, overflowing sideways, impossible to pinch out
+  /// far enough to fit a post, and unable to scroll past the first screen
+  /// (#369).
+  ///
+  /// Measured on an emulator at 393 CSS px, desktop agent, with the tag
+  /// Facebook serves injected into the page:
+  ///
+  /// | rewrite | resulting meta | layout width |
+  /// | --- | --- | --- |
+  /// | before | `user-scalable=yes, initial-scale=1` | 393 |
+  /// | after | `user-scalable=yes, width=980` | 980 |
+  ///
+  /// Left null for the touch layout, which is built for the phone's width and
+  /// must keep it.
   static String unlockZoomFunc({int? layoutWidth}) {
     return """
 (function () {


### PR DESCRIPTION
## What

Comments only, no behaviour change.

The comments that landed with #371 named `width=device-width` as the clause pinning the desktop layout to the phone's width. Facebook does not send that. With the Chrome DevTools protocol attached to the app's WebView on an emulator, the tag it actually serves is:

```
user-scalable=no,initial-scale=1,maximum-scale=1
```

No `width` clause at all. A viewport that names an initial scale and no width is laid out at `device-width / initial-scale`, so the older rewrite — which preserved `initial-scale=1` — pinned every layout to the phone's width, the desktop one included.

## The fix in #371 is unchanged and correct

Dropping `initial-scale` and writing `width=980` is exactly what moves the layout off the device width. Measured on the emulator, desktop agent, 393 CSS px screen, with Facebook's own tag injected into the live page:

| rewrite | resulting meta | layout width | scale |
| --- | --- | --- | --- |
| before | `user-scalable=yes, initial-scale=1` | 393 | 1.00 |
| after | `user-scalable=yes, width=980` | 980 | 0.40 |

Also corrected: the pre-existing claim at the top of `unlockZoomFunc` that Facebook's viewport carries `width=device-width`, and the note on `kDesktopLayoutWidth`. Facebook's logged-out desktop pages ship no viewport tag at all and land on 980 by themselves, which is why 980 is the right number to write when a tag is present.

## Verification

- `flutter analyze`: no new issues.
- `flutter test` on the js, controller and consts suites: 111 passed.
- Touch layout re-measured on the device with the same tooling and is untouched: meta rewritten to `user-scalable=yes, initial-scale=1`, layout width 393, scale 1.0.

## Still not verified

The signed-in desktop feed. Logged-out pages carry no viewport tag, so they never exercise this path; the numbers above come from injecting Facebook's own tag into a live page. Confirming the original report needs a signed-in session on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
